### PR TITLE
fix(webui): Increase file handling robustness -> handle config.ini update in firmware

### DIFF
--- a/sd-card/html/edit_config.html
+++ b/sd-card/html/edit_config.html
@@ -56,9 +56,10 @@
 	function saveTextAsFile()
 	{
 		if (confirm("Are you sure you want to save the configuration?")) {
-			FileDeleteOnServer("/config/config.ini", domainname);
 			var textToSave = document.getElementById("inputTextToSave").value;
-			FileSendContent(textToSave, "/config/config.ini", domainname);
+			// Save into temporary file and rename to config.ini on firmware level (server_file.cpp)
+     		// -> Prevent against  data loss if network connection is interrupted
+			FileSendContent(textToSave, "/config/config.tmp", domainname);
 
 			firework.launch('Save and apply configuration...', 'success', 5000);
 			setTimeout(function() {

--- a/sd-card/html/readconfigcommon.js
+++ b/sd-card/html/readconfigcommon.js
@@ -1,4 +1,4 @@
-function SaveConfigToServer(_domainname){
+function SaveConfigToServer(_domainname) {
      // leere Zeilen am Ende löschen
      var zw = config_split.length - 1;
      while (config_split[zw] == "") {
@@ -11,8 +11,9 @@ function SaveConfigToServer(_domainname){
           _config_gesamt = _config_gesamt + config_split[i] + "\n";
      } 
 
-     FileDeleteOnServer("/config/config.ini", _domainname);
-     FileSendContent(_config_gesamt, "/config/config.ini", _domainname);          
+     // Save to temporary file and then promote to config.ini on firmware level (server_file.cpp)
+     // -> Reduce data loss risk (e.g. network connection got interrupted during data transfer)
+     FileSendContent(_config_gesamt, "/config/config.tmp", _domainname);       
 }
 
 

--- a/sd-card/html/readconfigparam.js
+++ b/sd-card/html/readconfigparam.js
@@ -748,7 +748,6 @@ function CopyReferenceToImgTmp(_domainname)
      {
           _filenamevon = REFERENCES[index]["name"];
           _filenamenach = _filenamevon.replace("/config/", "/img_tmp/");
-          FileDeleteOnServer(_filenamenach, _domainname);
           FileCopyOnServer(_filenamevon, _filenamenach, _domainname);
      }
 }
@@ -763,7 +762,6 @@ function UpdateConfigReference(_domainname){
      {
           _filenamenach = REFERENCES[index]["name"];
           _filenamevon = _filenamenach.replace("/config/", "/img_tmp/");
-          FileDeleteOnServer(_filenamenach, _domainname);
           FileCopyOnServer(_filenamevon, _filenamenach, _domainname);
      }
 }


### PR DESCRIPTION
- Handle config.ini update in firmware to increase file handling robustness
  --> WebUI config.ini content gets transfered via REST API to a temporary file config.tmp and after sucessful transfer config.tmp gets promoted to updated config.ini on firmware level.
- Remove file deletion REST API request of alignment marker
  --> An existing alignment marker file is going to be overwritten on firmware level anyway.

