### PR TITLE
refactor(sdcard): Refactor SD card init

### DIFF
--- a/code/include/defines.h
+++ b/code/include/defines.h
@@ -304,26 +304,26 @@ CONFIG_WPA_11R_SUPPORT=n
 
 // Define BOARD and CAMERA configuration
 //************************************
-#define BOARD_AITHINKER_ESP32CAM
-#define CAMERA_MODEL_AI_THINKER
+#define BOARD_AITHINKER_ESP32CAM            // Define BOARD TYPE
+#define CAMERA_MODEL_AI_THINKER             // Define CAMERA MODEL
 
 
 // Define SD card configuration
-#define BOARD_SDCARD_SDMMC_BUS_WIDTH_1                  // SD MMC: Operate with 1 data line (D0) instead of 4 lines (D0-D3)
+#define BOARD_SDCARD_SDMMC_BUS_WIDTH_1      // SD MMC: Operate with 1 data line (D0) instead of 4 lines (D0-D3)
 
 
 // Board types
-//************************************ 
+//************************************
 #ifdef BOARD_AITHINKER_ESP32CAM
-    // SD card (operated with SDMMC peripheral - faster than SPI peripheral)
-    #define GPIO_SDCARD_CLK         GPIO_NUM_14
-    #define GPIO_SDCARD_CMD         GPIO_NUM_15
-    #define GPIO_SDCARD_D0          GPIO_NUM_2
+    // SD card (operated with SDMMC peripheral)
+    #define GPIO_SDCARD_CLK                 GPIO_NUM_14
+    #define GPIO_SDCARD_CMD                 GPIO_NUM_15
+    #define GPIO_SDCARD_D0                  GPIO_NUM_2
     #ifndef BOARD_SDCARD_SDMMC_BUS_WIDTH_1
-        #define GPIO_SDCARD_D1      GPIO_NUM_4
-        #define GPIO_SDCARD_D2      GPIO_NUM_12
+        #define GPIO_SDCARD_D1              GPIO_NUM_4
+        #define GPIO_SDCARD_D2              GPIO_NUM_12
     #endif
-    #define GPIO_SDCARD_D3          GPIO_NUM_13     // Needs to be high to init SD in MMC mode. After init GPIO can be used as spare GPIO
+    #define GPIO_SDCARD_D3                  GPIO_NUM_13     // Needs to be high to init SD in MMC mode. After init GPIO can be used as spare GPIO
 
     // Camera
     #define CAM_PIN_PWDN 32
@@ -432,4 +432,4 @@ CONFIG_WPA_11R_SUPPORT=n
     #define EXAMPLE_MAX_STA_CONN       1
 #endif // ENABLE_SOFTAP
 
-#endif // ifndef DEFINES_H
+#endif //DEFINES_H

--- a/code/include/defines.h
+++ b/code/include/defines.h
@@ -110,8 +110,6 @@
 
 
 //ClassControllCamera + ClassFlowTakeImage
-#define CAMERA_MODEL_AI_THINKER
-#define BOARD_ESP32CAM_AITHINKER
 #define DEMO_IMAGE_SIZE 30000 // Max size of demo image in bytes
 
 //server_GPIO
@@ -130,9 +128,6 @@
 //ClassFlowControll + Main + SoftAP
 #define WLAN_CONFIG_FILE "/sdcard/wlan.ini"
 
-
-//main
-#define __SD_USE_ONE_LINE_MODE__
 
 // server_file + Helper
     #define FILE_PATH_MAX (255) //Max length a file path can have on storage
@@ -303,9 +298,54 @@ CONFIG_WPA_11R_SUPPORT=n
 #define FLOWSTATE_ERRORS_IN_ROW_LIMIT   3
 
 
-//**************************************************************************************
-// HARDWARE DEFINITION
-//**************************************************************************************
+//*************************************************************************
+// HARDWARE RELATED DEFINITIONS
+//*************************************************************************
+
+// Define BOARD and CAMERA configuration
+//************************************
+#define BOARD_AITHINKER_ESP32CAM
+#define CAMERA_MODEL_AI_THINKER
+
+
+// Define SD card configuration
+#define BOARD_SDCARD_SDMMC_BUS_WIDTH_1                  // SD MMC: Operate with 1 data line (D0) instead of 4 lines (D0-D3)
+
+
+// Board types
+//************************************ 
+#ifdef BOARD_AITHINKER_ESP32CAM
+    // SD card (operated with SDMMC peripheral - faster than SPI peripheral)
+    #define GPIO_SDCARD_CLK         GPIO_NUM_14
+    #define GPIO_SDCARD_CMD         GPIO_NUM_15
+    #define GPIO_SDCARD_D0          GPIO_NUM_2
+    #ifndef BOARD_SDCARD_SDMMC_BUS_WIDTH_1
+        #define GPIO_SDCARD_D1      GPIO_NUM_4
+        #define GPIO_SDCARD_D2      GPIO_NUM_12
+    #endif
+    #define GPIO_SDCARD_D3          GPIO_NUM_13     // Needs to be high to init SD in MMC mode. After init GPIO can be used as spare GPIO
+
+    // Camera
+    #define CAM_PIN_PWDN 32
+    #define CAM_PIN_RESET -1 //software reset will be performed
+    #define CAM_PIN_XCLK 0
+    #define CAM_PIN_SIOD 26
+    #define CAM_PIN_SIOC 27
+
+    #define CAM_PIN_D7 35
+    #define CAM_PIN_D6 34
+    #define CAM_PIN_D5 39
+    #define CAM_PIN_D4 36
+    #define CAM_PIN_D3 21
+    #define CAM_PIN_D2 19
+    #define CAM_PIN_D1 18
+    #define CAM_PIN_D0 5
+    #define CAM_PIN_VSYNC 25
+    #define CAM_PIN_HREF 23
+    #define CAM_PIN_PCLK 22
+#endif //// Board types
+
+
 //******* camera model 
 #if defined(CAMERA_MODEL_WROVER_KIT)
     #define PWDN_GPIO_NUM    -1
@@ -368,51 +408,6 @@ CONFIG_WPA_11R_SUPPORT=n
     #error "Camera model not selected"
 #endif  //camera model
 
-// ******* Board type   
-#ifdef BOARD_WROVER_KIT // WROVER-KIT PIN Map
-
-    #define CAM_PIN_PWDN -1  //power down is not used
-    #define CAM_PIN_RESET -1 //software reset will be performed
-    #define CAM_PIN_XCLK 21
-    #define CAM_PIN_SIOD 26
-    #define CAM_PIN_SIOC 27
-
-    #define CAM_PIN_D7 35
-    #define CAM_PIN_D6 34
-    #define CAM_PIN_D5 39
-    #define CAM_PIN_D4 36
-    #define CAM_PIN_D3 19
-    #define CAM_PIN_D2 18
-    #define CAM_PIN_D1 5
-    #define CAM_PIN_D0 4
-    #define CAM_PIN_VSYNC 25
-    #define CAM_PIN_HREF 23
-    #define CAM_PIN_PCLK 22
-
-#endif //// WROVER-KIT PIN Map
-
-    
-#ifdef BOARD_ESP32CAM_AITHINKER // ESP32Cam (AiThinker) PIN Map
-
-    #define CAM_PIN_PWDN 32
-    #define CAM_PIN_RESET -1 //software reset will be performed
-    #define CAM_PIN_XCLK 0
-    #define CAM_PIN_SIOD 26
-    #define CAM_PIN_SIOC 27
-
-    #define CAM_PIN_D7 35
-    #define CAM_PIN_D6 34
-    #define CAM_PIN_D5 39
-    #define CAM_PIN_D4 36
-    #define CAM_PIN_D3 21
-    #define CAM_PIN_D2 19
-    #define CAM_PIN_D1 18
-    #define CAM_PIN_D0 5
-    #define CAM_PIN_VSYNC 25
-    #define CAM_PIN_HREF 23
-    #define CAM_PIN_PCLK 22
-
-#endif // ESP32Cam (AiThinker) PIN Map
 
 // ******* LED definition
 #ifdef USE_PWM_LEDFLASH

--- a/code/main/main.cpp
+++ b/code/main/main.cpp
@@ -384,17 +384,18 @@ esp_err_t initSDCard()
     sdmmc_slot_config_t slot_config = SDMMC_SLOT_CONFIG_DEFAULT();
 
     #ifdef SOC_SDMMC_USE_GPIO_MATRIX
-    slot_config.clk = GPIO_SDCARD_CLK;
-    slot_config.cmd = GPIO_SDCARD_CMD;
-    slot_config.d0 = GPIO_SDCARD_D0;
+        slot_config.clk = GPIO_SDCARD_CLK;
+        slot_config.cmd = GPIO_SDCARD_CMD;
+        slot_config.d0 = GPIO_SDCARD_D0;
     #endif
+
     #ifdef BOARD_SDCARD_SDMMC_BUS_WIDTH_1
         slot_config.width = 1;
     #else
         #ifdef SOC_SDMMC_USE_GPIO_MATRIX
-        slot_config.d1 = GPIO_SDCARD_D1;
-        slot_config.d2 = GPIO_SDCARD_D2;
-        slot_config.d3 = GPIO_SDCARD_D3;
+            slot_config.d1 = GPIO_SDCARD_D1;
+            slot_config.d2 = GPIO_SDCARD_D2;
+            slot_config.d3 = GPIO_SDCARD_D3;
         #endif
         slot_config.width = 4;
     #endif

--- a/code/main/main.cpp
+++ b/code/main/main.cpp
@@ -66,76 +66,9 @@ extern std::string getFwVersion(void);
 extern std::string getHTMLversion(void);
 extern std::string getHTMLcommit(void);
 
-void migrateConfiguration(void);
-
-
-bool Init_NVS_SDCard()
-{
-    esp_err_t ret = nvs_flash_init();
-    if (ret == ESP_ERR_NVS_NO_FREE_PAGES) {
-        ESP_ERROR_CHECK(nvs_flash_erase());
-        ret = nvs_flash_init();
-    }
-
-    ESP_LOGD(TAG, "Using SDMMC peripheral");
-    sdmmc_host_t host = SDMMC_HOST_DEFAULT();
-
-    // This initializes the slot without card detect (CD) and write protect (WP) signals.
-    // Modify slot_config.gpio_cd and slot_config.gpio_wp if your board has these signals.
-    sdmmc_slot_config_t slot_config = SDMMC_SLOT_CONFIG_DEFAULT();
-
-    // To use 1-line SD mode, uncomment the following line:
-    #ifdef __SD_USE_ONE_LINE_MODE__
-        slot_config.width = 1;
-    #endif
-
-    // GPIOs 15, 2, 4, 12, 13 should have external 10k pull-ups.
-    // Internal pull-ups are not sufficient. However, enabling internal pull-ups
-    // does make a difference some boards, so we do that here.
-    gpio_set_pull_mode(GPIO_NUM_15, GPIO_PULLUP_ONLY);   // CMD, needed in 4- and 1- line modes
-    gpio_set_pull_mode(GPIO_NUM_2, GPIO_PULLUP_ONLY);    // D0, needed in 4- and 1-line modes
-    #ifndef __SD_USE_ONE_LINE_MODE__
-        gpio_set_pull_mode(GPIO_NUM_4, GPIO_PULLUP_ONLY);    // D1, needed in 4-line mode only
-        gpio_set_pull_mode(GPIO_NUM_12, GPIO_PULLUP_ONLY);   // D2, needed in 4-line mode only
-    #endif
-    gpio_set_pull_mode(GPIO_NUM_13, GPIO_PULLUP_ONLY);   // D3, needed in 4- and 1-line modes
-
-    // Options for mounting the filesystem.
-    // If format_if_mount_failed is set to true, SD card will be partitioned and
-    // formatted in case when mounting fails.
-    esp_vfs_fat_sdmmc_mount_config_t mount_config = {
-        .format_if_mount_failed = false,
-        .max_files = 12,                         // previously -> 2022-09-21: 5, 2023-01-02: 7 
-        .allocation_unit_size = 16 * 1024
-    };
-
-    sdmmc_card_t* card;
-    // Use settings defined above to initialize SD card and mount FAT filesystem.
-    // Note: esp_vfs_fat_sdmmc_mount is an all-in-one convenience function.
-    // Please check its source code and implement error recovery when developing
-    // production applications.
-    ret = esp_vfs_fat_sdmmc_mount("/sdcard", &host, &slot_config, &mount_config, &card);
-
-    if (ret != ESP_OK) {
-        if (ret == ESP_FAIL) {
-            ESP_LOGE(TAG, "Failed to mount FAT filesystem on SD card. Check SD card filesystem (only FAT supported) or try another card");
-            StatusLED(SDCARD_INIT, 1, true);
-        } 
-        else if (ret == 263) { // Error code: 0x107 --> usually: SD not found
-            ESP_LOGE(TAG, "SD card init failed. Check if SD card is properly inserted into SD card slot or try another card");
-            StatusLED(SDCARD_INIT, 2, true);
-        }
-        else {
-            ESP_LOGE(TAG, "SD card init failed. Check error code or try another card");
-            StatusLED(SDCARD_INIT, 3, true);
-        }
-        return false;
-    }
-
-    //sdmmc_card_print_info(stdout, card);  // With activated CONFIG_NEWLIB_NANO_FORMAT --> capacity not printed correctly anymore
-    SaveSDCardInfo(card);
-    return true;
-}
+esp_err_t initNVSFlash();
+esp_err_t initSDCard();
+void migrateConfiguration();
 
 
 extern "C" void app_main(void)
@@ -159,14 +92,20 @@ extern "C" void app_main(void)
     // ********************************************
     // Highlight start of app_main 
     // ********************************************
-    ESP_LOGI(TAG, "================ Start app_main =================\n\n");
+    ESP_LOGI(TAG, "================ Start app_main =================");
     
+    // Init NVS flash
+    // ********************************************
+    if (ESP_OK != initNVSFlash()) {
+        ESP_LOGE(TAG, "Device init aborted");
+        return; // Stop here, NVS is needed for proper operation
+    }
+
     // Init SD card
     // ********************************************
-    if (!Init_NVS_SDCard())
-    {
+    if (ESP_OK != initSDCard()) {
         ESP_LOGE(TAG, "Device init aborted");
-        return; // No way to continue without working SD card!
+        return; // Stop here, SD card is needed for proper operation
     }
 
     // SD card: Create log directories (if not already existing)
@@ -414,6 +353,93 @@ extern "C" void app_main(void)
     else { 
         LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "Basic device initialization failed");
     }
+}
+
+
+esp_err_t initNVSFlash()
+{
+    ESP_LOGI(TAG, "Initializing NVS flash");
+    esp_err_t ret = nvs_flash_init();
+    if (ret == ESP_ERR_NVS_NO_FREE_PAGES) {
+        ESP_ERROR_CHECK(nvs_flash_erase());
+        ret = nvs_flash_init();
+    }
+    return ret;
+}
+
+
+esp_err_t initSDCard()
+{
+    esp_err_t ret = ESP_OK;
+
+    ESP_LOGI(TAG,"Initializing SD card: Using SDMMC peripheral");
+    sdmmc_host_t host = SDMMC_HOST_DEFAULT();
+
+    // Pullup SD card D3 pin to ensure SD init using MMC mode
+    // Additionally, an external pullup is needed
+    gpio_set_pull_mode(GPIO_SDCARD_D3, GPIO_PULLUP_ONLY);
+
+    // This initializes the slot without card detect (CD) and write protect (WP) signals.
+    // Modify slot_config.gpio_cd and slot_config.gpio_wp if your board has these signals.
+    sdmmc_slot_config_t slot_config = SDMMC_SLOT_CONFIG_DEFAULT();
+
+    #ifdef SOC_SDMMC_USE_GPIO_MATRIX
+    slot_config.clk = GPIO_SDCARD_CLK;
+    slot_config.cmd = GPIO_SDCARD_CMD;
+    slot_config.d0 = GPIO_SDCARD_D0;
+    #endif
+    #ifdef BOARD_SDCARD_SDMMC_BUS_WIDTH_1
+        slot_config.width = 1;
+    #else
+        #ifdef SOC_SDMMC_USE_GPIO_MATRIX
+        slot_config.d1 = GPIO_SDCARD_D1;
+        slot_config.d2 = GPIO_SDCARD_D2;
+        slot_config.d3 = GPIO_SDCARD_D3;
+        #endif
+        slot_config.width = 4;
+    #endif
+
+    // Enable internal pullups on enabled pins. The internal pullups
+    // are insufficient however, please make sure 10k external pullups are
+    // connected on the bus. This is for debug / example purpose only.
+    slot_config.flags |= SDMMC_SLOT_FLAG_INTERNAL_PULLUP;
+
+    // Options for mounting the filesystem.
+    // If format_if_mount_failed is set to true, SD card will be partitioned and
+    // formatted in case when mounting fails.
+    esp_vfs_fat_sdmmc_mount_config_t mount_config = {
+        .format_if_mount_failed = false,
+        .max_files = 12,                         // previously -> 2022-09-21: 5, 2023-01-02: 7 
+        .allocation_unit_size = 16 * 1024,
+        .disk_status_check_enable = 0
+    };
+
+    sdmmc_card_t* card;
+
+    // Use settings defined above to initialize SD card and mount FAT filesystem.
+    // Note: esp_vfs_fat_sdmmc_mount is an all-in-one convenience function.
+    // Please check its source code and implement error recovery when developing
+    // production applications.
+    ret = esp_vfs_fat_sdmmc_mount("/sdcard", &host, &slot_config, &mount_config, &card);
+
+    if (ret != ESP_OK) {
+        if (ret == ESP_FAIL) {
+            ESP_LOGE(TAG, "Failed to mount FAT filesystem on SD card. Check SD card filesystem (only FAT supported) or try another card");
+            StatusLED(SDCARD_INIT, 1, true);
+        } 
+        else if (ret == 263) { // Error code: 0x107 --> usually: SD not found
+            ESP_LOGE(TAG, "SD card init failed. Check if SD card is properly inserted into SD card slot or try another card");
+            StatusLED(SDCARD_INIT, 2, true);
+        }
+        else {
+            ESP_LOGE(TAG, "SD card init failed. Check error code or try another card");
+            StatusLED(SDCARD_INIT, 3, true);
+        }
+        return ret;
+    }
+
+    SaveSDCardInfo(card);
+    return ret;
 }
 
 

--- a/code/test/test_suite_flowcontroll.cpp
+++ b/code/test/test_suite_flowcontroll.cpp
@@ -124,17 +124,18 @@ esp_err_t initSDCard()
     sdmmc_slot_config_t slot_config = SDMMC_SLOT_CONFIG_DEFAULT();
 
     #ifdef SOC_SDMMC_USE_GPIO_MATRIX
-    slot_config.clk = GPIO_SDCARD_CLK;
-    slot_config.cmd = GPIO_SDCARD_CMD;
-    slot_config.d0 = GPIO_SDCARD_D0;
+        slot_config.clk = GPIO_SDCARD_CLK;
+        slot_config.cmd = GPIO_SDCARD_CMD;
+        slot_config.d0 = GPIO_SDCARD_D0;
     #endif
+
     #ifdef BOARD_SDCARD_SDMMC_BUS_WIDTH_1
         slot_config.width = 1;
     #else
         #ifdef SOC_SDMMC_USE_GPIO_MATRIX
-        slot_config.d1 = GPIO_SDCARD_D1;
-        slot_config.d2 = GPIO_SDCARD_D2;
-        slot_config.d3 = GPIO_SDCARD_D3;
+            slot_config.d1 = GPIO_SDCARD_D1;
+            slot_config.d2 = GPIO_SDCARD_D2;
+            slot_config.d3 = GPIO_SDCARD_D3;
         #endif
         slot_config.width = 4;
     #endif

--- a/code/test/test_suite_flowcontroll.cpp
+++ b/code/test/test_suite_flowcontroll.cpp
@@ -11,13 +11,10 @@
 #endif
 #include <cmath>
 
-#include "nvs_flash.h"
 #include "esp_vfs_fat.h"
 #include "driver/sdmmc_host.h"
-#include "driver/gpio.h"
 
 #include "server_ota.h"
-
 
 //*****************************************************************************
 // Include files with functions to test
@@ -30,68 +27,7 @@
 #include "components/jomjol-flowcontroll/test_getReadoutRawString.cpp"
 
 
-bool Init_NVS_SDCard()
-{
-    esp_err_t ret = nvs_flash_init();
-    if (ret == ESP_ERR_NVS_NO_FREE_PAGES) {
-        ESP_ERROR_CHECK(nvs_flash_erase());
-        ret = nvs_flash_init();
-    }
-////////////////////////////////////////////////
-
-    ESP_LOGI(TAG, "Using SDMMC peripheral");
-    sdmmc_host_t host = SDMMC_HOST_DEFAULT();
-
-    // This initializes the slot without card detect (CD) and write protect (WP) signals.
-    // Modify slot_config.gpio_cd and slot_config.gpio_wp if your board has these signals.
-    sdmmc_slot_config_t slot_config = SDMMC_SLOT_CONFIG_DEFAULT();
-
-    // To use 1-line SD mode, uncomment the following line:
-
-    #ifdef __SD_USE_ONE_LINE_MODE__
-        slot_config.width = 1;
-    #endif
-
-    // GPIOs 15, 2, 4, 12, 13 should have external 10k pull-ups.
-    // Internal pull-ups are not sufficient. However, enabling internal pull-ups
-    // does make a difference some boards, so we do that here.
-    gpio_set_pull_mode(GPIO_NUM_15, GPIO_PULLUP_ONLY);   // CMD, needed in 4- and 1- line modes
-    gpio_set_pull_mode(GPIO_NUM_2, GPIO_PULLUP_ONLY);    // D0, needed in 4- and 1-line modes
-    #ifndef __SD_USE_ONE_LINE_MODE__
-        gpio_set_pull_mode(GPIO_NUM_4, GPIO_PULLUP_ONLY);    // D1, needed in 4-line mode only
-        gpio_set_pull_mode(GPIO_NUM_12, GPIO_PULLUP_ONLY);   // D2, needed in 4-line mode only
-    #endif
-    gpio_set_pull_mode(GPIO_NUM_13, GPIO_PULLUP_ONLY);   // D3, needed in 4- and 1-line modes
-
-    // Options for mounting the filesystem.
-    // If format_if_mount_failed is set to true, SD card will be partitioned and
-    // formatted in case when mounting fails.
-    esp_vfs_fat_sdmmc_mount_config_t mount_config = {
-        .format_if_mount_failed = false,
-        .max_files = 12,                         // anstatt 5 (2022-09-21)
-        .allocation_unit_size = 16 * 1024
-    };
-
-    // Use settings defined above to initialize SD card and mount FAT filesystem.
-    // Note: esp_vfs_fat_sdmmc_mount is an all-in-one convenience function.
-    // Please check its source code and implement error recovery when developing
-    // production applications.
-    sdmmc_card_t* card;
-    ret = esp_vfs_fat_sdmmc_mount("/sdcard", &host, &slot_config, &mount_config, &card);
-
-    if (ret != ESP_OK) {
-        if (ret == ESP_FAIL) {
-            ESP_LOGE(TAG, "Failed to mount filesystem. "
-                "If you want the card to be formatted, set format_if_mount_failed = true.");
-        } else {
-            ESP_LOGE(TAG, "Failed to initialize the card (%s). "
-                "Make sure SD card lines have pull-up resistors in place.", esp_err_to_name(ret));
-        }
-        return false;
-    }
-
-    return true;
-}
+esp_err_t initSDCard();
 
 
 /**
@@ -144,16 +80,12 @@ void task_UnityTesting(void *pvParameter)
  */
 extern "C" void app_main()
 {
-    // Init NVS & SD card
+    // Init SD card
     // ********************************************
-    Init_NVS_SDCard();
-
-
-    // Set log level to DEBUG
-    // Be aware: Output is limited to max defined log level in sdkconfig
-    // ********************************************
-    esp_log_level_set("*", ESP_LOG_DEBUG); // set all components to DEBUG level
-
+    if (ESP_OK != initSDCard()) {
+        ESP_LOGE(TAG, "Device init aborted");
+        return; // Stop here, SD card is needed for proper operation
+    }
 
     // Check for updates before start testing
     // It is possbile to update thr firmware also by placing 'firmware.bin' to '/sdcard/firmware' and
@@ -165,8 +97,83 @@ extern "C" void app_main()
     #endif
     CheckOTAUpdate();
 
+    // Set log level to DEBUG
+    // Be aware: Output is limited to max defined log level in sdkconfig
+    // ********************************************
+    esp_log_level_set("*", ESP_LOG_DEBUG); // set all components to DEBUG level
 
     // Create dedicated testing task (heap size can be configured - large enough to handle a lot of testing cases)
     // ********************************************
     xTaskCreate(&task_UnityTesting, "task_UnityTesting", 12 * 1024, NULL, tskIDLE_PRIORITY+2, NULL);
+}
+
+
+esp_err_t initSDCard()
+{
+    esp_err_t ret = ESP_OK;
+
+    ESP_LOGI(TAG,"Initializing SD card: Using SDMMC peripheral");
+    sdmmc_host_t host = SDMMC_HOST_DEFAULT();
+
+    // Pullup SD card D3 pin to ensure SD init using MMC mode
+    // Additionally, an external pullup is needed
+    gpio_set_pull_mode(GPIO_SDCARD_D3, GPIO_PULLUP_ONLY);
+
+    // This initializes the slot without card detect (CD) and write protect (WP) signals.
+    // Modify slot_config.gpio_cd and slot_config.gpio_wp if your board has these signals.
+    sdmmc_slot_config_t slot_config = SDMMC_SLOT_CONFIG_DEFAULT();
+
+    #ifdef SOC_SDMMC_USE_GPIO_MATRIX
+    slot_config.clk = GPIO_SDCARD_CLK;
+    slot_config.cmd = GPIO_SDCARD_CMD;
+    slot_config.d0 = GPIO_SDCARD_D0;
+    #endif
+    #ifdef BOARD_SDCARD_SDMMC_BUS_WIDTH_1
+        slot_config.width = 1;
+    #else
+        #ifdef SOC_SDMMC_USE_GPIO_MATRIX
+        slot_config.d1 = GPIO_SDCARD_D1;
+        slot_config.d2 = GPIO_SDCARD_D2;
+        slot_config.d3 = GPIO_SDCARD_D3;
+        #endif
+        slot_config.width = 4;
+    #endif
+
+    // Enable internal pullups on enabled pins. The internal pullups
+    // are insufficient however, please make sure 10k external pullups are
+    // connected on the bus. This is for debug / example purpose only.
+    slot_config.flags |= SDMMC_SLOT_FLAG_INTERNAL_PULLUP;
+
+    // Options for mounting the filesystem.
+    // If format_if_mount_failed is set to true, SD card will be partitioned and
+    // formatted in case when mounting fails.
+    esp_vfs_fat_sdmmc_mount_config_t mount_config = {
+        .format_if_mount_failed = false,
+        .max_files = 12,                         // previously -> 2022-09-21: 5, 2023-01-02: 7 
+        .allocation_unit_size = 16 * 1024,
+        .disk_status_check_enable = 0
+    };
+
+    sdmmc_card_t* card;
+
+    // Use settings defined above to initialize SD card and mount FAT filesystem.
+    // Note: esp_vfs_fat_sdmmc_mount is an all-in-one convenience function.
+    // Please check its source code and implement error recovery when developing
+    // production applications.
+    ret = esp_vfs_fat_sdmmc_mount("/sdcard", &host, &slot_config, &mount_config, &card);
+
+    if (ret != ESP_OK) {
+        if (ret == ESP_FAIL) {
+            ESP_LOGE(TAG, "Failed to mount FAT filesystem on SD card. Check SD card filesystem (only FAT supported) or try another card");
+        } 
+        else if (ret == 263) { // Error code: 0x107 --> usually: SD not found
+            ESP_LOGE(TAG, "SD card init failed. Check if SD card is properly inserted into SD card slot or try another card");
+        }
+        else {
+            ESP_LOGE(TAG, "SD card init failed. Check error code or try another card");
+        }
+        return ret;
+    }
+
+    return ret;
 }


### PR DESCRIPTION
- Split NVS init and SD card init into two separate functions
- Cleanup code and defines
- Remove defines of board 'BOARD_WROVER_KIT' because not fully implemented and not tested at all