### PR TITLE
chore(testcases): Adapt test cases to new naming + add test cases

### DIFF
--- a/code/components/jomjol_flowcontroll/ClassFlowPostProcessing.cpp
+++ b/code/components/jomjol_flowcontroll/ClassFlowPostProcessing.cpp
@@ -406,14 +406,14 @@ void ClassFlowPostProcessing::setDecimalShift()
             if (NUMBERS[j]->isExtendedResolution && flowDigit->CNNTypeWithExtendedResolution())
                 NUMBERS[j]->decimalShift -= 1;
 
-            NUMBERS[j]->decimalPlaceCount = -(NUMBERS[j]->decimalShift);
+            NUMBERS[j]->decimalPlaceCount = -1*(NUMBERS[j]->decimalShift);
         }
         // Only analog pointers
         else if (!NUMBERS[j]->digit_roi && NUMBERS[j]->analog_roi) {
             if (NUMBERS[j]->isExtendedResolution && flowAnalog->CNNTypeWithExtendedResolution())
                 NUMBERS[j]->decimalShift -= 1;
             
-            NUMBERS[j]->decimalPlaceCount = -NUMBERS[j]->decimalShift;
+            NUMBERS[j]->decimalPlaceCount = -1*(NUMBERS[j]->decimalShift);
         }
         // Digit numbers & analog pointer available 
         else if (NUMBERS[j]->digit_roi && NUMBERS[j]->analog_roi) {

--- a/code/test/components/jomjol-flowcontroll/test_flow_postrocess_helper.cpp
+++ b/code/test/components/jomjol-flowcontroll/test_flow_postrocess_helper.cpp
@@ -40,7 +40,7 @@ std::string process_doFlow(std::vector<float> analog, std::vector<float> digits,
     UnderTestPost* _undertestPost = init_do_flow(analog, digits, digType, checkConsistency, extendedResolution, decimal_shift);
     ESP_LOGD(TAG, "SetupClassFlowPostprocessing completed.");
 
-    std:: time;
+    std::string time;
     // run test
     TEST_ASSERT_TRUE(_undertestPost->doFlow(time));
 
@@ -95,6 +95,7 @@ UnderTestPost* init_do_flow(std::vector<float> analog, std::vector<float> digits
     setConsitencyCheck(_undertestPost, checkConsistency);
     setExtendedResolution(_undertestPost, extendedResolution);
     setDecimalShift(_undertestPost, decimal_shift);
+    _undertestPost->setDecimalShift(); // decimal shift correction depending on extended resolution setting + decimal place count setting
 
     return _undertestPost;
 
@@ -159,4 +160,11 @@ void setAnalogdigitTransistionStart(UnderTestPost* _underTestPost, float _analog
             (*NUMBERS)[_n]->analogDigitalTransitionStart = _analogdigitTransistionStart; 
         }       
     }
+}
+
+
+int getDecimalPlaceCount(UnderTestPost* _underTestPost)
+{
+    std::vector<NumberPost*>* NUMBERS = _underTestPost->GetNumbers();
+    return (*NUMBERS)[0]->decimalPlaceCount;
 }

--- a/code/test/components/jomjol-flowcontroll/test_flow_postrocess_helper.h
+++ b/code/test/components/jomjol-flowcontroll/test_flow_postrocess_helper.h
@@ -1,6 +1,7 @@
 #pragma once
 #ifndef TEST_FLOW_H
 #define TEST_FLOW_H
+#include <cmath> // needs to be included before unity.h -> provide isnan and isinf defines
 #include <unity.h>
 #include <ClassFlowPostProcessing.h>
 #include <ClassFlowCNNGeneral.h>
@@ -14,6 +15,7 @@ class UnderTestPost : public ClassFlowPostProcessing {
             : ClassFlowPostProcessing::ClassFlowPostProcessing(lfc, _analog, _digit) {}
         
         using ClassFlowPostProcessing::InitNUMBERS;
+        using ClassFlowPostProcessing::setDecimalShift;
         using ClassFlowPostProcessing::flowAnalog;
         using ClassFlowPostProcessing::flowDigit;    
 
@@ -112,5 +114,14 @@ void setAnalogdigitTransistionStart(UnderTestPost* _underTestPost, float _analog
  * @param _allowNegatives if should be set true or false
  */
 void setAllowNegatives(UnderTestPost* _underTestPost, bool _allowNegatives);
+
+/**
+ * @brief Get the count of decimal places 
+ * 
+ * @param _underTestPost the testobject
+ * @return Number of decimal places
+ * 
+ */
+int getDecimalPlaceCount(UnderTestPost* _underTestPost);
 
 #endif // TEST_FLOW_H

--- a/code/test/components/jomjol-flowcontroll/test_flow_pp_negative.cpp
+++ b/code/test/components/jomjol-flowcontroll/test_flow_pp_negative.cpp
@@ -24,7 +24,7 @@ void testNegative() {
         setAllowNegatives(underTestPost, false);
         SetFallbackValue(underTestPost, fallbackValue);
         std::string result = process_doFlow(underTestPost);
-        TEST_ASSERT_EQUAL_STRING("no error", underTestPost->getReadoutError().c_str());
+        TEST_ASSERT_EQUAL_STRING("000 Valid", underTestPost->getReadoutError().c_str());
         TEST_ASSERT_EQUAL_STRING(expected, result.c_str());
         delete underTestPost;
 
@@ -35,8 +35,8 @@ void testNegative() {
         setAllowNegatives(underTestPost, false);
         SetFallbackValue(underTestPost, fallbackValue_extended);
         result = process_doFlow(underTestPost);
-        TEST_ASSERT_EQUAL_STRING("no error", underTestPost->getReadoutError().c_str());
-        //TEST_ASSERT_EQUAL_STRING(to_stringWithPrecision(fallbackValue_extended, analogs.size()+1).c_str(), result.c_str());
+        TEST_ASSERT_EQUAL_STRING("E91 Rate negative", underTestPost->getReadoutError().c_str());
+        TEST_ASSERT_EQUAL_STRING(to_stringWithPrecision(fallbackValue_extended, getDecimalPlaceCount(underTestPost)).c_str(), result.c_str()); // Use Fallback value
         delete underTestPost;
 
         // extendResolution=true
@@ -46,8 +46,8 @@ void testNegative() {
         setAllowNegatives(underTestPost, false);
         SetFallbackValue(underTestPost, fallbackValue_extended);
         result = process_doFlow(underTestPost);
-        TEST_ASSERT_EQUAL_STRING("Neg. Rate: Read: 16.984, Pre: 16.988", underTestPost->getReadoutError().c_str());
-        TEST_ASSERT_EQUAL_STRING("", result.c_str());
+        TEST_ASSERT_EQUAL_STRING("E91 Rate negative", underTestPost->getReadoutError().c_str());
+        TEST_ASSERT_EQUAL_STRING(to_stringWithPrecision(fallbackValue_extended, getDecimalPlaceCount(underTestPost)).c_str(), result.c_str()); // Use Fallback value
         delete underTestPost;
 
         // extendResolution=false
@@ -57,8 +57,8 @@ void testNegative() {
         setAllowNegatives(underTestPost, false);
         SetFallbackValue(underTestPost, fallbackValue_extended);
         result = process_doFlow(underTestPost);
-        TEST_ASSERT_EQUAL_STRING("Neg. Rate: Read: 16.98, Pre: 16.99", underTestPost->getReadoutError().c_str());
-        TEST_ASSERT_EQUAL_STRING("", result.c_str());
+        TEST_ASSERT_EQUAL_STRING("E91 Rate negative", underTestPost->getReadoutError().c_str());
+        TEST_ASSERT_EQUAL_STRING(to_stringWithPrecision(fallbackValue, getDecimalPlaceCount(underTestPost)).c_str(), result.c_str()); // Use Fallback value
         delete underTestPost;
 
 
@@ -70,7 +70,7 @@ void testNegative() {
         setAllowNegatives(underTestPost, true);
         SetFallbackValue(underTestPost, fallbackValue_extended);
         result = process_doFlow(underTestPost);
-        TEST_ASSERT_EQUAL_STRING("no error", underTestPost->getReadoutError().c_str());
+        TEST_ASSERT_EQUAL_STRING("000 Valid", underTestPost->getReadoutError().c_str());
         TEST_ASSERT_EQUAL_STRING(expected, result.c_str());
         delete underTestPost;
 
@@ -93,13 +93,13 @@ void testNegative_Issues() {
         // extendResolution=false
         // value < fallbackValue
         // Prüfung eingeschaltet => Fehler
-        fallbackValue = 22018.08; // zu groß
+        fallbackValue = 22018.08; // zu groß 
         UnderTestPost* underTestPost = init_do_flow(analogs, digits, Digital100, false, false, -2);
         setAllowNegatives(underTestPost, false);
-        SetFallbackValue(underTestPost, fallbackValue_extended);
+        SetFallbackValue(underTestPost, fallbackValue);
         std::string result = process_doFlow(underTestPost);
-        TEST_ASSERT_EQUAL_STRING("Neg. Rate: Read: 22017.98, Pre: 22018.08", underTestPost->getReadoutError().c_str());
-        TEST_ASSERT_EQUAL_STRING("", result.c_str());
+        TEST_ASSERT_EQUAL_STRING("E91 Rate negative", underTestPost->getReadoutError().c_str());
+        TEST_ASSERT_EQUAL_STRING(to_stringWithPrecision(fallbackValue, getDecimalPlaceCount(underTestPost)).c_str(), result.c_str()); // Use Fallback value
         delete underTestPost;
 
 }

--- a/code/test/components/jomjol-flowcontroll/test_flowpostprocessing.cpp
+++ b/code/test/components/jomjol-flowcontroll/test_flowpostprocessing.cpp
@@ -533,9 +533,9 @@ void test_doFlowPP4() {
 
         // Fehler  V13.0.4 
         // https://github.com/jomjol/AI-on-the-edge-device/issues/1503#issuecomment-1343335855
-         std::vector<float> digits = {  0.0, 0.0, 6.9, 1.0, 6.6};  // 716.0199 als falsches Ergebnis. 
+        std::vector<float> digits = {  0.0, 0.0, 6.9, 1.0, 6.6};  // 716.0199 als falsches Ergebnis. 
         // Test ist nur erfolgreich mit Veränderung des AnalogdigitTransistionStart
-         std::vector<float> analogs = {9.9, 1.8, 6.6, 5.8};
+        std::vector<float> analogs = {9.9, 1.8, 6.6, 5.8};
         const char* expected = "717.0165";
         const char* expected_extended= "717.01658";
         
@@ -546,7 +546,62 @@ void test_doFlowPP4() {
         // checkConsistency=false und extendResolution=true
         result = process_doFlow(analogs, digits, Digital100, false, true);
         TEST_ASSERT_EQUAL_STRING(expected_extended, result.c_str());
-
 }
 
 
+void test_doFlowPP5() {
+
+        // Real case 2023-08-19 -> Transistion issue from 99.99 to 100.00
+        std::vector<float> digits = {1.0, 0.0, 9.8};  // wrong result: 199.994
+        std::vector<float> analogs = {9.9, 9.4};
+        const char* expected = "99.99";
+        const char* expected_extended= "99.994";
+        
+        // extendResolution=false
+        std::string result = process_doFlow(analogs, digits, Digital100, false, false);
+        TEST_ASSERT_EQUAL_STRING(expected, result.c_str());
+
+        // checkConsistency=false und extendResolution=true
+        result = process_doFlow(analogs, digits, Digital100, false, true);
+        TEST_ASSERT_EQUAL_STRING(expected_extended, result.c_str());
+
+        
+        digits = {1.0, 9.9, 9.8};  // wrong result: 199.994
+        analogs = {9.9, 9.4};
+        expected = "99.99";
+        expected_extended= "99.994";
+        
+        // extendResolution=false
+        result = process_doFlow(analogs, digits, Digital100, false, false);
+        TEST_ASSERT_EQUAL_STRING(expected, result.c_str());
+
+        // checkConsistency=false und extendResolution=true
+        result = process_doFlow(analogs, digits, Digital100, false, true);
+        TEST_ASSERT_EQUAL_STRING(expected_extended, result.c_str());
+
+        digits = {0.9, 0.0, 9.8};  // wrong result: 199.994
+        analogs = {9.9, 9.4};
+        expected = "99.99";
+        expected_extended= "99.994";
+        
+        // extendResolution=false
+        result = process_doFlow(analogs, digits, Digital100, false, false);
+        TEST_ASSERT_EQUAL_STRING(expected, result.c_str());
+
+        // checkConsistency=false und extendResolution=true
+        result = process_doFlow(analogs, digits, Digital100, false, true);
+        TEST_ASSERT_EQUAL_STRING(expected_extended, result.c_str());
+
+        digits = {1.0, 0.0, 9.9};  // wrong result: 199.994
+        analogs = {9.9, 0.1};
+        expected = "100.00";
+        expected_extended= "100.001";
+        
+        // extendResolution=false
+        result = process_doFlow(analogs, digits, Digital100, false, false);
+        TEST_ASSERT_EQUAL_STRING(expected, result.c_str());
+
+        // checkConsistency=false und extendResolution=true
+        result = process_doFlow(analogs, digits, Digital100, false, true);
+        TEST_ASSERT_EQUAL_STRING(expected_extended, result.c_str());
+}

--- a/code/test/test_suite_flowcontroll.cpp
+++ b/code/test/test_suite_flowcontroll.cpp
@@ -1,5 +1,5 @@
 #include <unity.h>
-#include <math.h>
+#include <cmath>
 
 #include "components/jomjol_fileserver_ota/server_ota.h"
 #include "components/jomjol-flowcontroll/test_flow_postrocess_helper.cpp"
@@ -106,19 +106,20 @@ void initGPIO()
 void task_UnityTesting(void *pvParameter)
 {
     UNITY_BEGIN();
+        RUN_TEST(test_getReadoutRawString);
+        
         RUN_TEST(testNegative_Issues);
         RUN_TEST(testNegative);
 
         RUN_TEST(test_analogToDigit_Standard);
         RUN_TEST(test_analogToDigit_Transition);
+
         RUN_TEST(test_doFlowPP);
         RUN_TEST(test_doFlowPP1);
         RUN_TEST(test_doFlowPP2);
         RUN_TEST(test_doFlowPP3);
         RUN_TEST(test_doFlowPP4);
-
-        // getReadoutRawString test
-        RUN_TEST(test_getReadoutRawString);
+        RUN_TEST(test_doFlowPP5);
     UNITY_END();
 
     while(1);


### PR DESCRIPTION
- Adapt test cases to new naming to be aligned with #57
- Add post processing transition issue test case which happened at one of my meters (99.940 -> 199.994 -> 100.xx) caputured with new debug logging feature #59)
-> Actually, post-processing algorithm does not handle this correctly. Possible solution for this will follow in a separate PR
   - digits = {1.0, 0.0, 9.8};  // wrong result: 199.994
   - analogs = {9.9, 9.4};


BEGIN_COMMIT_OVERRIDE
chore(testcases): Adapt test cases to new naming + add test cases
END_COMMIT_OVERRIDE