### PR TITLE
fix(influxdbv2): Rename parameter 'database' to 'bucket'

### DIFF
--- a/code/components/jomjol_flowcontroll/ClassFlowInfluxDBv2.cpp
+++ b/code/components/jomjol_flowcontroll/ClassFlowInfluxDBv2.cpp
@@ -26,7 +26,7 @@ void ClassFlowInfluxDBv2::SetInitialParameter(void)
     ListFlowControll = NULL;
 
     uri = "";
-    database = "";
+    bucket = "";
     dborg = "";  
     dbtoken = "";  
     //dbfield = "";
@@ -99,9 +99,9 @@ bool ClassFlowInfluxDBv2::ReadParameter(FILE* pfile, std::string& aktparamgraph)
             this->uri = splitted[1];
         }
 
-        if (((toUpper(splitted[0]) == "DATABASE")) && (splitted.size() > 1))
+        if (((toUpper(splitted[0]) == "BUCKET")) && (splitted.size() > 1))
         {
-            this->database = splitted[1];
+            this->bucket = splitted[1];
         }
 
         if ((toUpper(_param) == "ORG") && (splitted.size() > 1))
@@ -125,12 +125,12 @@ bool ClassFlowInfluxDBv2::ReadParameter(FILE* pfile, std::string& aktparamgraph)
         }
     }
 
-    LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "Init with URI: " + uri + ", Database: " + database + ", Org: " + dborg + ", Token: *****");
+    LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "Init with URI: " + uri + ", bucket: " + bucket + ", Org: " + dborg + ", Token: *****");
 
-    if ((uri.length() > 0 && (uri != "undefined")) && (database.length() > 0) && (database != "undefined") && 
+    if ((uri.length() > 0 && (uri != "undefined")) && (bucket.length() > 0) && (bucket != "undefined") && 
         (dborg.length() > 0) && (dborg != "undefined") && (dbtoken.length() > 0) && (dbtoken != "undefined")) 
     { 
-        InfluxDB_V2_Init(uri, database, dborg, dbtoken); 
+        InfluxDB_V2_Init(uri, bucket, dborg, dbtoken); 
         InfluxDBenable = true;
     }
     else {

--- a/code/components/jomjol_flowcontroll/ClassFlowInfluxDBv2.h
+++ b/code/components/jomjol_flowcontroll/ClassFlowInfluxDBv2.h
@@ -15,7 +15,7 @@ class ClassFlowInfluxDBv2 : public ClassFlow
 {
 protected:
 	ClassFlowPostProcessing* flowpostprocessing;
-    std::string uri, database;
+    std::string uri, bucket;
     std::string dborg, dbtoken, dbfield;
     bool InfluxDBenable;
 

--- a/code/components/jomjol_influxdb/interface_influxdb.cpp
+++ b/code/components/jomjol_influxdb/interface_influxdb.cpp
@@ -17,17 +17,17 @@ std::string _influxDBUser;
 std::string _influxDBPassword;
 
 std::string _influxDB_V2_URI;
-std::string _influxDB_V2_Database;
+std::string _influxDB_V2_Bucket;
 std::string _influxDB_V2_Token;
 std::string _influxDB_V2_Org;
 
 static esp_err_t http_event_handler(esp_http_client_event_t *evt);
 
 
-void InfluxDB_V2_Init(std::string _uri, std::string _database, std::string _org, std::string _token)
+void InfluxDB_V2_Init(std::string _uri, std::string _bucket, std::string _org, std::string _token)
 {
     _influxDB_V2_URI = _uri;
-    _influxDB_V2_Database = _database;
+    _influxDB_V2_Bucket = _bucket;
     _influxDB_V2_Org = _org;
     _influxDB_V2_Token = _token;
 }
@@ -71,7 +71,7 @@ void InfluxDB_V2_Publish(std::string _measurement, std::string _key, std::string
 
     LogFile.WriteToFile(ESP_LOG_INFO, TAG, "InfluxDBV2: Payload: " + payload);
 
-    std::string apiURI = _influxDB_V2_URI + "/api/v2/write?org=" + _influxDB_V2_Org + "&bucket=" + _influxDB_V2_Database;
+    std::string apiURI = _influxDB_V2_URI + "/api/v2/write?org=" + _influxDB_V2_Org + "&bucket=" + _influxDB_V2_Bucket;
     apiURI.shrink_to_fit();
     http_config.url = apiURI.c_str();
     ESP_LOGI(TAG, "http_config: %s", http_config.url); // Add mark on log to see when it restarted

--- a/code/components/jomjol_influxdb/interface_influxdb.h
+++ b/code/components/jomjol_influxdb/interface_influxdb.h
@@ -13,7 +13,7 @@ void InfluxDBInit(std::string _influxDBURI, std::string _database, std::string _
 void InfluxDBPublish(std::string _measurement, std::string _key, std::string _content, std::string _timestamp);
 
 // Interface to InfluxDB v2.x
-void InfluxDB_V2_Init(std::string _uri, std::string _database, std::string _org, std::string _token);
+void InfluxDB_V2_Init(std::string _uri, std::string _bucket, std::string _org, std::string _token);
 void InfluxDB_V2_Publish(std::string _measurement, std::string _key, std::string _content, std::string _timestamp);
 
 

--- a/code/main/main.cpp
+++ b/code/main/main.cpp
@@ -630,7 +630,8 @@ void migrateConfiguration(void)
             }
             if (isInString(configLines[i], "Database")) { // It is the parameter "Database"
                 migrated = migrated | replaceString(configLines[i], "Database", "Bucket"); // Rename it to Bucket
-
+            }
+            
             /* Measurement has a <NUMBER> as prefix! */
             if (isInString(configLines[i], "Measurement") && isInString(configLines[i], ";")) { // It is the parameter "Measurement" and is it disabled
                 migrated = migrated | replaceString(configLines[i], ";", ""); // Enable it

--- a/code/main/main.cpp
+++ b/code/main/main.cpp
@@ -628,6 +628,8 @@ void migrateConfiguration(void)
             if (isInString(configLines[i], "Database") && isInString(configLines[i], ";")) { // It is the parameter "Database" and it is commented out
                 migrated = migrated | replaceString(configLines[i], ";", ""); // Enable it
             }
+            if (isInString(configLines[i], "Database")) { // It is the parameter "Database"
+                migrated = migrated | replaceString(configLines[i], "Database", "Bucket"); // Rename it to Bucket
 
             /* Measurement has a <NUMBER> as prefix! */
             if (isInString(configLines[i], "Measurement") && isInString(configLines[i], ";")) { // It is the parameter "Measurement" and is it disabled

--- a/sd-card/config/config.ini
+++ b/sd-card/config/config.ini
@@ -74,7 +74,7 @@ main.Field = undefined
 
 ;[InfluxDBv2]
 Uri = http://IP-ADDRESS:PORT
-Database = undefined
+Bucket = undefined
 ;Org = undefined
 ;Token = undefined
 main.Measurement = undefined

--- a/sd-card/html/edit_config_param.html
+++ b/sd-card/html/edit_config_param.html
@@ -1063,12 +1063,12 @@
 
         <tr class="InfluxDBv2Item">
 			<td class="indent1">
-				<span id="InfluxDBv2_Database_text" style="color:black;">Database</span>
+				<span id="InfluxDBv2_Bucket_text" style="color:black;">Bucket</span>
 			</td>
 			<td>
-				<input required type="text" id="InfluxDBv2_Database_value1">
+				<input required type="text" id="InfluxDBv2_Bucket_value1">
 			</td>
-			<td>$TOOLTIP_InfluxDBv2_Database</td>
+			<td>$TOOLTIP_InfluxDBv2_Bucket</td>
 		</tr>
 
 		<tr class="InfluxDBv2Item">
@@ -2292,7 +2292,7 @@
 		WriteParameter(param, category, "InfluxDB", "password", true);	
 
 		WriteParameter(param, category, "InfluxDBv2", "Uri", false);	
-		WriteParameter(param, category, "InfluxDBv2", "Database", false);	
+		WriteParameter(param, category, "InfluxDBv2", "Bucket", false);	
 		WriteParameter(param, category, "InfluxDBv2", "Org", true);	
 		WriteParameter(param, category, "InfluxDBv2", "Token", true);	
 
@@ -2426,7 +2426,7 @@
 		ReadParameter(param, "InfluxDB", "password", true);
 
 		ReadParameter(param, "InfluxDBv2", "Uri", false);
-		ReadParameter(param, "InfluxDBv2", "Database", false);
+		ReadParameter(param, "InfluxDBv2", "Bucket", false);
 		ReadParameter(param, "InfluxDBv2", "Org", true);
 		ReadParameter(param, "InfluxDBv2", "Token", true);
 

--- a/sd-card/html/readconfigparam.js
+++ b/sd-card/html/readconfigparam.js
@@ -210,7 +210,7 @@ function ParseConfig() {
      category[catname]["found"] = true;
      param[catname] = new Object();
      ParamAddSingleValueWithPreset(param, catname, "Uri", true, "http://IP-ADDRESS:PORT");
-     ParamAddSingleValueWithPreset(param, catname, "Database", true, "undefined");
+     ParamAddSingleValueWithPreset(param, catname, "Bucket", true, "undefined");
      ParamAddSingleValueWithPreset(param, catname, "Org", false, "undefined");
      ParamAddSingleValueWithPreset(param, catname, "Token", false, "undefined");
      ParamAddValue(param, catname, "Measurement", 1, true, "undefined");


### PR DESCRIPTION
Rename existing parameter 'database' to 'bucket', because this is named like this since InfluxDBv2 --> [data-organization](https://docs.influxdata.com/influxdb/v2/get-started/#data-organization)

Cherry-picked and ported from jomjol repo -> https://github.com/jomjol/AI-on-the-edge-device/pull/2704
