### PR TITLE
feat(webui): 'Overview' + 'Data Graph': Save auto page refresh config persistently

### DIFF
--- a/sd-card/config/config.ini
+++ b/sd-card/config/config.ini
@@ -123,3 +123,9 @@ Hostname = watermeter
 ;RSSIThreshold = -75
 CPUFrequency = 160
 SetupMode = true
+
+[WebUI]
+OverviewAutoRefresh = true
+OverviewAutoRefreshTime = 10
+DataGraphAutoRefresh = false
+DataGraphAutoRefreshTime = 60

--- a/sd-card/html/edit_config_param.html
+++ b/sd-card/html/edit_config_param.html
@@ -1977,8 +1977,8 @@
 				<span id="WebUI_OverviewAutoRefreshTime_text" style="color:black;">Auto Refresh Time</span>
 			</td>
 			<td>
-				<input required type="number" id="WebUI_OverviewAutoRefreshTime_value1"  min="2" step="1"
-					oninput="(!validity.rangeUnderflow||(value=2)) && (!validity.stepMismatch||(value=parseInt(this.value)));">Seconds
+				<input required type="number" id="WebUI_OverviewAutoRefreshTime_value1"  min="1" step="1"
+					oninput="(!validity.rangeUnderflow||(value=1)) && (!validity.stepMismatch||(value=parseInt(this.value)));">Seconds
 			</td>
 			<td>$TOOLTIP_WebUI_OverviewAutoRefreshTime</td>
 		</tr>
@@ -2007,8 +2007,8 @@
 				<span id="WebUI_DataGraphAutoRefreshTime_text" style="color:black;">Auto Refresh Time</span>
 			</td>
 			<td>
-				<input required type="number" id="WebUI_DataGraphAutoRefreshTime_value1"  min="2" step="1"
-					oninput="(!validity.rangeUnderflow||(value=2)) && (!validity.stepMismatch||(value=parseInt(this.value)));">Seconds
+				<input required type="number" id="WebUI_DataGraphAutoRefreshTime_value1"  min="1" step="1"
+					oninput="(!validity.rangeUnderflow||(value=1)) && (!validity.stepMismatch||(value=parseInt(this.value)));">Seconds
 			</td>
 			<td>$TOOLTIP_WebUI_DataGraphAutoRefreshTime</td>
 		</tr>

--- a/sd-card/html/edit_config_param.html
+++ b/sd-card/html/edit_config_param.html
@@ -1940,7 +1940,78 @@
 			</td>
 			<td>$TOOLTIP_System_CPUFrequency</td>
 		</tr>
+	</table>
 
+	<!-- WebUI -->
+	<table class="table">
+		<colgroup>
+			<col span="1" style="width:290px">
+			<col span="1" style="width:300px;">
+			<col span="1">
+		</colgroup>
+		<tr>
+			<th colspan="3">WebUI</th>
+		</tr>
+
+		<tr>
+			<td class="indent1" style="padding-top:25px" colspan="3">
+				<b>Overview</b>
+			</td>
+		</tr>
+
+		<tr>
+			<td class="indent2">
+				<span id="WebUI_OverviewAutoRefresh_text" style="color:black;">Auto Refresh</span>
+			</td>
+			<td>
+				<select id="WebUI_OverviewAutoRefresh_value1" onchange='setEnabled("WebUI_OverviewAutoRefresh_parameter", this.value == "true" ? true : false);'>
+					<option value="true" selected>true</option>
+					<option value="false" >false</option>
+				</select>
+			</td>
+			<td>$TOOLTIP_WebUI_OverviewAutoRefresh</td>
+		</tr>
+
+		<tr class="WebUI_OverviewAutoRefresh_parameter">
+			<td class="indent2">
+				<span id="WebUI_OverviewAutoRefreshTime_text" style="color:black;">Auto Refresh Time</span>
+			</td>
+			<td>
+				<input required type="number" id="WebUI_OverviewAutoRefreshTime_value1"  min="2" step="1"
+					oninput="(!validity.rangeUnderflow||(value=2)) && (!validity.stepMismatch||(value=parseInt(this.value)));">Seconds
+			</td>
+			<td>$TOOLTIP_WebUI_OverviewAutoRefreshTime</td>
+		</tr>
+
+		<tr>
+			<td class="indent1" style="padding-top:25px" colspan="3">
+				<b>Data Graph</b>
+			</td>
+		</tr>
+
+		<tr>
+			<td class="indent2">
+				<span id="WebUI_DataGraphAutoRefresh_text" style="color:black;">Auto Refresh</span>
+			</td>
+			<td>
+				<select id="WebUI_DataGraphAutoRefresh_value1" onchange='setEnabled("WebUI_DataGraphAutoRefresh_parameter", this.value == "true" ? true : false);'>
+					<option value="true">true</option>
+					<option value="false" selected>false</option>
+				</select>
+			</td>
+			<td>$TOOLTIP_WebUI_DataGraphAutoRefresh</td>
+		</tr>
+
+		<tr class="WebUI_DataGraphAutoRefresh_parameter">
+			<td class="indent2">
+				<span id="WebUI_DataGraphAutoRefreshTime_text" style="color:black;">Auto Refresh Time</span>
+			</td>
+			<td>
+				<input required type="number" id="WebUI_DataGraphAutoRefreshTime_value1"  min="2" step="1"
+					oninput="(!validity.rangeUnderflow||(value=2)) && (!validity.stepMismatch||(value=parseInt(this.value)));">Seconds
+			</td>
+			<td>$TOOLTIP_WebUI_DataGraphAutoRefreshTime</td>
+		</tr>
 	</table>
 
 	<table style="padding-top:10px">
@@ -2464,12 +2535,19 @@
 		WriteParameter(param, category, "System", "RSSIThreshold", true);
 		WriteParameter(param, category, "System", "CPUFrequency", false);
 
+		WriteParameter(param, category, "WebUI", "OverviewAutoRefresh", false);
+		WriteParameter(param, category, "WebUI", "OverviewAutoRefreshTime", false);
+		WriteParameter(param, category, "WebUI", "DataGraphAutoRefresh", false);
+		WriteParameter(param, category, "WebUI", "DataGraphAutoRefreshTime", false);
+
 		WriteModelFiles();
 
 		// Visualize subparameter of a parameter
 		setEnabled("MQTT_TLSEncryption_parameter", document.getElementById("MQTT_TLSEncryption_value1").value == "true" ? true : false);
 		setEnabled("InfluxDB_TLSEncryption_parameter", document.getElementById("InfluxDB_TLSEncryption_value1").value == "true" ? true : false);
 		setEnabled("InfluxDBv2_TLSEncryption_parameter", document.getElementById("InfluxDBv2_TLSEncryption_value1").value == "true" ? true : false);
+		setEnabled("WebUI_OverviewAutoRefresh_parameter", document.getElementById("WebUI_OverviewAutoRefresh_value1").value == "true" ? true : false);
+		setEnabled("WebUI_DataGraphAutoRefresh_parameter", document.getElementById("WebUI_DataGraphAutoRefresh_value1").value == "true" ? true : false);
 	}
 
 
@@ -2621,6 +2699,11 @@
 		ReadParameter(param, "System", "Hostname", false);
 		ReadParameter(param, "System", "RSSIThreshold", true);
 		ReadParameter(param, "System", "CPUFrequency", false);
+
+		ReadParameter(param, "WebUI", "OverviewAutoRefresh", false);
+		ReadParameter(param, "WebUI", "OverviewAutoRefreshTime", false);
+		ReadParameter(param, "WebUI", "DataGraphAutoRefresh", false);
+		ReadParameter(param, "WebUI", "DataGraphAutoRefreshTime", false);
 
 		var sel = document.getElementById("Numbers_value1");
 		UpdateInputIndividual(sel);

--- a/sd-card/html/graph.html
+++ b/sd-card/html/graph.html
@@ -77,8 +77,7 @@
             showRelativeValues = document.getElementById("showRelativeValues").checked;
             //alert("Auslesen: " + datefile + " " + numbername);
 
-            _domainname = getDomainname();
-            fetch(_domainname + '/fileserver/log/data/' + datefile)
+            fetch(getDomainname() + '/fileserver/log/data/' + datefile)
             .then(response => {
                 // handle the response
                 if (response.status == 404) {
@@ -299,9 +298,23 @@
     }
 
 
+    function initAutoRefreshContent()
+    {
+        loadConfig(getDomainname()); 
+        ParseConfigReduced();
+        param = getConfigParameters();
+        
+		document.getElementById("AutoRefreshEnabled").checked = param["WebUI"]["DataGraphAutoRefresh"]["value1"] == "true" ? true : false;
+		document.getElementById("AutoRefreshTime").value = param["WebUI"]["DataGraphAutoRefreshTime"]["value1"];   
+        
+        autoRefreshTimeoutHandle = null; // Init auto refresh handle
+        AutoRefreshContent();
+    }
+
+
 	function AutoRefreshContent()
-	{	
-		if (document.getElementById("AutoRefreshEnabled").checked == true) { // Activated -> Set timeout
+	{	   
+        if (document.getElementById("AutoRefreshEnabled").checked == true) { // Activated -> Set timeout
 
 			if (autoRefreshTimeoutHandle) { // Clear actual timeout handle
 				clearTimeout(autoRefreshTimeoutHandle);
@@ -331,8 +344,7 @@
 
     function init()
 	{
-        autoRefreshTimeoutHandle = null; // Init auto refresh handle
-		document.getElementById("AutoRefreshEnabled").checked = false; // Reset auto refresh checkbox at page init
+        initAutoRefreshContent();
         WriteDataFiles();
         WriteNumbers();
         run();

--- a/sd-card/html/overview.html
+++ b/sd-card/html/overview.html
@@ -310,6 +310,21 @@
 	}
 
 
+	function initAutoRefreshContent()
+    {
+        loadConfig(getDomainname()); 
+        ParseConfigReduced();
+        param = getConfigParameters();
+        
+		document.getElementById("AutoRefreshEnabled").checked = param["WebUI"]["OverviewAutoRefresh"]["value1"] == "true" ? true : false;
+		document.getElementById("AutoRefreshTime").value = param["WebUI"]["OverviewAutoRefreshTime"]["value1"];   
+        
+        autoRefreshTimeoutHandle = null; // Init auto refresh handle
+        AutoRefreshContent();
+    }
+
+
+
 	function AutoRefreshContent()
 	{	
 		if (document.getElementById("AutoRefreshEnabled").checked == true) { // Activated -> Set timeout
@@ -352,9 +367,8 @@
 		domainname = getDomainname();
 		document.getElementById("img").src = domainname + '/img_loading.gif?v=$COMMIT_HASH'; // Preset with loading indicator
 		document.getElementById("manual_refresh_img_loading").src = domainname + '/img_loading.gif?v=$COMMIT_HASH'; // Preset with loading indicator
-		autoRefreshTimeoutHandle = null; // Init auto refresh handle
-		document.getElementById("AutoRefreshEnabled").checked = false; // Reset auto refresh checkbox at page init
-		AutoRefreshContent();
+
+		initAutoRefreshContent();
 	}
 
 	

--- a/sd-card/html/readconfigparam.js
+++ b/sd-card/html/readconfigparam.js
@@ -275,14 +275,30 @@ function ParseConfig() {
      ParamAddSingleValueWithPreset(param, catname, "Hostname", true, "watermeter");   
      ParamAddSingleValueWithPreset(param, catname, "RSSIThreshold", false, "-75");   
      ParamAddSingleValueWithPreset(param, catname, "CPUFrequency", true, "160");
-     ParamAddSingleValueWithPreset(param, catname, "SetupMode", true, "true"); 
+     ParamAddSingleValueWithPreset(param, catname, "SetupMode", true, "true");
+
+     var catname = "WebUI";
+     category[catname] = new Object(); 
+     category[catname]["enabled"] = true;
+     category[catname]["found"] = true;
+     param[catname] = new Object();
+     ParamAddSingleValueWithPreset(param, catname, "OverviewAutoRefresh", true, "true");
+     ParamAddSingleValueWithPreset(param, catname, "OverviewAutoRefreshTime", true, "10");
+     ParamAddSingleValueWithPreset(param, catname, "DataGraphAutoRefresh", true, "false");
+     ParamAddSingleValueWithPreset(param, catname, "DataGraphAutoRefreshTime", true, "60");
      
-     
-     while (aktline < config_split.length){
+
+     while (aktline < config_split.length) {
           for (var cat in category) {
+               if (typeof config_split[aktline] === 'undefined') {
+                    aktline++;
+                    continue;
+               }
+
                zw = cat.toUpperCase();
                zw1 = "[" + zw + "]";
                zw2 = ";[" + zw + "]";
+               
                if ((config_split[aktline].trim().toUpperCase() == zw1) || (config_split[aktline].trim().toUpperCase() == zw2)) {
                     if (config_split[aktline].trim().toUpperCase() == zw1) {
                          category[cat]["enabled"] = true;
@@ -293,6 +309,7 @@ function ParseConfig() {
                     continue;
                }
           }
+          
           aktline++;
      }
 
@@ -345,11 +362,28 @@ function ParseConfigReduced() {
      param[catname] = new Object();
      ParamAddSingleValueWithPreset(param, catname, "HomeassistantDiscovery", true, "false");
 
+     var catname = "WebUI";
+     category[catname] = new Object(); 
+     category[catname]["enabled"] = true;
+     category[catname]["found"] = false;
+     param[catname] = new Object();
+     ParamAddSingleValueWithPreset(param, catname, "OverviewAutoRefresh", true, "true");
+     ParamAddSingleValueWithPreset(param, catname, "OverviewAutoRefreshTime", true, "10");
+     ParamAddSingleValueWithPreset(param, catname, "DataGraphAutoRefresh", true, "false");
+     ParamAddSingleValueWithPreset(param, catname, "DataGraphAutoRefreshTime", true, "60");
+
+
      while (aktline < config_split.length) {
           for (var cat in category) {
+               if (typeof config_split[aktline] === 'undefined') {
+                    aktline++;
+                    continue;
+               }
+               
                zw = cat.toUpperCase();
                zw1 = "[" + zw + "]";
                zw2 = ";[" + zw + "]";
+
                if ((config_split[aktline].trim().toUpperCase() == zw1) || (config_split[aktline].trim().toUpperCase() == zw2)) {
                     if (config_split[aktline].trim().toUpperCase() == zw1) {
                          category[cat]["enabled"] = true;


### PR DESCRIPTION
'Overview' + 'Data Graph': Save configuration for automatic page refresh function persistently.
This automatic page refresh function was initially introduced with PR #62.

  - Default refreshing behaviour can now be configured on 'Configuration' page
  - Add a new section 'WebUI' and four new parameter on 'Configuration' page:
     ![image](https://github.com/Slider0007/AI-on-the-edge-device/assets/115730895/1399e586-e2f8-49f5-bf02-a2d232e243f9)
  - The parameter are saved to config.ini
  - The functionality is only handled in WebUI
  - Temporary adjustments can still be done on the respective page:
    - 'Overview' page
    ![image](https://github.com/Slider0007/AI-on-the-edge-device/assets/115730895/15ade9b7-ea13-4e7c-b10d-6a8bd9244b87)
     - 'Data Graph' page
    ![image](https://github.com/Slider0007/AI-on-the-edge-device/assets/115730895/123866ef-5fb9-4fc1-a9cc-55b6cc85d3fd)

