### PR TITLE
chore(unity-test): Fix some test cases

### DIFF
--- a/code/components/jomjol_flowcontroll/ClassFlowCNNGeneral.cpp
+++ b/code/components/jomjol_flowcontroll/ClassFlowCNNGeneral.cpp
@@ -182,7 +182,7 @@ int ClassFlowCNNGeneral::EvalAnalogNumber(int _value, int _resultPreviousNumber)
         if (_resultPreviousNumber <= Analog_error)
         {
             result = valueMax / 10;
-            LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "EvalAnalogNumber (Ambiguous, use value + corretion): Result = " + std::to_string(result) +
+            LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "EvalAnalogNumber (Ambiguous, use value + corretion): Result: " + std::to_string(result) +
                                                         ", Value: " + to_stringWithPrecision(_value/10.0, 1) + 
                                                         ", resultPreviousNumber: " + std::to_string(_resultPreviousNumber));
             return result;

--- a/code/components/jomjol_tfliteclass/CTfLiteClass.cpp
+++ b/code/components/jomjol_tfliteclass/CTfLiteClass.cpp
@@ -341,7 +341,8 @@ CTfLiteClass::CTfLiteClass()
     modelfile = NULL;
     interpreter = nullptr;
     input = nullptr;
-    output = nullptr;  
+    output = nullptr;
+    tensor_arena = nullptr;
     kTensorArenaSize = 800 * 1024; // according to testfile: 108000 - so far 600;; 2021-09-11: 200 * 1024
 }
 

--- a/code/test/components/jomjol-flowcontroll/test_PointerEvalAnalogToDigitNew.cpp
+++ b/code/test/components/jomjol-flowcontroll/test_PointerEvalAnalogToDigitNew.cpp
@@ -1,5 +1,5 @@
-#include <unity.h>
 #include <ClassFlowCNNGeneral.h>
+
 
 class UnderTestCNNGeneral : public ClassFlowCNNGeneral {
     public:

--- a/code/test/components/jomjol-flowcontroll/test_cnnflowcontroll.cpp
+++ b/code/test/components/jomjol-flowcontroll/test_cnnflowcontroll.cpp
@@ -1,4 +1,3 @@
-#include <unity.h>
 #include <ClassFlowCNNGeneral.h>
 
 class UnderTestCNN : public ClassFlowCNNGeneral {
@@ -9,32 +8,35 @@ class UnderTestCNN : public ClassFlowCNNGeneral {
     
 };
 
+// Helper to enter value as float (1.0 -> 10, 4.5 -> 45)
+#define FLOAT_AS_INT(x) (int)(x*10)
+
 
 /**
  * @brief test if all combinations of digit 
  * evaluation are running correctly
  */
-void test_ZeigerEval() 
+void test_EvalAnalogNumber() 
 {
     UnderTestCNN undertest = UnderTestCNN(nullptr, "analog", Digital100);
 
     // the 5.2 is already above 5.0 and the previous digit too (3)
     printf("Test 5.2, 3\n");
-    int result = undertest.EvalAnalogNumber(5.2, 3);
+    int result = undertest.EvalAnalogNumber(FLOAT_AS_INT(5.2), 3);
     TEST_ASSERT_EQUAL(5, result);
 
     // the 5.2 is already above 5.0 and the previous digit not (9)
     // so the current digit shoult be reduced (4.9)
     printf("Test 5.2, 9\n");
-    TEST_ASSERT_EQUAL(4, undertest.EvalAnalogNumber(5.2, 9));
+    TEST_ASSERT_EQUAL(4, undertest.EvalAnalogNumber(FLOAT_AS_INT(5.2), 9));
 
     printf("Test 4.4, 9\n");
     // the 4.4 (digital100) is not above 5  and the previous digit (analog) too (9.3)
-    TEST_ASSERT_EQUAL(4, undertest.EvalAnalogNumber(4.4, 9));
+    TEST_ASSERT_EQUAL(4, undertest.EvalAnalogNumber(FLOAT_AS_INT(4.4), 9));
 
-    printf("Test 4.5, 0\n");
+    printf("Test 4.5, 9\n");
     // the 4.5 (digital100) is not above 5  and the previous digit (analog) too (9.6)
-    TEST_ASSERT_EQUAL(4, undertest.EvalAnalogNumber(4.5, 0));    
+    TEST_ASSERT_EQUAL(4, undertest.EvalAnalogNumber(FLOAT_AS_INT(4.5), 9));    
 
 }
 
@@ -42,66 +44,61 @@ void test_ZeigerEval()
  * @brief test if all combinations of digit 
  * evaluation are running correctly
  */
-void test_ZeigerEvalHybrid() {
+void test_EvalDigitNumber() {
     UnderTestCNN undertest = UnderTestCNN(nullptr, "digit", Digital100);
 
-    // the 5.2 and no previous should round down
+    // the 5.2 and no previous should trunc to 5
     printf("EvalDigitNumber(5.2, 0, -1)\n");
-    TEST_ASSERT_EQUAL(5, undertest.EvalDigitNumber(5.2, 0, -1));
+    TEST_ASSERT_EQUAL(5, undertest.EvalDigitNumber(FLOAT_AS_INT(5.2), 0, -1));
 
     // the 5.3 and no previous should trunc to 5
     printf("EvalDigitNumber(5.3, 0, -1)\n");
-    TEST_ASSERT_EQUAL(5, undertest.EvalDigitNumber(5.3, 0, -1));
+    TEST_ASSERT_EQUAL(5, undertest.EvalDigitNumber(FLOAT_AS_INT(5.3), 0, -1));
 
     printf("EvalDigitNumber(5.7, 0, -1)\n");
     // the 5.7 and no previous should trunc to 5
-    TEST_ASSERT_EQUAL(6, undertest.EvalDigitNumber(5.7, 0, -1));
+    TEST_ASSERT_EQUAL(5, undertest.EvalDigitNumber(FLOAT_AS_INT(5.7), 0, -1));
 
-    // the 5.8 and no previous should round up to 6
+    // the 5.8 and no previous should trunc to 5
     printf("EvalDigitNumber(5.8, 0, -1)\n");
-    TEST_ASSERT_EQUAL(6, undertest.EvalDigitNumber(5.8, 0, -1));
+    TEST_ASSERT_EQUAL(5, undertest.EvalDigitNumber(FLOAT_AS_INT(5.8), 0, -1));
 
-    // the 5.7 with previous and the previous between 0.3-0.5 should round up to 6
-    TEST_ASSERT_EQUAL(6, undertest.EvalDigitNumber(5.7, 0.4, 1));
+    // the 5.7 with previous and the previous between 0.3-0.7 should round up to 6
+    TEST_ASSERT_EQUAL(6, undertest.EvalDigitNumber(FLOAT_AS_INT(5.7), FLOAT_AS_INT(0.4), 0));
 
-    // the 5.3 with previous and the previous between 0.3-0.7 should round down to 5
-    TEST_ASSERT_EQUAL(5, undertest.EvalDigitNumber(5.3, 0.7, 1));
+    // the 5.3 with previous and the previous between 0.3-0.7 should trunc to 5
+    TEST_ASSERT_EQUAL(5, undertest.EvalDigitNumber(FLOAT_AS_INT(5.3), FLOAT_AS_INT(0.7), 0));
 
-    // the 5.3 with previous and the previous <=0.5 should trunc to 5
-    TEST_ASSERT_EQUAL(5, undertest.EvalDigitNumber(5.3, 0.1, 1));
+    // the 5.3 with previous and the previous <=0.7 should trunc to 5
+    TEST_ASSERT_EQUAL(5, undertest.EvalDigitNumber(FLOAT_AS_INT(5.3), FLOAT_AS_INT(0.1), 0));
 
-    // the 5.3 with previous and the previous >=9.5 should reduce to 4
-    TEST_ASSERT_EQUAL(4, undertest.EvalDigitNumber(5.3, 9.6, 9));
+    // the 5.3 with previous and the previous >9.7 (#define Digital_Transition_Area_Forward) should reduce to 4
+    TEST_ASSERT_EQUAL(4, undertest.EvalDigitNumber(FLOAT_AS_INT(5.3), FLOAT_AS_INT(9.8), 9));
 
-    // the 5.7 with previous and the previous >=9.5 should trunc to 5
-    TEST_ASSERT_EQUAL(5, undertest.EvalDigitNumber(5.7, 9.6, 9));
+    // the 5.7 with previous and the previous >9.7 (#define Digital_Transition_Area_Forward) should trunc to 5 (reason: decimal place >=4)
+    TEST_ASSERT_EQUAL(5, undertest.EvalDigitNumber(FLOAT_AS_INT(5.7), FLOAT_AS_INT(9.8), 9));
 
-    // the 4.5 (digital100) is not above 5  and the previous digit (analog) not over Zero (9.6)
-    TEST_ASSERT_EQUAL(4, undertest.EvalDigitNumber(4.5, 9.6, 0));    
+    // the 4.5 (digital100) is not above 5 and the previous digit (analog) not over zero (9.7) -> #define Digital_Transition_Area_Forward
+    TEST_ASSERT_EQUAL(4, undertest.EvalDigitNumber(FLOAT_AS_INT(4.5), FLOAT_AS_INT(9.8), 9));    
 
-    // the 4.5 (digital100) is not above 5  and the previous digit (analog) not over Zero (9.6)
-    TEST_ASSERT_EQUAL(4, undertest.EvalDigitNumber(4.5, 9.6, 9));    
-    // the 4.5 (digital100) is not above 5  and the previous digit (analog) not over Zero (9.5)
-    TEST_ASSERT_EQUAL(4, undertest.EvalDigitNumber(4.5, 9.5, 9));    
+    // the 4.5 (digital100) is not above 5 and the previous digit (analog) over zero (0.7) -> #define Digital_Transition_Area_Predecessor
+    TEST_ASSERT_EQUAL(4, undertest.EvalDigitNumber(FLOAT_AS_INT(4.5), FLOAT_AS_INT(0.7), 0));   
+
+    // the 4.5 (digital100) is not above 5 and the previous digit (analog) not over zero (9.5)
+    TEST_ASSERT_EQUAL(4, undertest.EvalDigitNumber(FLOAT_AS_INT(4.5), FLOAT_AS_INT(9.5), 9));    
 
     // 59.96889 - Pre: 58.94888
     // 8.6 : 9.8 : 6.7
-    // the 4.4 (digital100) is not above 5  and the previous digit (analog) not over Zero (9.5)
-    TEST_ASSERT_EQUAL(8, undertest.EvalDigitNumber(8.6, 9.8, 9));    
+    // the 8.6 (digital100) is not above 8 and the previous digit (analog) not over zero (9.8)
+    TEST_ASSERT_EQUAL(8, undertest.EvalDigitNumber(FLOAT_AS_INT(8.6), FLOAT_AS_INT(9.8), 9));    
 
     // pre = 9.9 (0.0 raw)
     // zahl = 1.8
-    TEST_ASSERT_EQUAL(2, undertest.EvalDigitNumber(1.8, 9.0, 9));    
+    TEST_ASSERT_EQUAL(2, undertest.EvalDigitNumber(FLOAT_AS_INT(1.8), FLOAT_AS_INT(9.0), 9));    
  
     // if a digit have an early transition and the pointer is < 9.0 
-    // prev (pointer) = 6.2, but on digital readout = 6.0 (prev is int parameter)
+    // prev (pointer) = 6.2, but on digital readout = 6 (result is int parameter)
     // zahl = 4.6
-    TEST_ASSERT_EQUAL(4, undertest.EvalDigitNumber(4.6, 6.0, 6));    
- 
-    
-    // issue #879 vorgaenger is -1, zahl = 6.7
-    //TEST_ASSERT_EQUAL(7, undertest.ZeigerEvalHybrid(6.7, -1.0, -1));    
-
-
+    TEST_ASSERT_EQUAL(4, undertest.EvalDigitNumber(FLOAT_AS_INT(4.6), FLOAT_AS_INT(6.2), 6)); 
 }
 

--- a/code/test/components/jomjol-flowcontroll/test_cnnflowcontroll.cpp
+++ b/code/test/components/jomjol-flowcontroll/test_cnnflowcontroll.cpp
@@ -43,6 +43,19 @@ void test_EvalAnalogNumber()
 /**
  * @brief test if all combinations of digit 
  * evaluation are running correctly
+ * 
+ * -> Desciption for call undertest.EvalDigitNumber(int _value, int _valuePreviousNumber, int _resultPreviousNumber, 
+ * bool isPreviousAnalog, float digitalAnalogTransitionStart)
+ * @param _value: is the current ROI as int value with one decimal digit (e.g. 10 -> 1.0)
+ * @param _valuePreviousNumber: is the last (lower) ROI as int with one decimal digit (e.g. 10 -> 1.0)
+ * @param _resultPreviousNumber: is the evaluated number. Sometimes a much lower value can change higer values
+ *                          example: 9.8, 9.9, 0.1
+ *                          0.1 => 0 (resultPreviousNumber)
+ *                          The 0 makes a 9.9 to 0 (resultPreviousNumber)
+ *                          The 0 makes a 9.8 to 0 
+ * @param isPreviousAnalog: false/true if the last ROI is an analog or digit ROI (default=false == digit)
+ *                              runs in special handling because analog is much less precise
+ * @param analogDigitalTransitionStart  start of the transitionlogic begins on valuePreviousNumber (default=9.2)
  */
 void test_EvalDigitNumber() {
     UnderTestCNN undertest = UnderTestCNN(nullptr, "digit", Digital100);
@@ -57,11 +70,11 @@ void test_EvalDigitNumber() {
 
     printf("EvalDigitNumber(5.7, 0, -1)\n");
     // the 5.7 and no previous should trunc to 5
-    TEST_ASSERT_EQUAL(5, undertest.EvalDigitNumber(FLOAT_AS_INT(5.7), 0, -1));
+    TEST_ASSERT_EQUAL(5, undertest.EvalDigitNumber(FLOAT_AS_INT(5.7), 0, -1, false, FLOAT_AS_INT(9.2)));
 
-    // the 5.8 and no previous should trunc to 5
-    printf("EvalDigitNumber(5.8, 0, -1)\n");
-    TEST_ASSERT_EQUAL(5, undertest.EvalDigitNumber(FLOAT_AS_INT(5.8), 0, -1));
+    // the 5.8 and no previous should round to 6 (already in transition)
+    printf("EvalDigitNumber(5.8, 8.0, 8, false, 8.0)\n");
+    TEST_ASSERT_EQUAL(6, undertest.EvalDigitNumber(FLOAT_AS_INT(5.8), FLOAT_AS_INT(8.0), 8, false, FLOAT_AS_INT(8.0)));
 
     // the 5.7 with previous and the previous between 0.3-0.7 should round up to 6
     TEST_ASSERT_EQUAL(6, undertest.EvalDigitNumber(FLOAT_AS_INT(5.7), FLOAT_AS_INT(0.4), 0));
@@ -72,8 +85,8 @@ void test_EvalDigitNumber() {
     // the 5.3 with previous and the previous <=0.7 should trunc to 5
     TEST_ASSERT_EQUAL(5, undertest.EvalDigitNumber(FLOAT_AS_INT(5.3), FLOAT_AS_INT(0.1), 0));
 
-    // the 5.3 with previous and the previous >9.7 (#define Digital_Transition_Area_Forward) should reduce to 4
-    TEST_ASSERT_EQUAL(4, undertest.EvalDigitNumber(FLOAT_AS_INT(5.3), FLOAT_AS_INT(9.8), 9));
+    // the 5.2 with previous and the previous >9.7 (#define Digital_Transition_Area_Forward) should reduce to 4
+    TEST_ASSERT_EQUAL(4, undertest.EvalDigitNumber(FLOAT_AS_INT(5.2), FLOAT_AS_INT(9.8), 9, false, FLOAT_AS_INT(9.0)));
 
     // the 5.7 with previous and the previous >9.7 (#define Digital_Transition_Area_Forward) should trunc to 5 (reason: decimal place >=4)
     TEST_ASSERT_EQUAL(5, undertest.EvalDigitNumber(FLOAT_AS_INT(5.7), FLOAT_AS_INT(9.8), 9));

--- a/code/test/components/jomjol-flowcontroll/test_flow_postrocess_helper.h
+++ b/code/test/components/jomjol-flowcontroll/test_flow_postrocess_helper.h
@@ -1,8 +1,7 @@
 #pragma once
 #ifndef TEST_FLOW_H
 #define TEST_FLOW_H
-#include <cmath> // needs to be included before unity.h -> provide isnan and isinf defines
-#include <unity.h>
+
 #include <ClassFlowPostProcessing.h>
 #include <ClassFlowCNNGeneral.h>
 #include <ClassFlowTakeImage.h>

--- a/code/test/components/jomjol-flowcontroll/test_flow_pp_negative.cpp
+++ b/code/test/components/jomjol-flowcontroll/test_flow_pp_negative.cpp
@@ -1,8 +1,6 @@
 #include "test_flow_postrocess_helper.h"
 
 
-
-
 /**
  * @brief Testfall für Überprüfung allowNegatives
  * 

--- a/code/test/components/jomjol-flowcontroll/test_flowpostprocessing.cpp
+++ b/code/test/components/jomjol-flowcontroll/test_flowpostprocessing.cpp
@@ -1,8 +1,6 @@
 #include "test_flow_postrocess_helper.h"
 
 
-
-
 /**
  * ACHTUNG! Die Test laufen aktuell nur mit ausgeschaltetem Debug in ClassFlowCNNGeneral 
  * 

--- a/code/test/components/jomjol-flowcontroll/test_getReadoutRawString.cpp
+++ b/code/test/components/jomjol-flowcontroll/test_getReadoutRawString.cpp
@@ -1,7 +1,6 @@
 #include "test_flow_postrocess_helper.h"
 
 
-
 void test_getReadoutRawString() {
 
     // no ROIs setted up
@@ -21,7 +20,4 @@ void test_getReadoutRawString() {
 
     result = _undertestPost->flowAnalog->getReadoutRawString(0);
     TEST_ASSERT_EQUAL_STRING(",5.5", result.c_str());
-
-
-
 }

--- a/code/test/test_suite_flowcontroll.cpp
+++ b/code/test/test_suite_flowcontroll.cpp
@@ -1,12 +1,4 @@
 #include <unity.h>
-#include <cmath>
-
-#include "components/jomjol_fileserver_ota/server_ota.h"
-#include "components/jomjol-flowcontroll/test_flow_postrocess_helper.cpp"
-#include "components/jomjol-flowcontroll/test_flowpostprocessing.cpp"
-#include "components/jomjol-flowcontroll/test_flow_pp_negative.cpp"
-#include "components/jomjol-flowcontroll/test_PointerEvalAnalogToDigitNew.cpp"
-#include "components/jomjol-flowcontroll/test_getReadoutRawString.cpp"
 
 // SD-Card ////////////////////
 #include "nvs_flash.h"
@@ -14,9 +6,23 @@
 #include "sdmmc_cmd.h"
 #include "driver/sdmmc_host.h"
 #include "driver/sdmmc_defs.h"
-//static const char *TAG = "MAIN TEST";
 #define __SD_USE_ONE_LINE_MODE__
+// SD-Card ////////////////////
+
 #include "server_GPIO.h"
+#include "components/jomjol_fileserver_ota/server_ota.h"
+
+
+//*****************************************************************************
+// Include files with functions to test
+//*****************************************************************************
+#include "components/jomjol-flowcontroll/test_flow_postrocess_helper.cpp"
+#include "components/jomjol-flowcontroll/test_flowpostprocessing.cpp"
+#include "components/jomjol-flowcontroll/test_flow_pp_negative.cpp"
+#include "components/jomjol-flowcontroll/test_PointerEvalAnalogToDigitNew.cpp"
+#include "components/jomjol-flowcontroll/test_getReadoutRawString.cpp"
+#include "components/jomjol-flowcontroll/test_cnnflowcontroll.cpp"
+
 
 bool Init_NVS_SDCard()
 {
@@ -78,11 +84,8 @@ bool Init_NVS_SDCard()
         return false;
     }
 
-    sdmmc_card_print_info(stdout, card);
-    SaveSDCardInfo(card);
     return true;
 }
-
 
 
 void initGPIO()
@@ -91,7 +94,7 @@ void initGPIO()
     //set as output mode
     io_conf.mode = gpio_mode_t::GPIO_MODE_INPUT;
     //bit mask of the pins that you want to set,e.g.GPIO18/19
-     io_conf.pull_down_en =  gpio_pulldown_t::GPIO_PULLDOWN_ENABLE;
+    io_conf.pull_down_en =  gpio_pulldown_t::GPIO_PULLDOWN_ENABLE;
     //set pull-up mode
     io_conf.pull_up_en =  gpio_pullup_t::GPIO_PULLUP_DISABLE;
     //configure GPIO with the given settings
@@ -105,20 +108,37 @@ void initGPIO()
  */
 void task_UnityTesting(void *pvParameter)
 {
+    vTaskDelay( 3000 / portTICK_PERIOD_MS ); // 3s delay to ensure established serial connection
+    
     UNITY_BEGIN();
         RUN_TEST(test_getReadoutRawString);
+        printf("---------------------------------------------------------------------------\n");
+        
+        RUN_TEST(test_EvalAnalogNumber);
+        printf("---------------------------------------------------------------------------\n");
+        RUN_TEST(test_EvalDigitNumber);
+        printf("---------------------------------------------------------------------------\n");
         
         RUN_TEST(testNegative_Issues);
+        printf("---------------------------------------------------------------------------\n");
         RUN_TEST(testNegative);
+        printf("---------------------------------------------------------------------------\n");
 
         RUN_TEST(test_analogToDigit_Standard);
+        printf("---------------------------------------------------------------------------\n");
         RUN_TEST(test_analogToDigit_Transition);
+        printf("---------------------------------------------------------------------------\n");
 
         RUN_TEST(test_doFlowPP);
+        printf("---------------------------------------------------------------------------\n");
         RUN_TEST(test_doFlowPP1);
+        printf("---------------------------------------------------------------------------\n");
         RUN_TEST(test_doFlowPP2);
+        printf("---------------------------------------------------------------------------\n");
         RUN_TEST(test_doFlowPP3);
+        printf("---------------------------------------------------------------------------\n");
         RUN_TEST(test_doFlowPP4);
+        printf("---------------------------------------------------------------------------\n");
         RUN_TEST(test_doFlowPP5);
     UNITY_END();
 

--- a/code/test/test_suite_flowcontroll.cpp
+++ b/code/test/test_suite_flowcontroll.cpp
@@ -146,7 +146,6 @@ void task_UnityTesting(void *pvParameter)
 }
 
 
-
 /**
  * @brief main task
  */

--- a/code/test/test_suite_flowcontroll.cpp
+++ b/code/test/test_suite_flowcontroll.cpp
@@ -108,7 +108,7 @@ void initGPIO()
  */
 void task_UnityTesting(void *pvParameter)
 {
-    vTaskDelay( 3000 / portTICK_PERIOD_MS ); // 3s delay to ensure established serial connection
+    vTaskDelay( 5000 / portTICK_PERIOD_MS ); // 5s delay to ensure established serial connection
     
     UNITY_BEGIN();
         RUN_TEST(test_getReadoutRawString);


### PR DESCRIPTION
Fix some test cases
- Added missing test cases `test_EvalAnalogNumber` and `test_EvalDigitNumber`
- Adapt these test cases to follow this change (#2466) implemented with #34
- Align test cases with #2783