### PR TITLE
fix: Delete TFLiteClass only when ClassFlowCNN gets deleted

### DIFF
--- a/code/components/jomjol_flowcontroll/ClassFlowCNNGeneral.cpp
+++ b/code/components/jomjol_flowcontroll/ClassFlowCNNGeneral.cpp
@@ -586,7 +586,6 @@ bool ClassFlowCNNGeneral::getNetworkParameter()
     if (!tflite->LoadModel(zwcnn)) {
         LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "TFLITE: Failed to load model: " + cnnmodelfile);
         LogFile.WriteHeapInfo("getNetworkParameter-LoadModel");
-        delete tflite;
         return false;
     } 
 
@@ -692,7 +691,6 @@ bool ClassFlowCNNGeneral::doNeuralNetwork(string time)
                         }
                         else {
                             LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "Invoke aborted");
-                            delete tflite;
                             return false;
                         }
 
@@ -746,7 +744,6 @@ bool ClassFlowCNNGeneral::doNeuralNetwork(string time)
                         }
                         else {
                             LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "Invoke aborted");
-                            delete tflite;
                             return false;
                         }
 
@@ -830,7 +827,6 @@ bool ClassFlowCNNGeneral::doNeuralNetwork(string time)
                         }
                         else {
                             LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "Invoke aborted");
-                            delete tflite;
                             return false;
                         }
     


### PR DESCRIPTION
- In rare cases: Prevent access to a non available ressource


BEGIN_COMMIT_OVERRIDE
fix: Delete TFLiteClass only when ClassFlowCNN gets deleted
END_COMMIT_OVERRIDE