### PR TITLE
fix(gpio): Fix init issue & wrong mode comparison

### DIFF
--- a/code/components/jomjol_controlGPIO/server_GPIO.cpp
+++ b/code/components/jomjol_controlGPIO/server_GPIO.cpp
@@ -105,7 +105,7 @@ void GpioPin::init()
     gpio_config(&io_conf);
 
 //    if (_interruptType != GPIO_INTR_DISABLE) {                // ohne GPIO_PIN_MODE_EXTERNAL_FLASH_WS281X, wenn das genutzt wird, dann soll auch der Handler hier nicht initialisiert werden, da das dann über SmartLED erfolgt.
-    if ((_interruptType != GPIO_INTR_DISABLE) && (_interruptType != GPIO_PIN_MODE_EXTERNAL_FLASH_WS281X)) {
+    if ((_interruptType != GPIO_INTR_DISABLE) && (_mode != GPIO_PIN_MODE_EXTERNAL_FLASH_WS281X)) {
         //hook isr handler for specific gpio pin
         ESP_LOGD(TAG, "GpioPin::init add isr handler for GPIO %d", _gpio);
         gpio_isr_handler_add(_gpio, gpio_isr_handler, (void*)&_gpio);

--- a/code/components/jomjol_flowcontroll/ClassFlowControll.cpp
+++ b/code/components/jomjol_flowcontroll/ClassFlowControll.cpp
@@ -499,7 +499,7 @@ void ClassFlowControll::DeinitFlow(void)
     StatusLEDOff();
     //LogFile.WriteHeapInfo("After camera");
 
-    gpio_handler_destroy();
+    gpio_handler_deinit();
     //LogFile.WriteHeapInfo("After GPIO");
     
     #ifdef ENABLE_MQTT


### PR DESCRIPTION
- GPIO init was aborted due to missing GPIO handler
-> Deinit GPIO only instead of destroying handler to keep handler for proper init
- Fix usage of wrong variable for comparison (compiler warning)