### PR TITLE
chore: Remove redundant 'getFileSize()' function

### DIFF
--- a/code/components/jomjol_controlcamera/ClassControllCamera.cpp
+++ b/code/components/jomjol_controlcamera/ClassControllCamera.cpp
@@ -21,7 +21,6 @@
 #include <esp_system.h>
 #include <nvs_flash.h>
 #include <sys/param.h>
-#include <sys/stat.h>
 
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
@@ -809,7 +808,7 @@ bool CCamera::loadNextDemoImage(camera_fb_t *fb) {
         return false;
     }
 
-    fileSize = GetFileSize(filename);
+    fileSize = getFileSize(filename);
     if (fileSize > DEMO_IMAGE_SIZE) {
         char buf[100];
         snprintf(buf, sizeof(buf), "Demo Image (%d bytes) is larger than provided buffer (%d bytes)",
@@ -827,14 +826,6 @@ bool CCamera::loadNextDemoImage(camera_fb_t *fb) {
     // ToDo do we also need to set height, width, format and timestamp?
 
     return true;
-}
-
-
-long CCamera::GetFileSize(std::string filename)
-{
-    struct stat stat_buf;
-    long rc = stat(filename.c_str(), &stat_buf);
-    return rc == 0 ? stat_buf.st_size : -1;
 }
 
 

--- a/code/components/jomjol_helper/Helper.cpp
+++ b/code/components/jomjol_helper/Helper.cpp
@@ -470,6 +470,15 @@ std::string getFileType(std::string filename)
 }
 
 
+long getFileSize(std::string filename)
+{
+    struct stat stat_buf;
+    long rc = stat(filename.c_str(), &stat_buf);
+    return rc == 0 ? stat_buf.st_size : -1;
+}
+
+
+
 /* recursive mkdir */
 int mkdir_r(const char *dir, const mode_t mode) {
     char tmp[FILE_PATH_MAX];

--- a/code/components/jomjol_helper/Helper.h
+++ b/code/components/jomjol_helper/Helper.h
@@ -28,6 +28,7 @@ bool ctype_space(const char c, std::string adddelimiter);
 std::string getFileType(std::string filename);
 std::string getFileFullFileName(std::string filename);
 std::string getDirectory(std::string filename);
+long getFileSize(std::string filename);
 
 
 int mkdir_r(const char *dir, const mode_t mode);

--- a/code/components/jomjol_tfliteclass/CTfLiteClass.cpp
+++ b/code/components/jomjol_tfliteclass/CTfLiteClass.cpp
@@ -5,7 +5,6 @@
 #include "esp_log.h"
 #include "../../include/defines.h"
 
-#include <sys/stat.h>
 
 // #define DEBUG_DETAIL_ON
 
@@ -248,14 +247,6 @@ void CTfLiteClass::GetInputTensorSize()
 }
 
 
-long CTfLiteClass::GetFileSize(std::string filename)
-{
-    struct stat stat_buf;
-    long rc = stat(filename.c_str(), &stat_buf);
-    return rc == 0 ? stat_buf.st_size : -1;
-}
-
-
 bool CTfLiteClass::ReadFileToModel(std::string _fn)
 {
     LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "Read TFLITE model file: " + _fn);
@@ -264,7 +255,7 @@ bool CTfLiteClass::ReadFileToModel(std::string _fn)
             LogFile.WriteHeapInfo("ReadFileToModel: start");
     #endif
 
-    long size = GetFileSize(_fn);
+    long size = getFileSize(_fn);
     if (size <= 0) {
         LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "File not existing or zero size: " + _fn);
         return false;


### PR DESCRIPTION
Remove redundant 'getFileSize()' function and move to Helper.cpp


BEGIN_COMMIT_OVERRIDE
chore: Remove redundant 'getFileSize()' function
END_COMMIT_OVERRIDE
