### PR TITLE
feat: ROI images not saving to sd card by default

### DIFF
--- a/code/components/jomjol_flowcontroll/ClassFlowCNNGeneral.cpp
+++ b/code/components/jomjol_flowcontroll/ClassFlowCNNGeneral.cpp
@@ -894,12 +894,15 @@ std::vector<HTMLInfo*> ClassFlowCNNGeneral::GetHTMLInfo()
         for (int i = 0; i < GENERAL[_ana]->ROI.size(); ++i)
         {
             ESP_LOGD(TAG, "Image: %d", (int) GENERAL[_ana]->ROI[i]->image);
-            if (GENERAL[_ana]->ROI[i]->image)
+            if (SaveAllFiles)
             {
-                if (GENERAL[_ana]->name == "default")
-                    GENERAL[_ana]->ROI[i]->image->SaveToFile(FormatFileName("/sdcard/img_tmp/" + GENERAL[_ana]->ROI[i]->name + ".jpg"));
-                else
-                    GENERAL[_ana]->ROI[i]->image->SaveToFile(FormatFileName("/sdcard/img_tmp/" + GENERAL[_ana]->name + "_" + GENERAL[_ana]->ROI[i]->name + ".jpg"));
+                if (GENERAL[_ana]->ROI[i]->image)
+                {
+                    if (GENERAL[_ana]->name == "default")
+                        GENERAL[_ana]->ROI[i]->image->SaveToFile(FormatFileName("/sdcard/img_tmp/" + GENERAL[_ana]->ROI[i]->name + ".jpg"));
+                    else
+                        GENERAL[_ana]->ROI[i]->image->SaveToFile(FormatFileName("/sdcard/img_tmp/" + GENERAL[_ana]->name + "_" + GENERAL[_ana]->ROI[i]->name + ".jpg"));
+                }
             }
 
             HTMLInfo *zw = new HTMLInfo;

--- a/code/dependencies.lock
+++ b/code/dependencies.lock
@@ -3,7 +3,7 @@ dependencies:
     component_hash: null
     source:
       type: idf
-    version: 5.0.1
+    version: 5.0.2
 manifest_hash: f880feca80f04921fc95fd31e9c2936b9896764c15a62f6e2d312c57a62a36db
 target: esp32
 version: 1.0.0


### PR DESCRIPTION
- Not saving all ROI images to SD card folder `/img_tmp` whenever recognition page gets opened -> faster page loading
- They are still accessable by REST API `http://IP/img_tmp/{number_sequence}_{ROI_name}.jpg`


BEGIN_COMMIT_OVERRIDE
feat: ROI images not saving to sd card by default to reduce write cycles
END_COMMIT_OVERRIDE