### PR TITLE
chore(build): Remove folder creation during build

### DIFF
--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -101,7 +101,6 @@ jobs:
         cp -r ./sd-card/html/* ./html/
 
         python -m pip install markdown
-        mkdir html/param-tooltips
         cd tools/parameter-tooltip-generator
         bash generate-param-doc-tooltips.sh
         cd ../..


### PR DESCRIPTION
Folder 'html/param-tooltips' is not used anymore