### PR TITLE
refactor: Rename 'round' to 'cycle'

### DIFF
--- a/code/components/jomjol_controlcamera/ClassControllCamera.cpp
+++ b/code/components/jomjol_controlcamera/ClassControllCamera.cpp
@@ -858,7 +858,7 @@ bool CCamera::loadNextDemoImage(camera_fb_t *fb) {
     char filename[50];
     long fileSize;
 
-    snprintf(filename, sizeof(filename), "/sdcard/demo/%s", demoFiles[getCountFlowRounds() % demoFiles.size()].c_str());
+    snprintf(filename, sizeof(filename), "/sdcard/demo/%s", demoFiles[getFlowCycleCounter() % demoFiles.size()].c_str());
 
     LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "Using " + std::string(filename) + " as demo image");
 

--- a/code/components/jomjol_flowcontroll/ClassFlowAlignment.cpp
+++ b/code/components/jomjol_flowcontroll/ClassFlowAlignment.cpp
@@ -25,7 +25,7 @@ void ClassFlowAlignment::SetInitialParameter(void)
     presetFlowStateHandler(true);
     initalrotate = 0.0;
     anz_ref = 0;
-    AlignFAST_SADThreshold = 10;  // FAST ALIGN ALGO: SADNorm -> if smaller than threshold use same alignment values as last round
+    AlignFAST_SADThreshold = 10;  // FAST ALIGN ALGO: SADNorm -> if smaller than threshold use same alignment values as last cycle
     initialmirror = false;
     use_antialiasing = false;
     initialflip = false;

--- a/code/components/jomjol_flowcontroll/ClassFlowControll.cpp
+++ b/code/components/jomjol_flowcontroll/ClassFlowControll.cpp
@@ -1221,7 +1221,7 @@ esp_err_t ClassFlowControll::GetJPGStream(std::string _fn, httpd_req_t *req)
             free(fileBuffer);
         }
         else if ((!flowtakeimage->getFlowState()->getExecuted && getActStatus().compare(std::string(FLOW_IDLE_NO_AUTOSTART)) == 0) ||
-                    (!isAutoStart() && FlowStateEventOccured() && getActStatus().compare(std::string(FLOW_TAKE_IMAGE)) == 0)) {   // Show only before first round started or error occured, otherwise result will be shown till next start
+                    (!isAutoStart() && FlowStateEventOccured() && getActStatus().compare(std::string(FLOW_TAKE_IMAGE)) == 0)) {   // Show only before first cycle started or error occured, otherwise result will be shown till next start
             FILE* file = fopen("/sdcard/html/Flowstate_idle_no_autostart.jpg", "rb"); 
 
             if (!file) {

--- a/code/components/jomjol_flowcontroll/ClassFlowMQTT.cpp
+++ b/code/components/jomjol_flowcontroll/ClassFlowMQTT.cpp
@@ -195,7 +195,7 @@ bool ClassFlowMQTT::ReadParameter(FILE* pfile, std::string& aktparamgraph)
 
 bool ClassFlowMQTT::Start(float _processingInterval) 
 {
-    keepAlive = _processingInterval * 60 * 2.5; // Seconds, make sure it is greater thatn 2 rounds!
+    keepAlive = _processingInterval * 60 * 2.5; // Seconds, make sure it is greater than 2 processing cycles!
 
     std::stringstream stream;
     stream << std::fixed << std::setprecision(1) << "Processing interval: " << _processingInterval <<

--- a/code/components/jomjol_flowcontroll/ClassFlowMQTT.h
+++ b/code/components/jomjol_flowcontroll/ClassFlowMQTT.h
@@ -18,7 +18,6 @@ protected:
     std::string uri, topic, topicError, clientname, topicRate, topicTimeStamp, topicUptime, topicFreeMem;
     std::string user, password;
     std::string maintopic; 
-    float roundInterval; // Minutes
     int keepAlive; // Seconds
     bool SetRetainFlag;
 

--- a/code/components/jomjol_flowcontroll/MainFlowControl.h
+++ b/code/components/jomjol_flowcontroll/MainFlowControl.h
@@ -23,7 +23,7 @@ void DeleteMainFlowTask();
 bool isSetupModusActive();
 void setTaskAutoFlowState(uint8_t _value);
 
-int getCountFlowRounds();
+int getFlowCycleCounter();
 
 #ifdef ENABLE_MQTT
 esp_err_t MQTTCtrlFlowStart(std::string _topic);

--- a/code/components/jomjol_mqtt/interface_mqtt.cpp
+++ b/code/components/jomjol_mqtt/interface_mqtt.cpp
@@ -14,7 +14,7 @@ static const char *TAG = "MQTT IF";
 std::map<std::string, std::function<void()>>* connectFunktionMap = NULL;  
 std::map<std::string, std::function<bool(std::string, char*, int)>>* subscribeFunktionMap = NULL;
 
-int failedOnRound = -1;
+int failedOnCycle = -1;
 int MQTTReconnectCnt = 0;
  
 esp_mqtt_event_id_t esp_mqtt_ID = MQTT_EVENT_ANY;
@@ -38,7 +38,7 @@ bool MQTTPublish(std::string _key, std::string _content, int qos, bool retained_
         return false;
     }
 
-    if (failedOnRound == getCountFlowRounds()) {    // we already failed in this round, do not retry until the next round
+    if (failedOnCycle == getFlowCycleCounter()) {    // we already failed in this cycle, do not retry until the next cycle
         return true; // Fail quietly
     }
 
@@ -66,8 +66,8 @@ bool MQTTPublish(std::string _key, std::string _content, int qos, bool retained_
                 ESP_LOGD(TAG, "Publish msg_id %d in %lld ms", msg_id, (esp_timer_get_time() - starttime)/1000);
             #endif
             if (msg_id == -1) {
-                LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "Failed to publish topic '" + _key + "', skipping all MQTT publishings in this round");
-                failedOnRound = getCountFlowRounds();
+                LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "Failed to publish topic '" + _key + "', skipping all MQTT publishings in this cycle");
+                failedOnCycle = getFlowCycleCounter();
                 return false;
             }
         }

--- a/code/components/jomjol_mqtt/server_mqtt.cpp
+++ b/code/components/jomjol_mqtt/server_mqtt.cpp
@@ -29,7 +29,7 @@ std::string meterType = "";
 std::string valueUnit = "";
 std::string timeUnit = "";
 std::string rateUnit = "Unit/Minute";
-float roundInterval; // Minutes
+float processingInterval; // Minutes
 int keepAlive = 0; // Seconds
 bool retainFlag;
 static std::string maintopic;
@@ -37,11 +37,11 @@ static bool sendingOf_DiscoveryAndStaticTopics_scheduled;
 
 
 
-void mqttServer_setParameter(std::vector<NumberPost*>* _NUMBERS, int _keepAlive, float _roundInterval)
+void mqttServer_setParameter(std::vector<NumberPost*>* _NUMBERS, int _keepAlive, float _processingInterval)
 {
     NUMBERS = _NUMBERS;
     keepAlive = _keepAlive;
-    roundInterval = _roundInterval; 
+    processingInterval = _processingInterval; 
 }
 
 
@@ -259,7 +259,7 @@ bool publishStaticData(int qos)
     allSendsSuccessed |= MQTTPublish(maintopic + "/" + "hostname", wlan_config.hostname, qos, retainFlag);
 
     std::stringstream stream;
-    stream << std::fixed << std::setprecision(1) << roundInterval; // minutes
+    stream << std::fixed << std::setprecision(1) << processingInterval; // minutes
     allSendsSuccessed |= MQTTPublish(maintopic + "/" + "interval", stream.str(), qos, retainFlag);
 
     LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "Successfully published static topics");

--- a/code/components/jomjol_mqtt/server_mqtt.h
+++ b/code/components/jomjol_mqtt/server_mqtt.h
@@ -8,7 +8,7 @@
 #include "ClassFlowDefineTypes.h"
 
 void SetHomeassistantDiscoveryEnabled(bool enabled);
-void mqttServer_setParameter(std::vector<NumberPost*>* _NUMBERS, int interval, float roundInterval);
+void mqttServer_setParameter(std::vector<NumberPost*>* _NUMBERS, int _interval, float _processingInterval);
 void mqttServer_setMeterType(std::string meterType, std::string valueUnit, std::string timeUnit,std::string rateUnit);
 void setMqtt_Server_Retain(bool SetRetainFlag);
 void mqttServer_setMainTopic( std::string maintopic);

--- a/code/components/jomjol_wlan/connect_wlan.cpp
+++ b/code/components/jomjol_wlan/connect_wlan.cpp
@@ -333,7 +333,7 @@ void wifiRoamingQuery(void)
 	if (WIFIConnected && (esp_rrm_is_rrm_supported_connection() || esp_wnm_is_btm_supported_connection())) {
 		/* Client is allowed to send query to AP for roaming request if RSSI is lower than threshold */
 		/* Note 1: Set RSSI threshold funtion needs to be called to trigger WIFI_EVENT_STA_BSS_RSSI_LOW */
-		/* Note 2: Additional querys will be sent after flow round is finshed --> server_tflite.cpp - function "task_autodoFlow" */
+		/* Note 2: Additional querys will be sent after flow cycle is finshed --> server_tflite.cpp - function "task_autodoFlow" */
 		/* Note 3: RSSI_Threshold = 0 --> Disable client query by application (WebUI parameter) */
 		
 		if (wlan_config.rssi_threshold != 0 && get_WIFI_RSSI() != -127 && (get_WIFI_RSSI() < wlan_config.rssi_threshold))
@@ -503,7 +503,7 @@ static void event_handler(void* arg, esp_event_base_t event_base, int32_t event_
 			printRoamingFeatureSupport();
 
 			#ifdef WLAN_USE_MESH_ROAMING_ACTIVATE_CLIENT_TRIGGERED_QUERIES
-			// wifiRoamingQuery();	// Avoid client triggered query during processing flow (reduce risk of heap shortage). Request will be triggered at the end of every round anyway
+			// wifiRoamingQuery();	// Avoid client triggered query during processing flow (reduce risk of heap shortage). Request will be triggered at the end of every cycle anyway
 			#endif //WLAN_USE_MESH_ROAMING_ACTIVATE_CLIENT_TRIGGERED_QUERIES
 			
 		#endif //WLAN_USE_MESH_ROAMING

--- a/code/main/main.cpp
+++ b/code/main/main.cpp
@@ -232,7 +232,7 @@ extern "C" void app_main(void)
 
     // Init time (as early as possible, but SD card needs to be initialized)
     // ********************************************
-    setupTime();    // NTP time service: Status of time synchronization will be checked after every round (server_tflite.cpp)
+    setupTime();    // NTP time service: Status of time synchronization will be checked after every cycle (server_tflite.cpp)
 
     // Set CPU Frequency
     // ********************************************

--- a/code/main/server_main.cpp
+++ b/code/main/server_main.cpp
@@ -103,10 +103,10 @@ esp_err_t handler_get_info(httpd_req_t *req)
         httpd_resp_sendstr(req, zw.c_str());
         return ESP_OK;        
     }
-    else if (_task.compare("Round") == 0)
+    else if (_task.compare("CycleCounter") == 0)
     {
         char formated[10] = "";    
-        snprintf(formated, sizeof(formated), "%d", getCountFlowRounds());
+        snprintf(formated, sizeof(formated), "%d", getFlowCycleCounter());
         httpd_resp_sendstr(req, formated);
         return ESP_OK;        
     }

--- a/sd-card/html/index.html
+++ b/sd-card/html/index.html
@@ -128,7 +128,7 @@
 
     <li><a>Manual Control <i class="arrow down"></i></a>
         <ul class="submenu">
-            <li><a href="#" onclick="flow_start()">Start Round</a></li>
+            <li><a href="#" onclick="flow_start()">Start Cycle</a></li>
             <li id="HASendDiscovery" style="display:none;"><a href="#" onclick="HA_send_discovery()">Resend HA Discovery</a></li>
         </ul>
     </li>
@@ -158,14 +158,14 @@
 		xhttp.onreadystatechange = function() {
 			if (this.readyState == 4 && this.status == 200) {
 				if (xhttp.responseText.substring(0,3) == "001") {
-					firework.launch('Flow start triggered', 'success', 5000);
+					firework.launch('Cycle start triggered', 'success', 5000);
                     window.location.reload();
 				}
 				else if (xhttp.responseText.substring(0,3) == "002") {
-					firework.launch('Flow start scheduled. Start after round is completed', 'success', 5000);
+					firework.launch('Cycle start scheduled. Start new cycle after actual cycle is completed', 'success', 5000);
 				}
 				else if (xhttp.responseText.substring(0,3) == "099") {
-					firework.launch('Flow start triggered, but start not possible (no flow task available)', 'danger', 5000);
+					firework.launch('Cycle start triggered, but cycle start not possible (no main flow task available)', 'danger', 5000);
 				}
 			}
 		}

--- a/sd-card/html/overview.html
+++ b/sd-card/html/overview.html
@@ -127,7 +127,7 @@
 			<td>
 				<table>
 					<tr><td style="padding: 0px;">Uptime</td><td style="padding: 0px 20px"><output id="uptime"></output></td></tr>
-					<tr><td style="padding: 0px;">Round Counter</td><td style="padding: 0px 20px"><output id="round"></output></td></tr>
+					<tr><td style="padding: 0px;">Cycle Counter</td><td style="padding: 0px 20px"><output id="cycle_counter"></output></td></tr>
 					<tr><td style="padding: 0px;">WIFI Signal</td><td style="padding: 0px 20px"><output id="rssi"></output></td></tr>
 					<tr><td style="padding: 0px;">CPU Temp</td><td style="padding: 0px 20px"><output id="cputemp"></output></td></tr>
 				</table>
@@ -165,7 +165,7 @@
 				$('#statusflow').html(_jsonData.process_state);
 				loadProcessError(_jsonData.process_error);
 				$('#uptime').html(_jsonData.uptime);
-				$('#round').html(_jsonData.round_counter);
+				$('#cycle_counter').html(_jsonData.cycle_counter);
 				loadRSSI(_jsonData.rssi);
 				$('#cputemp').html(_jsonData.temperature + "°C");
 			}

--- a/sd-card/html/readconfigcommon.js
+++ b/sd-card/html/readconfigcommon.js
@@ -25,10 +25,10 @@ function reload_config() {
                     firework.launch('Configuration updated and applied', 'success', 5000);
                }
                else if (xhttp.responseText.substring(0,3) == "004") {
-                    firework.launch('Configuration updated and get applied after round is completed', 'success', 5000);
+                    firework.launch('Configuration updated and get applied after actual cycle is completed', 'success', 5000);
                }
                else if (xhttp.responseText.substring(0,3) == "099") {
-                    firework.launch('Configuration updated, but cannot get applied (no flow task running)', 'danger', 5000);
+                    firework.launch('Configuration updated, but cannot get applied (no main flow task running)', 'danger', 5000);
                }
           }
      }


### PR DESCRIPTION
Harmonize naming of the description of a processing cycle
- Rename every occurance of 'round' to 'cycle'

:warning: BREAKING CHANGE:
renamed REST API `/info?type=Round` to `/info?type=CycleCounter`