### PR TITLE
feat: Make camera frequency adjustable

### DIFF
--- a/code/components/jomjol_controlcamera/ClassControllCamera.h
+++ b/code/components/jomjol_controlcamera/ClassControllCamera.h
@@ -55,9 +55,10 @@ class CCamera {
         esp_err_t CaptureToStream(httpd_req_t *req, bool FlashlightOn);
 
         void ledc_init(void);
+        void SetCameraFrequency(int _frequency);
         void SetQualitySize(int qual, framesize_t resol);
-        framesize_t TextToFramesize(const char * text);
         bool SetBrightnessContrastSaturation(int _brightness, int _contrast, int _saturation);
+        framesize_t TextToFramesize(const char * text);
         void GetCameraParameter(httpd_req_t *req, int &qual, framesize_t &resol);
         void SetLEDIntensity(int _intrel);
 

--- a/code/components/jomjol_flowcontroll/ClassFlowTakeImage.cpp
+++ b/code/components/jomjol_flowcontroll/ClassFlowTakeImage.cpp
@@ -29,6 +29,7 @@ void ClassFlowTakeImage::SetInitialParameter(void)
     isImageSize = false;
     ImageSize = FRAMESIZE_VGA;
     TimeImageTaken = 0;
+    CameraFrequency = 20; // Mhz
     ImageQuality = 12;
     brightness = 0;
     contrast = 0;
@@ -61,72 +62,66 @@ bool ClassFlowTakeImage::ReadParameter(FILE* pfile, std::string& aktparamgraph)
     while (this->getNextLine(pfile, &aktparamgraph) && !this->isNewParagraph(aktparamgraph))
     {
         splitted = ZerlegeZeile(aktparamgraph);
-        if ((toUpper(splitted[0]) ==  "RAWIMAGESLOCATION") && (splitted.size() > 1))
-        {
+        if ((toUpper(splitted[0]) ==  "RAWIMAGESLOCATION") && (splitted.size() > 1)) {
             imagesLocation = "/sdcard" + splitted[1];
             isLogImage = true;
         }
 
-        if ((toUpper(splitted[0]) == "RAWIMAGESRETENTION") && (splitted.size() > 1))
-        {
+        if ((toUpper(splitted[0]) == "RAWIMAGESRETENTION") && (splitted.size() > 1)) {
             this->imagesRetention = std::stoi(splitted[1]);
         }
 
-        if ((toUpper(splitted[0]) == "WAITBEFORETAKINGPICTURE") && (splitted.size() > 1))
-        {
+        if ((toUpper(splitted[0]) == "WAITBEFORETAKINGPICTURE") && (splitted.size() > 1)) {
             waitbeforepicture = stof(splitted[1]);
             flash_duration = (int)(waitbeforepicture * 1000);
         }
 
-        if ((toUpper(splitted[0]) == "IMAGEQUALITY") && (splitted.size() > 1))
-            ImageQuality = std::stod(splitted[1]);
+        if ((toUpper(splitted[0]) == "CAMERAFREQUENCY") && (splitted.size() > 1)) {
+            CameraFrequency = std::stoi(splitted[1]);
+        }
 
-        if ((toUpper(splitted[0]) == "IMAGESIZE") && (splitted.size() > 1))
-        {
+        if ((toUpper(splitted[0]) == "IMAGEQUALITY") && (splitted.size() > 1)) {
+            ImageQuality = std::stod(splitted[1]);
+        }
+
+        if ((toUpper(splitted[0]) == "IMAGESIZE") && (splitted.size() > 1)) {
             ImageSize = Camera.TextToFramesize(splitted[1].c_str());
             isImageSize = true;
         }
 
-        if ((toUpper(splitted[0]) == "LEDINTENSITY") && (splitted.size() > 1))
-        {
+        if ((toUpper(splitted[0]) == "LEDINTENSITY") && (splitted.size() > 1)) {
             ledintensity = stoi(splitted[1]);
             ledintensity = std::min(100, ledintensity);
             ledintensity = std::max(0, ledintensity);
         }
 
-        if ((toUpper(splitted[0]) == "BRIGHTNESS") && (splitted.size() > 1))
-        {
+        if ((toUpper(splitted[0]) == "BRIGHTNESS") && (splitted.size() > 1)) {
             brightness = stoi(splitted[1]);
         }
 
-        if ((toUpper(splitted[0]) == "CONTRAST") && (splitted.size() > 1))
-        {
+        if ((toUpper(splitted[0]) == "CONTRAST") && (splitted.size() > 1)) {
             contrast = stoi(splitted[1]);
         }
 
-        if ((toUpper(splitted[0]) == "SATURATION") && (splitted.size() > 1))
-        {
+        if ((toUpper(splitted[0]) == "SATURATION") && (splitted.size() > 1)) {
             saturation = stoi(splitted[1]);
         }
 
-        if ((toUpper(splitted[0]) == "FIXEDEXPOSURE") && (splitted.size() > 1))
-        {
+        if ((toUpper(splitted[0]) == "FIXEDEXPOSURE") && (splitted.size() > 1)) {
             if (toUpper(splitted[1]) == "TRUE")
                 FixedExposure = true;
             else
                 FixedExposure = false;
         }
 
-        if ((toUpper(splitted[0]) == "DEMO") && (splitted.size() > 1))
-        {
+        if ((toUpper(splitted[0]) == "DEMO") && (splitted.size() > 1)) {
             if (toUpper(splitted[1]) == "TRUE")
                 Camera.EnableDemoMode();
             else
                 Camera.DisableDemoMode();
         }
 
-        if ((toUpper(splitted[0]) == "SAVEALLFILES") && (splitted.size() > 1))
-        {
+        if ((toUpper(splitted[0]) == "SAVEALLFILES") && (splitted.size() > 1)) {
             if (toUpper(splitted[1]) == "TRUE")
                 SaveAllFiles = true;
             else
@@ -136,8 +131,9 @@ bool ClassFlowTakeImage::ReadParameter(FILE* pfile, std::string& aktparamgraph)
 
     Camera.ledc_init(); // PWM init needs to be done here due to parameter reload (camera class not to be deleted completely)
     Camera.SetLEDIntensity(ledintensity);
-    Camera.SetBrightnessContrastSaturation(brightness, contrast, saturation);
+    Camera.SetCameraFrequency(CameraFrequency);
     Camera.SetQualitySize(ImageQuality, ImageSize);
+    Camera.SetBrightnessContrastSaturation(brightness, contrast, saturation);
 
     image_width = Camera.image_width;
     image_height = Camera.image_height;

--- a/code/components/jomjol_flowcontroll/ClassFlowTakeImage.h
+++ b/code/components/jomjol_flowcontroll/ClassFlowTakeImage.h
@@ -18,6 +18,7 @@ protected:
     int flash_duration;
     framesize_t ImageSize;
     bool isImageSize;
+    int CameraFrequency;
     int ImageQuality;
     int brightness;
     int contrast;

--- a/sd-card/config/config.ini
+++ b/sd-card/config/config.ini
@@ -2,6 +2,7 @@
 ;RawImagesLocation = /log/source
 ;RawImagesRetention = 5
 WaitBeforeTakingPicture = 2
+CameraFrequency = 20
 ImageQuality = 12
 ImageSize = VGA
 LEDIntensity = 50

--- a/sd-card/html/edit_config_param.html
+++ b/sd-card/html/edit_config_param.html
@@ -304,6 +304,21 @@
 
 		<tr class="expert">
 			<td class="indent1">
+				<class id="TakeImage_CameraFrequency_text" style="color:black;">Camera Frequency</class>
+			</td>
+			<td>
+				<select id="TakeImage_CameraFrequency_value1">
+					<option value="20" selected>20 Mhz</option>
+					<option value="16" >16 Mhz</option>
+					<option value="10" >10 Mhz</option>
+					<option value="8" >8 Mhz</option>
+				</select>
+			</td>
+			<td>$TOOLTIP_TakeImage_CameraFrequency</td>
+		</tr>
+
+		<tr class="expert">
+			<td class="indent1">
 				<class id="TakeImage_ImageQuality_text" style="color:black;">Image Quality</class>
 			</td>
 			<td>
@@ -2109,6 +2124,7 @@ function UpdateInput() {
     WriteParameter(param, category, "TakeImage", "RawImagesRetention", true);
     WriteParameter(param, category, "TakeImage", "Demo", false);
     WriteParameter(param, category, "TakeImage", "WaitBeforeTakingPicture", false);
+	WriteParameter(param, category, "TakeImage", "CameraFrequency", false);
     WriteParameter(param, category, "TakeImage", "ImageQuality", false);
     WriteParameter(param, category, "TakeImage", "Brightness", false);
     WriteParameter(param, category, "TakeImage", "Contrast", false);
@@ -2240,6 +2256,7 @@ function ReadParameterAll()
     ReadParameter(param, "TakeImage", "RawImagesRetention", true);
     ReadParameter(param, "TakeImage", "Demo", false);
     ReadParameter(param, "TakeImage", "WaitBeforeTakingPicture", false);
+	ReadParameter(param, "TakeImage", "CameraFrequency", false);
     ReadParameter(param, "TakeImage", "ImageQuality", false);
     ReadParameter(param, "TakeImage", "Brightness", false);
     ReadParameter(param, "TakeImage", "Contrast", false);

--- a/sd-card/html/readconfigparam.js
+++ b/sd-card/html/readconfigparam.js
@@ -119,6 +119,7 @@ function ParseConfig() {
      ParamAddSingleValueWithPreset(param, catname, "RawImagesLocation", false, "/log/source");
      ParamAddSingleValueWithPreset(param, catname, "RawImagesRetention", false, "5");
      ParamAddSingleValueWithPreset(param, catname, "WaitBeforeTakingPicture", true, "2.0");
+     ParamAddSingleValueWithPreset(param, catname, "CameraFrequency", true, "20");
      ParamAddSingleValueWithPreset(param, catname, "ImageQuality", true, "12");
      ParamAddSingleValueWithPreset(param, catname, "ImageSize", true, "VGA");
      ParamAddSingleValueWithPreset(param, catname, "LEDIntensity", true, "50");


### PR DESCRIPTION
Add expert parameter 'Camera Frequency' [5, 8, 10, 20 Mhz (default)] to 'Take Image section'

Note:
Usually there is no need to adapt the frequency.
Some devices do have issues with bad responsiveness. One possible root cause could be possible disturbances due to bad PCB routing of the frequency wire from SOC to the attached camera module. Modifying the camera frequency could possibly improve the situation. If it is not improving the situation, only hardware related optimizations are possible like shielding the respective area by copper foil, attach external antenna, etc...

Using Freenove ESP32S3 or XIAO ESP32S3 Sense boards, lowering to 8Mhz increased the responsivness massive.

Similar issue:
https://github.com/esphome/issues/issues/4191
https://github.com/espressif/arduino-esp32/issues/5834