### PR TITLE
feat: Provide flow process error -> MQTT / REST API

### DIFF
--- a/code/include/defines.h
+++ b/code/include/defines.h
@@ -229,6 +229,9 @@
     #define FLOW_AUTO_ERROR_HANDLING    "Automatic Error Handling"
     #define FLOW_INVALID_STATE          "Invalid State"
 
+    // Process state misc
+    #define FLOWSTATE_ERRORS_IN_ROW_LIMIT 3
+
 
 /////////////////////////////////////////////
 ////      Conditionnal definitions       ////

--- a/sd-card/html/overview.html
+++ b/sd-card/html/overview.html
@@ -153,7 +153,7 @@
 		var xhttp = new XMLHttpRequest();
 		xhttp.onreadystatechange = function() {
 			if (this.readyState == 4 && this.status == 200) {
-				if (xhttp.responseText == "TRUE") {
+				if (xhttp.responseText.substring(0,3) == "001" || xhttp.responseText.substring(0,3) == "002") {
 					$('#flowerror').html("!!! Process error detected. Check logs !!!");
 				}
 				else {


### PR DESCRIPTION
- Flow process error event provided to MQTT broker (`{maintopic}/flowerror`) after flow process error occured min. 3 times in a row
- Enhance REST API `http://IP/flowerror` to signal beside the already available single flow process error also a dedicated state for flow process error occured min. 3 times in a row


BEGIN_COMMIT_OVERRIDE
feat: Provide cycle process error -> MQTT / REST API
END_COMMIT_OVERRIDE