### PR TITLE
fix: Update SmartLeds driver -> avoid warnings (ESP-IDF5.x)

### DIFF
--- a/code/components/jomjol_controlGPIO/Color.cpp
+++ b/code/components/jomjol_controlGPIO/Color.cpp
@@ -29,7 +29,7 @@ int iRgbSqrt( int num ) {
     return res;
 }
 
-Rgb::Rgb( Hsv y ) {
+Rgb::Rgb(const Hsv& y ) {
     // https://stackoverflow.com/questions/24152553/hsv-to-rgb-and-back-without-floating-point-math-in-python
     // greyscale
     if( y.s == 0 ) {
@@ -57,19 +57,19 @@ Rgb::Rgb( Hsv y ) {
     a = y.a;
 }
 
-Rgb& Rgb::operator=( Hsv hsv ) {
+Rgb& Rgb::operator=( const Hsv& hsv ) {
     Rgb r{ hsv };
     swap( r );
     return *this;
 }
 
-Rgb Rgb::operator+( Rgb in ) const {
+Rgb Rgb::operator+( const Rgb& in ) const {
     auto copy = *this;
     copy += in;
     return copy;
 }
 
-Rgb& Rgb::operator+=( Rgb in ) {
+Rgb& Rgb::operator+=( const Rgb& in ) {
     unsigned int red = r + in.r;
     r = ( red < 255 ) ? red : 255;
     unsigned int green = g + in.g;
@@ -79,7 +79,20 @@ Rgb& Rgb::operator+=( Rgb in ) {
     return *this;
 }
 
-Rgb& Rgb::blend( Rgb in ) {
+Rgb Rgb::operator-( const Rgb& in ) const {
+    auto copy = *this;
+    copy -= in;
+    return copy;
+}
+
+Rgb& Rgb::operator-=( const Rgb& in ) {
+    r = ( in.r > r ) ? 0 : r - in.r;
+    g = ( in.g > g ) ? 0 : g - in.g;
+    b = ( in.b > b ) ? 0 : b - in.b;
+    return *this;
+}
+
+Rgb& Rgb::blend( const Rgb& in ) {
     unsigned int inAlpha = in.a * ( 255 - a );
     unsigned int alpha = a + inAlpha;
     r = iRgbSqrt( ( ( r * r * a ) + ( in.r * in.r * inAlpha ) ) / alpha );
@@ -89,7 +102,7 @@ Rgb& Rgb::blend( Rgb in ) {
     return *this;
 }
 
-uint8_t IRAM_ATTR Rgb::getGrb( int idx ) {
+uint8_t Rgb::getGrb( int idx ) const {
     switch ( idx ) {
         case 0: return g;
         case 1: return r;
@@ -98,7 +111,7 @@ uint8_t IRAM_ATTR Rgb::getGrb( int idx ) {
     __builtin_unreachable();
 }
 
-Hsv::Hsv( Rgb r ) {
+Hsv::Hsv( const Rgb& r ) {
     int min = std::min( r.r, std::min( r.g, r.b ) );
     int max = std::max( r.r, std::max( r.g, r.b ) );
     int chroma = max - min;
@@ -125,7 +138,7 @@ Hsv::Hsv( Rgb r ) {
     a = r.a;
 }
 
-Hsv& Hsv::operator=( Rgb rgb ) {
+Hsv& Hsv::operator=( const Rgb& rgb ) {
     Hsv h{ rgb };
     swap( h );
     return *this;

--- a/code/components/jomjol_controlGPIO/Color.h
+++ b/code/components/jomjol_controlGPIO/Color.h
@@ -1,34 +1,34 @@
 #pragma once
 
-#ifndef COLOR_H
-#define COLOR_H
-
 #include <cstdint>
 #include "esp_attr.h"
 union Hsv;
 
 union Rgb {
     struct __attribute__ ((packed)) {
-        uint8_t r, g, b, a;
+        uint8_t g, r, b, a;
     };
     uint32_t value;
 
-    Rgb( uint8_t r = 0, uint8_t g = 0, uint8_t b = 0, uint8_t a = 255 ) : r( r ), g( g ), b( b ), a( a ) {}
-    Rgb( Hsv c );
-    Rgb& operator=( Rgb rgb ) { swap( rgb ); return *this; }
-    Rgb& operator=( Hsv hsv );
-    Rgb operator+( Rgb in ) const;
-    Rgb& operator+=( Rgb in );
-    bool operator==( Rgb in ) const { return in.value == value; }
-    Rgb& blend( Rgb in );
-    void swap( Rgb& o ) {  value = o.value; }
+    Rgb( uint8_t r = 0, uint8_t g = 0, uint8_t b = 0, uint8_t a = 255 ) : g( g ), r( r ), b( b ), a( a ) {}
+    Rgb( const Hsv& c );
+    Rgb(const Rgb&) = default;
+    Rgb& operator=( const Rgb& rgb ) { swap( rgb ); return *this; }
+    Rgb& operator=( const Hsv& hsv );
+    Rgb operator+( const Rgb& in ) const;
+    Rgb& operator+=( const Rgb& in );
+    Rgb operator-(const Rgb& in) const;
+    Rgb &operator-=(const Rgb& in);
+    bool operator==(const Rgb& in ) const { return in.value == value; }
+    Rgb& blend( const Rgb& in );
+    void swap( const Rgb& o ) {  value = o.value; }
     void linearize() {
         r = channelGamma(r);
         g = channelGamma(g);
         b = channelGamma(b);
     }
 
-    uint8_t IRAM_ATTR getGrb( int idx );
+    uint8_t getGrb( int idx ) const;
 
     void stretchChannels( uint8_t maxR, uint8_t maxG, uint8_t maxB ) {
         r = stretch( r, maxR );
@@ -64,11 +64,9 @@ union Hsv {
     uint32_t value;
 
     Hsv( uint8_t h, uint8_t s = 0, uint8_t v = 0, uint8_t a = 255 ) : h( h ), s( s ), v( v ), a( a ) {}
-    Hsv( Rgb r );
-    Hsv& operator=( Hsv h ) { swap( h ); return *this; }
-    Hsv& operator=( Rgb rgb );
-    bool operator==( Hsv in ) const { return in.value == value; }
-    void swap( Hsv& o ) { value = o.value; }
+    Hsv( const Rgb& r );
+    Hsv& operator=( const Hsv& h ) { swap( h ); return *this; }
+    Hsv& operator=( const Rgb& rgb );
+    bool operator==( const Hsv& in ) const { return in.value == value; }
+    void swap( const Hsv& o ) { value = o.value; }
 };
-
-#endif //COLOR_H

--- a/code/components/jomjol_controlGPIO/SmartLeds.cpp
+++ b/code/components/jomjol_controlGPIO/SmartLeds.cpp
@@ -1,34 +1,6 @@
 #include "SmartLeds.h"
 
-
-/* PlatformIO 6 (ESP IDF 5) does no longer allow access to RMTMEM,
-   see https://docs.espressif.com/projects/esp-idf/en/latest/esp32/migration-guides/release-5.x/5.0/peripherals.html?highlight=rmtmem#id5 
-   As a dirty workaround, we copy the needed structures from rmt_struct.h
-   In the long run, this should be replaced! */
-typedef struct rmt_item32_s {
-    union {
-        struct {
-            uint32_t duration0 :15;
-            uint32_t level0 :1;
-            uint32_t duration1 :15;
-            uint32_t level1 :1;
-        };
-        uint32_t val;
-    };
-} rmt_item32_t;
-
-//Allow access to RMT memory using RMTMEM.chan[0].data32[8]
-typedef volatile struct rmt_mem_s {
-    struct {
-        rmt_item32_t data32[64];
-    } chan[8];
-} rmt_mem_t;
-extern rmt_mem_t RMTMEM;
-
-
-
 IsrCore SmartLed::_interruptCore = CoreCurrent;
-intr_handle_t SmartLed::_interruptHandle = NULL;
 
 SmartLed*& IRAM_ATTR SmartLed::ledForChannel( int channel ) {
     static SmartLed* table[8] = { nullptr };
@@ -36,55 +8,49 @@ SmartLed*& IRAM_ATTR SmartLed::ledForChannel( int channel ) {
     return table[ channel ];
 }
 
-void IRAM_ATTR SmartLed::interruptHandler(void*) {
-    for (int channel = 0; channel != 8; channel++) {
-        auto self = ledForChannel( channel );
-
-        if ( RMT.int_st.val & (1 << (24 + channel ) ) ) { // tx_thr_event
-            if ( self )
-                self->copyRmtHalfBlock();
-            RMT.int_clr.val |= 1 << ( 24 + channel );
-        } else if ( RMT.int_st.val & ( 1 << (3 * channel ) ) ) { // tx_end
-            if ( self )
-                xSemaphoreGiveFromISR( self->_finishedFlag, nullptr );
-            RMT.int_clr.val |= 1 << ( 3 * channel );
-        }
-    }
+void IRAM_ATTR SmartLed::txEndCallback(rmt_channel_t channel, void *arg) {
+    xSemaphoreGiveFromISR(ledForChannel(channel)->_finishedFlag, nullptr);
 }
 
-void IRAM_ATTR SmartLed::copyRmtHalfBlock() {
-    int offset = detail::MAX_PULSES * _halfIdx;
-    _halfIdx = !_halfIdx;
-    int len = 3 - _componentPosition + 3 * ( _count - 1 );
-    len = std::min( len, detail::MAX_PULSES / 8 );
 
-    if ( !len ) {
-        for ( int i = 0; i < detail::MAX_PULSES; i++) {
-            RMTMEM.chan[ _channel].data32[i + offset ].val = 0;
+void IRAM_ATTR SmartLed::translateForRmt(const void *src, rmt_item32_t *dest, size_t src_size,
+    size_t wanted_rmt_items_num, size_t *out_consumed_src_bytes, size_t *out_used_rmt_items) {
+    SmartLed *self;
+    ESP_ERROR_CHECK(rmt_translator_get_context(out_used_rmt_items, (void**)&self));
+
+    const auto& _bitToRmt = self->_bitToRmt;
+    const auto src_offset = self->_translatorSourceOffset;
+
+    auto *src_components = (const uint8_t *)src;
+    size_t consumed_src_bytes = 0;
+    size_t used_rmt_items = 0;
+
+    while (consumed_src_bytes < src_size && used_rmt_items + 7 < wanted_rmt_items_num) {
+        uint8_t val = *src_components;
+
+        // each bit, from highest to lowest
+        for ( uint8_t j = 0; j != 8; j++, val <<= 1 ) {
+            dest->val = _bitToRmt[ val >> 7 ].val;
+            ++dest;
+        }
+
+        used_rmt_items += 8;
+        ++src_components;
+        ++consumed_src_bytes;
+
+        // skip alpha byte
+        if(((src_offset + consumed_src_bytes) % 4) == 3) {
+            ++src_components;
+            ++consumed_src_bytes;
+
+            // TRST delay after last pixel in strip
+            if(consumed_src_bytes == src_size) {
+                (dest-1)->duration1 = self->_timing.TRS / ( detail::RMT_DURATION_NS * detail::DIVIDER );
+            }
         }
     }
 
-    int i;
-    for ( i = 0; i != len && _pixelPosition != _count; i++ ) {
-        uint8_t val = _buffer[ _pixelPosition ].getGrb( _componentPosition );
-        for ( int j = 0; j != 8; j++, val <<= 1 ) {
-            int bit = val >> 7;
-            int idx = i * 8 + offset + j;
-            RMTMEM.chan[ _channel ].data32[ idx ].val = _bitToRmt[ bit & 0x01 ].value;
-        }
-        if ( _pixelPosition == _count - 1 && _componentPosition == 2 ) {
-            RMTMEM.chan[ _channel ].data32[ i * 8 + offset + 7 ].duration1 =
-                _timing.TRS / ( detail::RMT_DURATION_NS * detail::DIVIDER );
-        }
-
-        _componentPosition++;
-        if ( _componentPosition == 3 ) {
-            _componentPosition = 0;
-            _pixelPosition++;
-        }
-    }
-
-    for ( i *= 8; i != detail::MAX_PULSES; i++ ) {
-        RMTMEM.chan[ _channel ].data32[ i + offset ].val = 0;
-    }
+    self->_translatorSourceOffset = src_offset + consumed_src_bytes;
+    *out_consumed_src_bytes = consumed_src_bytes;
+    *out_used_rmt_items = used_rmt_items;
 }

--- a/code/components/jomjol_controlGPIO/SmartLeds.h
+++ b/code/components/jomjol_controlGPIO/SmartLeds.h
@@ -1,8 +1,5 @@
 #pragma once
 
-#ifndef SMARTLEDS_H
-#define SMARTLEDS_H
-
 /*
  * A C++ driver for the WS2812 LEDs using the RMT peripheral on the ESP32.
  *
@@ -35,70 +32,14 @@
 #include <cassert>
 #include <cstring>
 
-#include "esp_idf_version.h"
-#if (ESP_IDF_VERSION_MAJOR >= 5)
-#include "soc/periph_defs.h"
-#include "esp_private/periph_ctrl.h"
-#include "soc/gpio_sig_map.h"
-#include "soc/gpio_periph.h"
-#include "soc/io_mux_reg.h"
-#include "esp_rom_gpio.h"
-#define gpio_pad_select_gpio esp_rom_gpio_pad_select_gpio
-#define gpio_matrix_in(a,b,c) esp_rom_gpio_connect_in_signal(a,b,c)
-#define gpio_matrix_out(a,b,c,d) esp_rom_gpio_connect_out_signal(a,b,c,d)
-#define ets_delay_us(a) esp_rom_delay_us(a)
-#endif
+#include <freertos/FreeRTOS.h>
+#include <freertos/semphr.h>
+#include <esp_intr_alloc.h>
+#include <esp_ipc.h>
+#include <driver/gpio.h>
+#include <driver/spi_master.h>
 
-#if defined ( ARDUINO )
-    extern "C" { // ...someone forgot to put in the includes...
-        #include "esp32-hal.h"
-        #include "esp_intr_alloc.h"
-        #include "esp_ipc.h"
-        #include "driver/gpio.h"
-        #include "driver/periph_ctrl.h"
-        #include "freertos/semphr.h"
-        #include "soc/rmt_struct.h"
-        #include <driver/spi_master.h>
-        #include "esp_idf_version.h"
-#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL( 4, 0, 0 )
-        #include "soc/dport_reg.h"
-#endif
-    }
-#elif defined ( ESP_PLATFORM )
-    extern "C" { // ...someone forgot to put in the includes...
-        #include <esp_intr_alloc.h>
-        #include <esp_ipc.h>
-        #include <driver/gpio.h>
-        #include <freertos/FreeRTOS.h>
-        #include <freertos/semphr.h>
-        #include <soc/dport_reg.h>
-        #include <soc/gpio_sig_map.h>
-        #include <soc/rmt_struct.h>
-        #include <driver/spi_master.h>
-    }
-    #include <stdio.h>
-#endif
-
-#if (ESP_IDF_VERSION_MAJOR >= 4) && (ESP_IDF_VERSION_MINOR > 1)
-#include "hal/gpio_ll.h"
-#else
-#include "soc/gpio_periph.h"
-#define esp_rom_delay_us ets_delay_us
-static inline int gpio_ll_get_level(gpio_dev_t *hw, int gpio_num)
-{
-    if (gpio_num < 32) {
-        return (hw->in >> gpio_num) & 0x1;
-    } else {
-        return (hw->in1.data >> (gpio_num - 32)) & 0x1;
-    }
-}
-#endif
-
-#if (ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 0, 0))
-#if !(configENABLE_BACKWARD_COMPATIBILITY == 1)
-#define xSemaphoreHandle SemaphoreHandle_t
-#endif
-#endif
+#include <driver/rmt.h>
 
 #include "Color.h"
 
@@ -112,18 +53,7 @@ struct TimingParams {
     uint32_t TRS;
 };
 
-union RmtPulsePair {
-    struct {
-        int duration0:15;
-        int level0:1;
-        int duration1:15;
-        int level1:1;
-    };
-    uint32_t value;
-};
-
 static const int DIVIDER = 4; // 8 still seems to work, but timings become marginal
-static const int MAX_PULSES = 32; // A channel has a 64 "pulse" buffer - we use half per pass
 static const double RMT_DURATION_NS = 12.5; // minimum time of a single RMT duration based on clock ns
 
 } // namespace detail
@@ -135,6 +65,7 @@ static const LedType LED_WS2812B = { 400, 850, 850, 400, 50100 };
 static const LedType LED_SK6812  = { 300, 600, 900, 600, 80000 };
 static const LedType LED_WS2813  = { 350, 800, 350, 350, 300000 };
 
+// Single buffer == can't touch the Rgbs between show() and wait()
 enum BufferType { SingleBuffer = 0, DoubleBuffer };
 
 enum IsrCore { CoreFirst = 0, CoreSecond = 1, CoreCurrent = 2};
@@ -147,30 +78,18 @@ public:
     //
     // If you use anything other than CoreCurrent, the FreeRTOS scheduler MUST be already running,
     // so you can't use it if you define SmartLed as global variable.
-    SmartLed( const LedType& type, int count, int pin, int channel = 0, BufferType doubleBuffer = SingleBuffer, IsrCore isrCore = CoreCurrent)
-        : _timing( type ),
-          _channel( channel ),
-          _count( count ),
-          _firstBuffer( new Rgb[ count ] ),
+    SmartLed(const LedType &type, int count, int pin, int channel = 0, BufferType doubleBuffer = DoubleBuffer, IsrCore isrCore = CoreCurrent)
+        : _timing(type),
+          _channel((rmt_channel_t)channel),
+          _count(count),
+          _firstBuffer(new Rgb[count]),
           _secondBuffer( doubleBuffer ? new Rgb[ count ] : nullptr ),
-          _finishedFlag( xSemaphoreCreateBinary() )
+          _finishedFlag(xSemaphoreCreateBinary())
     {
-        assert( channel >= 0 && channel < 8 );
+        assert( channel >= 0 && channel < RMT_CHANNEL_MAX );
         assert( ledForChannel( channel ) == nullptr );
 
         xSemaphoreGive( _finishedFlag );
-
-        DPORT_SET_PERI_REG_MASK( DPORT_PERIP_CLK_EN_REG, DPORT_RMT_CLK_EN );
-        DPORT_CLEAR_PERI_REG_MASK( DPORT_PERIP_RST_EN_REG, DPORT_RMT_RST );
-
-        PIN_FUNC_SELECT( GPIO_PIN_MUX_REG[ pin ], 2 );
-        gpio_set_direction( static_cast< gpio_num_t >( pin ), GPIO_MODE_OUTPUT );
-        gpio_matrix_out( static_cast< gpio_num_t >( pin ), RMT_SIG_OUT0_IDX + _channel, 0, 0 );
-        initChannel( _channel );
-
-        RMT.tx_lim_ch[ _channel ].limit = detail::MAX_PULSES;
-        RMT.int_ena.val = RMT.int_ena.val | 1 << ( 24 + _channel );
-        RMT.int_ena.val = RMT.int_ena.val | 1 << ( 3 * _channel );
 
         _bitToRmt[ 0 ].level0 = 1;
         _bitToRmt[ 0 ].level1 = 0;
@@ -182,26 +101,38 @@ public:
         _bitToRmt[ 1 ].duration0 = _timing.T1H / ( detail::RMT_DURATION_NS * detail::DIVIDER );
         _bitToRmt[ 1 ].duration1 = _timing.T1L / ( detail::RMT_DURATION_NS * detail::DIVIDER );
 
-        if ( !anyAlive() ) {
+        rmt_config_t config = RMT_DEFAULT_CONFIG_TX((gpio_num_t)pin, _channel);
+        config.rmt_mode = RMT_MODE_TX;
+        config.clk_div = detail::DIVIDER;
+        config.mem_block_num = 1;
+        config.tx_config.idle_output_en = true;
+
+        ESP_ERROR_CHECK(rmt_config(&config));
+
+        const auto anyAliveCached = anyAlive();
+        if (!anyAliveCached && isrCore != CoreCurrent) {
             _interruptCore = isrCore;
-            if(isrCore != CoreCurrent) {
-                ESP_ERROR_CHECK(esp_ipc_call_blocking(isrCore, registerInterrupt, NULL));
-            } else {
-                registerInterrupt(NULL);
-            }
+            ESP_ERROR_CHECK(esp_ipc_call_blocking(isrCore, registerInterrupt, (void*)((intptr_t)_channel)));
+        } else {
+            registerInterrupt((void*)((intptr_t)_channel));
         }
+
+        if(!anyAliveCached) {
+            rmt_register_tx_end_callback(txEndCallback, NULL);
+        }
+
+        ESP_ERROR_CHECK(rmt_translator_init(_channel, translateForRmt));
+        ESP_ERROR_CHECK(rmt_translator_set_context(_channel, this));
 
         ledForChannel( channel ) = this;
     }
 
     ~SmartLed() {
         ledForChannel( _channel ) = nullptr;
-        if ( !anyAlive() ) {
-            if(_interruptCore != CoreCurrent) {
-                ESP_ERROR_CHECK(esp_ipc_call_blocking(_interruptCore, unregisterInterrupt, NULL));
-            } else {
-                unregisterInterrupt(NULL);
-            }
+        if ( !anyAlive() && _interruptCore != CoreCurrent ) {
+            ESP_ERROR_CHECK(esp_ipc_call_blocking(_interruptCore, unregisterInterrupt, (void*)((intptr_t)_channel)));
+        } else {
+            unregisterInterrupt((void*)((intptr_t)_channel));
         }
         vSemaphoreDelete( _finishedFlag );
     }
@@ -214,10 +145,10 @@ public:
         return _firstBuffer[ idx ];
     }
 
-    void show() {
-        _buffer = _firstBuffer.get();
-        startTransmission();
+    esp_err_t show() {
+        esp_err_t err = startTransmission();
         swapBuffers();
+        return err;
     }
 
     bool wait( TickType_t timeout = portMAX_DELAY ) {
@@ -241,57 +172,17 @@ public:
     const Rgb *cend() const { return _firstBuffer.get() + _count; }
 
 private:
-    static intr_handle_t _interruptHandle;
     static IsrCore _interruptCore;
 
-    static void initChannel( int channel ) {
-        RMT.apb_conf.fifo_mask = 1;  //enable memory access, instead of FIFO mode.
-        RMT.apb_conf.mem_tx_wrap_en = 1; //wrap around when hitting end of buffer
-        RMT.conf_ch[ channel ].conf0.div_cnt = detail::DIVIDER;
-        RMT.conf_ch[ channel ].conf0.mem_size = 1;
-        RMT.conf_ch[ channel ].conf0.carrier_en = 0;
-        RMT.conf_ch[ channel ].conf0.carrier_out_lv = 1;
-        RMT.conf_ch[ channel ].conf0.mem_pd = 0;
-
-        RMT.conf_ch[ channel ].conf1.rx_en = 0;
-        RMT.conf_ch[ channel ].conf1.mem_owner = 0;
-        RMT.conf_ch[ channel ].conf1.tx_conti_mode = 0;    //loop back mode.
-        RMT.conf_ch[ channel ].conf1.ref_always_on = 1;    // use apb clock: 80M
-        RMT.conf_ch[ channel ].conf1.idle_out_en = 1;
-        RMT.conf_ch[ channel ].conf1.idle_out_lv = 0;
+    static void registerInterrupt(void *channelVoid) {
+        ESP_ERROR_CHECK(rmt_driver_install((rmt_channel_t)((intptr_t)channelVoid), 0, ESP_INTR_FLAG_IRAM));
     }
 
-    static void registerInterrupt(void *) {
-        ESP_ERROR_CHECK(esp_intr_alloc( ETS_RMT_INTR_SOURCE, 0, interruptHandler, nullptr, &_interruptHandle));
-    }
-
-    static void unregisterInterrupt(void*) {
-        esp_intr_free( _interruptHandle );
+    static void unregisterInterrupt(void *channelVoid) {
+        ESP_ERROR_CHECK(rmt_driver_uninstall((rmt_channel_t)((intptr_t)channelVoid)));
     }
 
     static SmartLed*& IRAM_ATTR ledForChannel( int channel );
-    static void IRAM_ATTR interruptHandler( void* );
-
-    void IRAM_ATTR copyRmtHalfBlock();
-
-    void swapBuffers() {
-        if ( _secondBuffer )
-            _firstBuffer.swap( _secondBuffer );
-    }
-
-    void startTransmission() {
-        // Invalid use of the library
-        if( xSemaphoreTake( _finishedFlag, 0 ) != pdTRUE )
-            abort();
-
-        _pixelPosition = _componentPosition = _halfIdx = 0;
-        copyRmtHalfBlock();
-        if ( _pixelPosition < _count )
-            copyRmtHalfBlock();
-
-        RMT.conf_ch[ _channel ].conf1.mem_rd_rst = 1;
-        RMT.conf_ch[ _channel ].conf1.tx_start = 1;
-    }
 
     static bool anyAlive() {
         for ( int i = 0; i != 8; i++ )
@@ -299,20 +190,50 @@ private:
         return false;
     }
 
+    static void IRAM_ATTR txEndCallback(rmt_channel_t channel, void *arg);
+
+    static void IRAM_ATTR translateForRmt(const void *src, rmt_item32_t *dest, size_t src_size,
+        size_t wanted_rmt_items_num, size_t *out_consumed_src_bytes, size_t *out_used_rmt_items);
+
+    void swapBuffers() {
+        if (_secondBuffer)
+            _firstBuffer.swap(_secondBuffer);
+    }
+
+    esp_err_t startTransmission() {
+        // Invalid use of the library, you must wait() fir previous frame to get processed first
+        if( xSemaphoreTake( _finishedFlag, 0 ) != pdTRUE )
+            abort();
+
+        _translatorSourceOffset = 0;
+
+        auto err = rmt_write_sample(_channel, (const uint8_t *)_firstBuffer.get(), _count * 4, false);
+        if(err != ESP_OK) {
+            return err;
+        }
+
+        return ESP_OK;
+    }
+
     const LedType& _timing;
-    int _channel;
-    detail::RmtPulsePair _bitToRmt[ 2 ];
+    rmt_channel_t _channel;
+    rmt_item32_t _bitToRmt[ 2 ];
     int _count;
-    std::unique_ptr< Rgb[] > _firstBuffer;
-    std::unique_ptr< Rgb[] > _secondBuffer;
-    Rgb *_buffer;
+    std::unique_ptr<Rgb[]> _firstBuffer;
+    std::unique_ptr<Rgb[]> _secondBuffer;
 
-    xSemaphoreHandle _finishedFlag;
+    size_t _translatorSourceOffset;
 
-    int _pixelPosition;
-    int _componentPosition;
-    int _halfIdx;
+    SemaphoreHandle_t _finishedFlag;
 };
+
+#ifdef CONFIG_IDF_TARGET_ESP32
+#define _SMARTLEDS_SPI_HOST HSPI_HOST
+#elif defined(CONFIG_IDF_TARGET_ESP32S3)
+#define _SMARTLEDS_SPI_HOST SPI2_HOST
+#else
+#error "SmartLeds SPI host not defined for this chip/esp-idf version."
+#endif
 
 class Apa102 {
 public:
@@ -362,10 +283,10 @@ public:
         devcfg.queue_size = TRANS_COUNT;
         devcfg.pre_cb = nullptr;
 
-        auto ret = spi_bus_initialize( HSPI_HOST, &buscfg, 1 );
+        auto ret = spi_bus_initialize( _SMARTLEDS_SPI_HOST, &buscfg, 1 );
         assert( ret == ESP_OK );
 
-        ret = spi_bus_add_device( HSPI_HOST, &devcfg, &_spi );
+        ret = spi_bus_add_device( _SMARTLEDS_SPI_HOST, &devcfg, &_spi );
         assert( ret == ESP_OK );
 
         std::fill_n( _finalFrame, FINAL_FRAME_SIZE, 0xFFFFFFFF );
@@ -492,10 +413,10 @@ public:
         devcfg.queue_size = TRANS_COUNT_MAX;
         devcfg.pre_cb = nullptr;
 
-        auto ret = spi_bus_initialize( HSPI_HOST, &buscfg, 1 );
+        auto ret = spi_bus_initialize( _SMARTLEDS_SPI_HOST, &buscfg, 1 );
         assert( ret == ESP_OK );
 
-        ret = spi_bus_add_device( HSPI_HOST, &devcfg, &_spi );
+        ret = spi_bus_add_device( _SMARTLEDS_SPI_HOST, &devcfg, &_spi );
         assert( ret == ESP_OK );
 
         std::fill_n( _latchBuffer, LATCH_FRAME_SIZE_BYTES, 0x0 );
@@ -566,5 +487,3 @@ private:
     int _latchFrames;
     uint8_t _latchBuffer[ LATCH_FRAME_SIZE_BYTES ];
 };
-
-#endif //SMARTLEDS_H


### PR DESCRIPTION
Update SmartLeds driver to v2.0 (https://github.com/RoboticsBrno/SmartLeds/releases/tag/v2.0.0)

Note: The updated driver still uses ESP-IDF RMT driver which is deprecated in ESP-IDF 5.x.

BEGIN_COMMIT_OVERRIDE
fix: Update SmartLeds driver (avoid build warnings)
END_COMMIT_OVERRIDE