### PR TITLE
fix(wifi): Allow operation with empty WIFI password

### DIFF
--- a/code/components/jomjol_wlan/read_wlanini.cpp
+++ b/code/components/jomjol_wlan/read_wlanini.cpp
@@ -173,10 +173,9 @@ int LoadWlanFromFile(std::string fn)
         return -2;
     }
 
-    /* Check if password is empty (mandatory parameter) */
+    /* Check if password is empty --> handle password only as optional parameter: see issue #2393 */
     if (wlan_config.password.empty()) {
-        LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "Password empty. Device init aborted!");
-        return -2;
+        LogFile.WriteToFile(ESP_LOG_INFO, TAG, "Password empty");
     }
 
     return 0;

--- a/code/components/jomjol_wlan/read_wlanini.cpp
+++ b/code/components/jomjol_wlan/read_wlanini.cpp
@@ -94,11 +94,16 @@ int LoadWlanFromFile(std::string fn)
                     tmp = tmp.substr(1, tmp.length()-2);
                 }
                 wlan_config.password = tmp;
-                #ifndef __HIDE_PASSWORD
-                LogFile.WriteToFile(ESP_LOG_INFO, TAG, "Password: " + wlan_config.password);
-                #else
-                LogFile.WriteToFile(ESP_LOG_INFO, TAG, "Password: XXXXXXXX");
-                #endif
+                if (!wlan_config.password.empty()) {
+                    #ifndef __HIDE_PASSWORD
+                    LogFile.WriteToFile(ESP_LOG_INFO, TAG, "Password: " + wlan_config.password);
+                    #else
+                    LogFile.WriteToFile(ESP_LOG_INFO, TAG, "Password: XXXXXXXX");
+                    #endif
+                }
+                else {
+                    LogFile.WriteToFile(ESP_LOG_INFO, TAG, "Password: No password set");
+                }
             }   
 
             else if ((splitted.size() > 1) && (toUpper(splitted[0]) == "HOSTNAME")){
@@ -173,10 +178,7 @@ int LoadWlanFromFile(std::string fn)
         return -2;
     }
 
-    /* Check if password is empty --> handle password only as optional parameter: see issue #2393 */
-    if (wlan_config.password.empty()) {
-        LogFile.WriteToFile(ESP_LOG_INFO, TAG, "Password empty");
-    }
+    /* No check if password is empty --> handle password only as optional parameter: see issue #2393 */
 
     return 0;
 }

--- a/code/main/main.cpp
+++ b/code/main/main.cpp
@@ -330,9 +330,9 @@ extern "C" void app_main(void)
         StatusLED(WLAN_INIT, 1, true);
         return; // No way to continue without reading the wlan.ini
     }
-    else if (iWLANStatus == -2) { // SSID or password not configured
+    else if (iWLANStatus == -2) { // SSID not configured
         StatusLED(WLAN_INIT, 2, true);
-        return; // No way to continue with empty SSID or password!
+        return; // No way to continue with empty SSID
     }
 
     xDelay = 2000 / portTICK_PERIOD_MS;

--- a/sd-card/wlan.ini
+++ b/sd-card/wlan.ini
@@ -2,7 +2,7 @@
 ; AI on the edge - WLAN configuration
 ;++++++++++++++++++++++++++++++++++
 ; ssid: Name of WLAN network (mandatory), e.g. "WLAN-SSID"
-; password: Password of WLAN network (mandatory), e.g. "PASSWORD"
+; password: Password of WLAN network (optional), e.g. "PASSWORD"
 
 ssid = ""
 password = ""


### PR DESCRIPTION
- Allow operation with empty WIFI password due to this issue [#2393](https://github.com/jomjol/AI-on-the-edge-device/issues/2393) --> Allow using MAC Radius authentication
- Empty password will be mentioned in logfile and serial log as INFO



BEGIN_COMMIT_OVERRIDE
fix(wifi): Allow operation with empty WIFI password
END_COMMIT_OVERRIDE