### PR TITLE
fix: Reactivate "init delayed" functionality after crash

### DIFF
--- a/code/main/main.cpp
+++ b/code/main/main.cpp
@@ -301,6 +301,7 @@ extern "C" void app_main(void)
                                                "Flow init is delayed by 5 minutes to check the logs or do an OTA update"); 
         LogFile.WriteToFile(ESP_LOG_WARN, TAG, "Keep device running until crash occurs again and check logs after device is up again");
         LogFile.setLogLevel(ESP_LOG_DEBUG);
+	setTaskAutoFlowState(FLOW_TASK_STATE_INIT_DELAYED);
     }
     else {
         LogFile.WriteToFile(ESP_LOG_INFO, TAG, "Reset reason: " + getResetReason());

--- a/code/main/main.cpp
+++ b/code/main/main.cpp
@@ -301,7 +301,7 @@ extern "C" void app_main(void)
                                                "Flow init is delayed by 5 minutes to check the logs or do an OTA update"); 
         LogFile.WriteToFile(ESP_LOG_WARN, TAG, "Keep device running until crash occurs again and check logs after device is up again");
         LogFile.setLogLevel(ESP_LOG_DEBUG);
-	setTaskAutoFlowState(FLOW_TASK_STATE_INIT_DELAYED);
+        setTaskAutoFlowState(FLOW_TASK_STATE_INIT_DELAYED);
     }
     else {
         LogFile.WriteToFile(ESP_LOG_INFO, TAG, "Reset reason: " + getResetReason());


### PR DESCRIPTION
Missing after implementation of #2 