### PR TITLE
fix(REST API): Fix misleading REST API send_file error

### DIFF
--- a/code/main/server_main.cpp
+++ b/code/main/server_main.cpp
@@ -460,8 +460,7 @@ esp_err_t handler_img_tmp_virtual(httpd_req_t *req)
         return GetRawJPG(req); 
 
     // Serve alg.jpg, alg_roi.jpg or digital and analog ROIs
-    if (ESP_OK == GetJPG(filetosend, req))
-        return ESP_OK;
+    return GetJPG(filetosend, req));
 
     #ifdef DEBUG_DETAIL_ON      
         LogFile.WriteHeapInfo("handler_img_tmp_virtual - Done");   

--- a/code/main/server_main.cpp
+++ b/code/main/server_main.cpp
@@ -460,7 +460,7 @@ esp_err_t handler_img_tmp_virtual(httpd_req_t *req)
         return GetRawJPG(req); 
 
     // Serve alg.jpg, alg_roi.jpg or digital and analog ROIs
-    return GetJPG(filetosend, req));
+    return GetJPG(filetosend, req);
 
     #ifdef DEBUG_DETAIL_ON      
         LogFile.WriteHeapInfo("handler_img_tmp_virtual - Done");   


### PR DESCRIPTION
REST API handler_img_tmp: Fix misleading REST send_file error
- Return img_tmp handler function if underlaying GetJPG function fails
- After loading a JPG (e.g. alg_roi.jpg) from RAM fails for some reason, same filename was used to load file form SD card, but file is only available in RAM -> misleading error log