### PR TITLE
fix(REST API): Fix rare exception for log file handling

### DIFF
--- a/code/components/jomjol_logfile/ClassLogFile.cpp
+++ b/code/components/jomjol_logfile/ClassLogFile.cpp
@@ -174,6 +174,9 @@ std::string fileNameDate;
 
 void ClassLogFile::WriteToFile(esp_log_level_t level, std::string tag, std::string message, bool _time)
 {
+    if (level > loglevel)// Skip logging if defined message loglevel is more verbose than configured threshold loglevel
+        return;
+
     std::string fileNameDateNew;
     std::string zwtime;
     std::string ntpTime = "";
@@ -191,10 +194,6 @@ void ClassLogFile::WriteToFile(esp_log_level_t level, std::string tag, std::stri
     }
     else {
         ESP_LOG_LEVEL(level, "", "%s", message.c_str());
-    }
-    
-    if (level > loglevel) {// Only write to file if loglevel is below threshold
-        return;
     }
 
     if (_time) {
@@ -234,9 +233,9 @@ void ClassLogFile::WriteToFile(esp_log_level_t level, std::string tag, std::stri
             std::string logpath = logFileRootFolder + "/" + fileNameDateNew; 
 
             ESP_LOGI(TAG, "Opening logfile %s for appending", logpath.c_str());
-            logFileAppendHandle = fopen(logpath.c_str(), "a+");
+            logFileAppendHandle = fopen(logpath.c_str(), "a");
             if (logFileAppendHandle==NULL) {
-                ESP_LOGE(TAG, "Can't open log file %s", logpath.c_str());
+                ESP_LOGE(TAG, "WriteToFile: Failed to open logfile %s", logpath.c_str());
                 return;
             }
 
@@ -244,9 +243,9 @@ void ClassLogFile::WriteToFile(esp_log_level_t level, std::string tag, std::stri
         }
     #else
         std::string logpath = logFileRootFolder + "/" + fileNameDateNew; 
-        logFileAppendHandle = fopen(logpath.c_str(), "a+");
-        if (logFileAppendHandle==NULL) {
-            ESP_LOGE(TAG, "Can't open log file %s", logpath.c_str());
+        logFileAppendHandle = fopen(logpath.c_str(), "a");
+        if (logFileAppendHandle == NULL) {
+            ESP_LOGE(TAG, "WriteToFile: Failed to open logfile %s", logpath.c_str());
             return;
         }
     #endif

--- a/code/include/defines.h
+++ b/code/include/defines.h
@@ -113,7 +113,7 @@
 
     //server_file + server_help
     #define IS_FILE_EXT(filename, ext) \
-    (strcasecmp(&filename[strlen(filename) - sizeof(ext) + 1], ext) == 0)
+                (strcasecmp(&filename[strlen(filename) - sizeof(ext) + 1], ext) == 0)
 
 
     //server_ota


### PR DESCRIPTION
- Fix rare exception for log file handling
-> not anymore actively closing logfile before reading data for REST API request
-> This situation only occurs rarly if heavy logging is active, e.g. debug logging and constantly requesting data over REST API
- Skip log message writing request as early as possible if log level is not relevant (save some more CPU cycles)
- Some code cleanup