### PR TITLE
feat: Keep alignment marker in RAM

### DIFF
--- a/code/components/jomjol_flowcontroll/ClassFlowAlignment.h
+++ b/code/components/jomjol_flowcontroll/ClassFlowAlignment.h
@@ -15,16 +15,15 @@ using namespace std;
 class ClassFlowAlignment : public ClassFlow
 {
 protected:
+    CImageBasis *ImageTMP;
+    CAlignAndCutImage *AlignAndCutImage;
+    strRefInfo References[2];
+    int anz_ref;
     float initalrotate;
     bool initialmirror;
     bool initialflip;
     bool use_antialiasing;
     bool SaveAllFiles;
-    int anz_ref;
-    strRefInfo References[2];
-    std::string namerawimage;
-    std::string FileStoreRefAlignment;
-    CAlignAndCutImage *AlignAndCutImage;
     int AlignFAST_SADThreshold;
 
     void SetInitialParameter(void);
@@ -32,16 +31,14 @@ protected:
     bool SaveReferenceAlignmentValues(void);
 
 public:
-    CImageBasis *ImageBasis, *ImageTMP;
+    CImageBasis *ImageBasis;
     ImageData *AlgROI;
     
     ClassFlowAlignment(std::vector<ClassFlow*>* lfc);
     virtual ~ClassFlowAlignment();
 
     CAlignAndCutImage* GetAlignAndCutImage() {return AlignAndCutImage;};
-
     void DrawRef(CImageBasis *_zw);
-
     bool ReadParameter(FILE* pfile, string& aktparamgraph);
     bool doFlow(string time);
     string getHTMLSingleStep(string host);

--- a/code/components/jomjol_flowcontroll/ClassFlowTakeImage.cpp
+++ b/code/components/jomjol_flowcontroll/ClassFlowTakeImage.cpp
@@ -144,6 +144,7 @@ bool ClassFlowTakeImage::ReadParameter(FILE* pfile, string& aktparamgraph)
     rawImage = new CImageBasis("rawImage");
     if (rawImage) {
         if(!rawImage->CreateEmptyImage(image_width, image_height, 3, 1)) {
+            LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "Failed to create rawimage");
             return false;
         }
     }

--- a/code/components/jomjol_helper/psram.cpp
+++ b/code/components/jomjol_helper/psram.cpp
@@ -42,19 +42,12 @@ void *malloc_psram_heap_STBI(std::string name, size_t size, uint32_t caps)
 {
 	void *ptr;
 
-	if ((STBIObjectPSRAM.name.compare("rawImage") == 0) && STBIObjectPSRAM.usePreallocated && 
-            STBIObjectPSRAM.PreallocatedMemory != NULL && size >= 900000)
+	if (STBIObjectPSRAM.usePreallocated && STBIObjectPSRAM.PreallocatedMemorySize == size &&
+        STBIObjectPSRAM.PreallocatedMemory != NULL)
     {
-        if (STBIObjectPSRAM.PreallocatedMemorySize >= size) {
-            ptr = STBIObjectPSRAM.PreallocatedMemory;
-            name += ": Use preallocated memory (" + STBIObjectPSRAM.name + ")";
-            STBIObjectPSRAM.usePreallocated = false;
-        }
-        else {
-            LogFile.WriteToFile(ESP_LOG_ERROR, TAG, name + ": Preallocation size " + std::to_string(STBIObjectPSRAM.PreallocatedMemorySize) +
-                                                           " too small for needed size of " + std::to_string(size));
-            ptr = heap_caps_malloc(size, caps);
-        }
+        ptr = STBIObjectPSRAM.PreallocatedMemory;
+        name += ": Use preallocated memory (" + STBIObjectPSRAM.name + ")";
+        STBIObjectPSRAM.usePreallocated = false;
     }
     else {
         ptr = heap_caps_malloc(size, caps);

--- a/code/components/jomjol_image_proc/CFindTemplate.h
+++ b/code/components/jomjol_image_proc/CFindTemplate.h
@@ -6,6 +6,7 @@
 #include "CImageBasis.h"
 
 struct strRefInfo {
+    CImageBasis* refImage = NULL;
     std::string image_file; 
     int alignment_algo = 0;             // 0 = "Default" (nur R-Kanal), 1 = "HighAccuracy" (RGB-Kanal), 2 = "Fast" (1.x RGB, dann isSimilar)
     int target_x = 0;
@@ -24,12 +25,16 @@ struct strRefInfo {
 
 class CFindTemplate : public CImageBasis
 {
-    public:
-        int tpl_width, tpl_height, tpl_bpp;    
-        CFindTemplate(std::string name, uint8_t* _rgb_image, int _channels, int _width, int _height, int _bpp) : CImageBasis(name, _rgb_image, _channels, _width, _height, _bpp) {};
+    private:
+        uint8_t* rgb_template;
 
+        bool CalculateSimularities(strRefInfo *_ref);  
+    
+    public:
+        int tpl_width, tpl_height, tpl_bpp;
+
+        CFindTemplate(std::string name, uint8_t* _rgb_image, int _channels, int _width, int _height, int _bpp) : CImageBasis(name, _rgb_image, _channels, _width, _height, _bpp) {rgb_template = NULL;};
         bool FindTemplate(strRefInfo *_ref, bool _noFAST);
-        bool CalculateSimularities(uint8_t* _rgb_tmpl, strRefInfo *_ref);
 };
 
 #endif //CFINDTEMPLATE_H

--- a/code/components/jomjol_image_proc/CImageBasis.cpp
+++ b/code/components/jomjol_image_proc/CImageBasis.cpp
@@ -519,6 +519,52 @@ void CImageBasis::LoadFromMemoryPreallocated(stbi_uc *_buffer, int len)
 }
 
 
+void CImageBasis::LoadFromFilePreallocated(std::string _name, std::string _image)
+{
+    name = _name;
+    islocked = false;
+    channels = 3;
+    externalImage = false;
+    filename = _image;
+
+    if (file_size(_image.c_str()) == 0) {
+        LogFile.WriteToFile(ESP_LOG_ERROR, TAG, filename + " is empty!");
+        return;
+    }
+
+    RGBImageLock();
+
+    if (rgb_image == NULL) {
+        LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "No preallocation found");
+    }
+
+    #ifdef DEBUG_DETAIL_ON 
+        LogFile.WriteHeapInfo("CImageBasis-LoadFromFilePreallocated - Start");
+    #endif
+
+    rgb_image = stbi_load(filename.c_str(), &width, &height, &bpp, channels);
+
+    if (rgb_image == NULL) {
+        LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "CImageBasis-LoadFromFilePreallocated: Failed to load " + filename);
+        LogFile.WriteHeapInfo("CImageBasis-LoadFromFilePreallocated");
+        RGBImageRelease();
+        return;
+    }
+    
+    RGBImageRelease();
+
+    #ifdef DEBUG_DETAIL_ON 
+        std::string zw = "CImageBasis LoadFromFilePreallocated after load " + _image;
+        ESP_LOGI(TAG, "%s", zw.c_str());
+        ESP_LOGI(TAG, "w %d, h %d, b %d, c %d", width, height, bpp, channels);
+    #endif
+
+    #ifdef DEBUG_DETAIL_ON 
+        LogFile.WriteHeapInfo("CImageBasis-LoadFromFilePreallocated - done");
+    #endif
+}
+
+
 CImageBasis::CImageBasis(std::string _name, CImageBasis *_copyfrom) 
 {
     name = _name;

--- a/code/components/jomjol_image_proc/CImageBasis.h
+++ b/code/components/jomjol_image_proc/CImageBasis.h
@@ -81,6 +81,7 @@ class CImageBasis
 
         void LoadFromMemory(stbi_uc *_buffer, int len);
         void LoadFromMemoryPreallocated(stbi_uc *_buffer, int len);
+        void LoadFromFilePreallocated(std::string _name, std::string _image);
 
         ImageData* writeToMemoryAsJPG(const int quality = 90);
         void writeToMemoryAsJPG(ImageData* ii, const int quality = 90);


### PR DESCRIPTION
Load alignment marker form SD card (`sdcard/config/ref0.jpg` + `sdcard/config/ref1.jpg`) to RAM during initialization state and keep then in RAM during flow processing -> reduced read cycle of SD card



BEGIN_COMMIT_OVERRIDE
feat: Keep alignment marker in RAM to reduce SD read cycles
END_COMMIT_OVERRIDE
