### PR TITLE
feat(webui): Alignment: Add option to switch off rotation

### DIFF
--- a/code/components/jomjol_flowcontroll/ClassFlowAlignment.cpp
+++ b/code/components/jomjol_flowcontroll/ClassFlowAlignment.cpp
@@ -275,7 +275,7 @@ bool ClassFlowAlignment::doFlow(string time)
     }
 
     if (AlgROI) {
-        if(References[0].alignment_algo <= 2) // Only if any additional alignment algo is used: "default", "highaccuracy" or "fast"
+        if(References[0].alignment_algo <= 2) { // Only if any additional alignment algo is used: "default", "highaccuracy" or "fast"
             DrawRef(ImageTMP);
         }
         flowctrl.DigitalDrawROI(ImageTMP);

--- a/code/components/jomjol_flowcontroll/ClassFlowAlignment.cpp
+++ b/code/components/jomjol_flowcontroll/ClassFlowAlignment.cpp
@@ -78,8 +78,10 @@ bool ClassFlowAlignment::ReadParameter(FILE* pfile, string& aktparamgraph)
                 alg_algo = 1;
             else if (toUpper(splitted[1]) == "FAST")
                 alg_algo = 2;
-            else if (toUpper(splitted[1]) == "OFF") // no align algo if set to 3 = off => no draw ref //add disable aligment algo |01.2023
+            else if (toUpper(splitted[1]) == "ROTATION")
                 alg_algo = 3;
+            else if (toUpper(splitted[1]) == "OFF")
+                alg_algo = 4;
             else
                 alg_algo = 0;   // Default
 
@@ -166,7 +168,7 @@ bool ClassFlowAlignment::ReadParameter(FILE* pfile, string& aktparamgraph)
         }
     }
 
-    if (References[0].alignment_algo == 2)
+    if (References[0].alignment_algo == 2) // Load references if "fast" algo is used
         LoadReferenceAlignmentValues();
 
     return true;
@@ -207,7 +209,7 @@ bool ClassFlowAlignment::doFlow(string time)
         ImageTMP = new CImageBasis("ImageTMP", ImageBasis, 1);
         if (ImageTMP == NULL) 
         {
-            LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "Faioled to allocate ImageTMP");
+            LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "Failed to allocate ImageTMP");
             LogFile.WriteHeapInfo("ClassFlowAlignment-doFlow");
             return false;
         }
@@ -245,6 +247,9 @@ bool ClassFlowAlignment::doFlow(string time)
  
     if ((initalrotate != 0) || initialflip)
     {
+        if (References[0].alignment_algo == 4)  // alignment off: no initial rotation and no additional alignment algo
+            initalrotate = 0;
+        
         if (use_antialiasing)
             rt.RotateAntiAliasing(initalrotate);
         else
@@ -256,7 +261,7 @@ bool ClassFlowAlignment::doFlow(string time)
 
     LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "Initial rotation: " + std::to_string(initalrotate));
 
-    if(References[0].alignment_algo != 3) {  // if align_algo = off -> no align
+    if(References[0].alignment_algo <= 2) { // Only if any additional alignment algo is used: "default", "highaccuracy" or "fast"
         int AlignRetval = AlignAndCutImage->Align(&References[0], &References[1]);
 
         if (AlignRetval >= 0) {
@@ -270,7 +275,7 @@ bool ClassFlowAlignment::doFlow(string time)
     }
 
     if (AlgROI) {
-        if(References[0].alignment_algo != 3){ // if align_algo = off -> draw no alignment marker
+        if(References[0].alignment_algo <= 2) // Only if any additional alignment algo is used: "default", "highaccuracy" or "fast"
             DrawRef(ImageTMP);
         }
         flowctrl.DigitalDrawROI(ImageTMP);

--- a/code/components/jomjol_image_proc/CFindTemplate.h
+++ b/code/components/jomjol_image_proc/CFindTemplate.h
@@ -8,7 +8,7 @@
 struct strRefInfo {
     CImageBasis* refImage = NULL;
     std::string image_file; 
-    int alignment_algo = 0;             // 0 = "Default" (nur R-Kanal), 1 = "HighAccuracy" (RGB-Kanal), 2 = "Fast" (1.x RGB, dann isSimilar)
+    int alignment_algo = 0;             // 0 = "Default" (nur R-Kanal), 1 = "HighAccuracy" (RGB-Kanal), 2 = "Fast" (1.x RGB, dann isSimilar), 3= "only initial rotation", 4 = "off"
     int target_x = 0;
     int target_y = 0;
     int width = 0;

--- a/sd-card/html/edit_config_param.html
+++ b/sd-card/html/edit_config_param.html
@@ -363,20 +363,21 @@
 
 
 		<!------------- Alignment ------------------>
-		<tr class="expert"  style="border-bottom: 2px solid lightgray;" id="ex4">
+		<tr style="border-bottom: 2px solid lightgray;">
 			<td colspan="3" style="padding-left: 0px; padding-bottom: 3px;"><h4>Alignment</h4></td>
 		</tr>
 
-		<tr class="expert"  id="AlignmentAlgo_ex8">
+		<tr>
 			<td class="indent1">
 				<class id="Alignment_AlignmentAlgo_text" style="color:black;">Alignment Algorithm</class>
 			</td>
 			<td>
 				<select id="Alignment_AlignmentAlgo_value1">
-					<option value="default" selected>Default</option>
-					<option value="highAccuracy" >HighAccuracy</option>
-					<option value="fast" >Fast</option>
-					<option value="off" >Off</option><!-- add disable aligment algo |01.2023 -->
+					<option value="default" selected>Rotation + Default Algo</option>
+					<option value="highAccuracy" >Rotation + High Accuracy Algo</option>
+					<option value="fast" >Rotation + Fast Algo</option>
+					<option value="rotation" >Only Rotation</option>
+					<option value="off" >Off</option>
 				</select>
 			</td>
 			<td>$TOOLTIP_Alignment_AlignmentAlgo</td>


### PR DESCRIPTION
- New / redeclared alignment options:
  - `Only Rotation` --> previous named as "Off", only disabled pattern algorithm, but rotation is performed
  - `Off` --> No image rotation and no pattern algorithm will be performed
- UI configuration page:
  - Declare `Alignment Algorithm` as regular parameter, no expert parameter anymore
  - Rename alignment options



BEGIN_COMMIT_OVERRIDE
feat(webui): Alignment: Add option to switch off rotation
END_COMMIT_OVERRIDE
