### PR TITLE
feat: Move bss segment to SPIRAM -> more free internal RAM

### DIFF
--- a/code/sdkconfig.defaults
+++ b/code/sdkconfig.defaults
@@ -102,7 +102,7 @@ CONFIG_SPIRAM_MALLOC_RESERVE_INTERNAL=131072
 CONFIG_SPIRAM_CACHE_WORKAROUND=y
 CONFIG_SPIRAM_IGNORE_NOTFOUND=y
 #CONFIG_SPIRAM_TRY_ALLOCATE_WIFI_LWIP=y => Leads to memory fragmentation, see https://github.com/jomjol/AI-on-the-edge-device/issues/2200
-#CONFIG_SPIRAM_ALLOW_BSS_SEG_EXTERNAL_MEMORY=y => Leads to memory fragmentation, see https://github.com/jomjol/AI-on-the-edge-device/issues/2200
+CONFIG_SPIRAM_ALLOW_BSS_SEG_EXTERNAL_MEMORY=y
 
 CONFIG_ESP_INT_WDT_TIMEOUT_MS=2000
 


### PR DESCRIPTION
Move bss segment to SPIRAM
-> Ca. 12kB more internal RAM
-> No fragmentation should occur in SPIRAM



BEGIN_COMMIT_OVERRIDE
feat: Move bss segment to SPIRAM -> more free internal RAM
END_COMMIT_OVERRIDE