### PR TITLE
chore(platformio): Update platformIO to 6.3.2

### DIFF
--- a/code/platformio.ini
+++ b/code/platformio.ini
@@ -19,7 +19,7 @@
 
 [common:esp32-idf]
     extends = common:idf
-    platform = platformio/espressif32 @ 6.3.1
+    platform = platformio/espressif32 @ 6.3.2
     framework = espidf
     lib_deps = 
         ${common:idf.lib_deps}


### PR DESCRIPTION
Release note: https://github.com/platformio/platform-espressif32/releases/tag/v6.3.2

Fix possible build issue due to python environment


BEGIN_COMMIT_OVERRIDE
chore(platformio): Update platformIO to 6.3.2
END_COMMIT_OVERRIDE