### PR TITLE
feat(webui): Add initial rotate to WebUI config page

### DIFF
--- a/code/components/jomjol_flowcontroll/ClassFlowAlignment.cpp
+++ b/code/components/jomjol_flowcontroll/ClassFlowAlignment.cpp
@@ -109,17 +109,17 @@ bool ClassFlowAlignment::ReadParameter(FILE* pfile, string& aktparamgraph)
                 initialflip = false;
         }
 
+        if ((toUpper(splitted[0]) == "INITIALROTATE") && (splitted.size() > 1))
+        {
+            this->initalrotate = std::stof(splitted[1]);
+        }
+
         if ((toUpper(splitted[0]) == "INITIALMIRROR") && (splitted.size() > 1))
         {
             if (toUpper(splitted[1]) == "TRUE")
                 initialmirror = true;
             else
                 initialmirror = false;
-        }
-
-        if (((toUpper(splitted[0]) == "INITALROTATE") || (toUpper(splitted[0]) == "INITIALROTATE")) && (splitted.size() > 1))
-        {
-            this->initalrotate = std::stof(splitted[1]);
         }
  
         if ((toUpper(splitted[0]) == "ANTIALIASING") && (splitted.size() > 1))

--- a/sd-card/config/config.ini
+++ b/sd-card/config/config.ini
@@ -16,8 +16,8 @@ AlignmentAlgo = Default
 SearchFieldX = 20
 SearchFieldY = 20
 FlipImageSize = false
-InitialMirror = false
 InitialRotate = 0.0
+InitialMirror = false
 /config/ref0.jpg 103 271
 /config/ref1.jpg 442 142
 

--- a/sd-card/html/edit_config_param.html
+++ b/sd-card/html/edit_config_param.html
@@ -431,6 +431,17 @@
 			<td>$TOOLTIP_Alignment_InitialMirror</td>
 		</tr>
 
+        <tr class="expert">
+            <td class="indent1">
+                <class id="Alignment_InitialRotate_text" style="color:black;">Image Rotation</class>
+            </td>
+            <td>
+                <input required type="number" name="name" id="Alignment_InitialRotate_value1" size="13" min="-360.0" max="360.0" step="0.1"
+                oninput="(!validity.rangeUnderflow||(value=-360.0)) && (!validity.rangeOverflow||(value=360.0)) && 
+                (!validity.stepMismatch||(value=parseInt(this.value)));">Degree
+            </td>
+            <td>$TOOLTIP_Alignment_InitialRotate</td>
+        </tr>
 
 		<!------------- Digit ROIs ------------------>
 		<tr style="border-bottom: 2px solid lightgray;" id="Category_Digits_ex4">
@@ -2049,7 +2060,8 @@ function UpdateInput() {
     WriteParameter(param, category, "Alignment", "SearchFieldY", false);		
     WriteParameter(param, category, "Alignment", "AlignmentAlgo", false);
     WriteParameter(param, category, "Alignment", "FlipImageSize", false);
-    WriteParameter(param, category, "Alignment", "InitialMirror", false);			
+    WriteParameter(param, category, "Alignment", "InitialMirror", false);
+    WriteParameter(param, category, "Alignment", "InitialRotate", false);
 
     WriteParameter(param, category, "Digits", "CNNGoodThreshold", false);
     WriteParameter(param, category, "Digits", "ROIImagesLocation", true);		
@@ -2180,6 +2192,7 @@ function ReadParameterAll()
     ReadParameter(param, "Alignment", "AlignmentAlgo", false);
     ReadParameter(param, "Alignment", "FlipImageSize", false);
     ReadParameter(param, "Alignment", "InitialMirror", false);
+    ReadParameter(param, "Alignment", "InitialRotate", false);
 
     ReadParameter(param, "Digits", "Model", false);
     ReadParameter(param, "Digits", "CNNGoodThreshold", false);

--- a/sd-card/html/edit_config_param.html
+++ b/sd-card/html/edit_config_param.html
@@ -418,20 +418,7 @@
 			<td>$TOOLTIP_Alignment_FlipImageSize</td>
 		</tr>
 
-		<tr class="expert"  id="ex13">
-			<td class="indent1">
-			    <class id="Alignment_InitialMirror_text" style="color:black;">Initial Mirror</class>
-			</td>
-			<td>
-				<select id="Alignment_InitialMirror_value1">
-					<option value="true">true</option>
-					<option value="false" selected>false</option>
-				</select>
-			</td>
-			<td>$TOOLTIP_Alignment_InitialMirror</td>
-		</tr>
-
-        <tr class="expert">
+		<tr>
             <td class="indent1">
                 <class id="Alignment_InitialRotate_text" style="color:black;">Image Rotation</class>
             </td>
@@ -442,6 +429,20 @@
             </td>
             <td>$TOOLTIP_Alignment_InitialRotate</td>
         </tr>
+
+		<tr>
+			<td class="indent1">
+			    <class id="Alignment_InitialMirror_text" style="color:black;">Mirror Image</class>
+			</td>
+			<td>
+				<select id="Alignment_InitialMirror_value1">
+					<option value="true">true</option>
+					<option value="false" selected>false</option>
+				</select>
+			</td>
+			<td>$TOOLTIP_Alignment_InitialMirror</td>
+		</tr>
+
 
 		<!------------- Digit ROIs ------------------>
 		<tr style="border-bottom: 2px solid lightgray;" id="Category_Digits_ex4">

--- a/sd-card/html/edit_config_param.html
+++ b/sd-card/html/edit_config_param.html
@@ -2061,8 +2061,8 @@ function UpdateInput() {
     WriteParameter(param, category, "Alignment", "SearchFieldY", false);		
     WriteParameter(param, category, "Alignment", "AlignmentAlgo", false);
     WriteParameter(param, category, "Alignment", "FlipImageSize", false);
+	WriteParameter(param, category, "Alignment", "InitialRotate", false);
     WriteParameter(param, category, "Alignment", "InitialMirror", false);
-    WriteParameter(param, category, "Alignment", "InitialRotate", false);
 
     WriteParameter(param, category, "Digits", "CNNGoodThreshold", false);
     WriteParameter(param, category, "Digits", "ROIImagesLocation", true);		
@@ -2192,8 +2192,8 @@ function ReadParameterAll()
     ReadParameter(param, "Alignment", "SearchFieldY", false);
     ReadParameter(param, "Alignment", "AlignmentAlgo", false);
     ReadParameter(param, "Alignment", "FlipImageSize", false);
+	ReadParameter(param, "Alignment", "InitialRotate", false);
     ReadParameter(param, "Alignment", "InitialMirror", false);
-    ReadParameter(param, "Alignment", "InitialRotate", false);
 
     ReadParameter(param, "Digits", "Model", false);
     ReadParameter(param, "Digits", "CNNGoodThreshold", false);

--- a/sd-card/html/readconfigparam.js
+++ b/sd-card/html/readconfigparam.js
@@ -131,11 +131,8 @@ function ParseConfig() {
      ParamAddValue(param, catname, "SearchFieldX");
      ParamAddValue(param, catname, "SearchFieldY");     
      ParamAddValue(param, catname, "FlipImageSize");
-     ParamAddValue(param, catname, "InitialMirror");   
-     // InitialRotate not visible on config page, create parameter with default value if not available (special care)
      ParamAddValue(param, catname, "InitialRotate");
-     param[catname]["InitialRotate"]["enabled"] = true;
-     param[catname]["InitialRotate"]["value1"] = 0.0;
+     ParamAddValue(param, catname, "InitialMirror");   
 
      var catname = "Digits";
      category[catname] = new Object(); 


### PR DESCRIPTION
- Add parameter `initialRotate` named `Image Rotation` to WebUI config page
- List `initialMirror` named `Mirror Image` as regular parameter, no expert parameter anymore
- Reorder and align parameter order


BEGIN_COMMIT_OVERRIDE
feat(webui): Add initial rotate to WebUI config page
END_COMMIT_OVERRIDE