### PR TITLE
chore(nvs): Add staus LED blink codes for NVS init errors

### DIFF
--- a/code/components/jomjol_helper/statusled.cpp
+++ b/code/components/jomjol_helper/statusled.cpp
@@ -78,8 +78,8 @@ void StatusLED(StatusLedSource _eSource, int _iCode, bool _bInfinite)
 		StatusLEDData.iBlinkTime = 250;
 		StatusLEDData.bInfinite = _bInfinite;
 	}
-	else if (_eSource == SDCARD_INIT) {
-		StatusLEDData.iSourceBlinkCnt = SDCARD_INIT;
+	else if (_eSource == SDCARD_NVS_INIT) {
+		StatusLEDData.iSourceBlinkCnt = SDCARD_NVS_INIT;
 		StatusLEDData.iCodeBlinkCnt = _iCode;
 		StatusLEDData.iBlinkTime = 250;
 		StatusLEDData.bInfinite = _bInfinite;

--- a/code/components/jomjol_helper/statusled.h
+++ b/code/components/jomjol_helper/statusled.h
@@ -10,7 +10,7 @@ extern TaskHandle_t xHandle_task_StatusLED;
 enum StatusLedSource {
 	WLAN_CONN = 1,
     WLAN_INIT = 2,
-    SDCARD_INIT = 3,
+    SDCARD_NVS_INIT = 3,
 	SDCARD_CHECK = 4,
     CAM_INIT = 5,
     PSRAM_INIT = 6,

--- a/code/main/main.cpp
+++ b/code/main/main.cpp
@@ -376,7 +376,7 @@ esp_err_t initNVSFlash()
             StatusLED(SDCARD_NVS_INIT, 5, true);
         }
         else {
-            ESP_LOGE(TAG, "NVS flash init failed. Error code: " + intToHexString(ret));
+            ESP_LOGE(TAG, "NVS flash init failed. Check error code");
             StatusLED(SDCARD_NVS_INIT, 6, true);
         }
     }

--- a/code/main/main.cpp
+++ b/code/main/main.cpp
@@ -359,11 +359,28 @@ extern "C" void app_main(void)
 esp_err_t initNVSFlash()
 {
     ESP_LOGI(TAG, "Initializing NVS flash");
+    
     esp_err_t ret = nvs_flash_init();
     if (ret == ESP_ERR_NVS_NO_FREE_PAGES) {
         ESP_ERROR_CHECK(nvs_flash_erase());
         ret = nvs_flash_init();
     }
+    
+    if (ret != ESP_OK) {
+        if (ret == ESP_ERR_NOT_FOUND) {
+            ESP_LOGE(TAG, "NVS flash init failed. No NVS partition found");
+            StatusLED(SDCARD_NVS_INIT, 4, true);
+        } 
+        else if (ret == ESP_ERR_NVS_NO_FREE_PAGES) {
+            ESP_LOGE(TAG, "NVS flash init failed. No free NVS pages found");
+            StatusLED(SDCARD_NVS_INIT, 5, true);
+        }
+        else {
+            ESP_LOGE(TAG, "NVS flash init failed. Error code: " + intToHexString(ret));
+            StatusLED(SDCARD_NVS_INIT, 6, true);
+        }
+    }
+
     return ret;
 }
 
@@ -426,15 +443,15 @@ esp_err_t initSDCard()
     if (ret != ESP_OK) {
         if (ret == ESP_FAIL) {
             ESP_LOGE(TAG, "Failed to mount FAT filesystem on SD card. Check SD card filesystem (only FAT supported) or try another card");
-            StatusLED(SDCARD_INIT, 1, true);
+            StatusLED(SDCARD_NVS_INIT, 1, true);
         } 
         else if (ret == 263) { // Error code: 0x107 --> usually: SD not found
             ESP_LOGE(TAG, "SD card init failed. Check if SD card is properly inserted into SD card slot or try another card");
-            StatusLED(SDCARD_INIT, 2, true);
+            StatusLED(SDCARD_NVS_INIT, 2, true);
         }
         else {
             ESP_LOGE(TAG, "SD card init failed. Check error code or try another card");
-            StatusLED(SDCARD_INIT, 3, true);
+            StatusLED(SDCARD_NVS_INIT, 3, true);
         }
         return ret;
     }

--- a/code/test/test_suite_flowcontroll.cpp
+++ b/code/test/test_suite_flowcontroll.cpp
@@ -11,6 +11,7 @@
 #endif
 #include <cmath>
 
+#include "nvs_flash.h"
 #include "esp_vfs_fat.h"
 #include "driver/sdmmc_host.h"
 
@@ -26,7 +27,7 @@
 #include "components/jomjol-flowcontroll/test_PointerEvalAnalogToDigitNew.cpp"
 #include "components/jomjol-flowcontroll/test_getReadoutRawString.cpp"
 
-
+esp_err_t initNVSFlash();
 esp_err_t initSDCard();
 
 
@@ -80,6 +81,13 @@ void task_UnityTesting(void *pvParameter)
  */
 extern "C" void app_main()
 {
+    // Init NVS flash
+    // ********************************************
+    if (ESP_OK != initNVSFlash()) {
+        ESP_LOGE(TAG, "Device init aborted");
+        return; // Stop here, NVS is needed for proper operation
+    }
+    
     // Init SD card
     // ********************************************
     if (ESP_OK != initSDCard()) {
@@ -105,6 +113,32 @@ extern "C" void app_main()
     // Create dedicated testing task (heap size can be configured - large enough to handle a lot of testing cases)
     // ********************************************
     xTaskCreate(&task_UnityTesting, "task_UnityTesting", 12 * 1024, NULL, tskIDLE_PRIORITY+2, NULL);
+}
+
+
+esp_err_t initNVSFlash()
+{
+    ESP_LOGI(TAG, "Initializing NVS flash");
+
+    esp_err_t ret = nvs_flash_init();
+    if (ret == ESP_ERR_NVS_NO_FREE_PAGES) {
+        ESP_ERROR_CHECK(nvs_flash_erase());
+        ret = nvs_flash_init();
+    }
+    
+    if (ret != ESP_OK) {
+        if (ret == ESP_ERR_NOT_FOUND) {
+            ESP_LOGE(TAG, "NVS flash init failed. No NVS partition found");
+        } 
+        else if (ret == ESP_ERR_NVS_NO_FREE_PAGES) {
+            ESP_LOGE(TAG, "NVS flash init failed. No free NVS pages found");
+        }
+        else {
+            ESP_LOGE(TAG, "NVS flash init failed. Error code: " + intToHexString(ret));
+        }
+    }
+    
+    return ret;
 }
 
 

--- a/code/test/test_suite_flowcontroll.cpp
+++ b/code/test/test_suite_flowcontroll.cpp
@@ -134,7 +134,7 @@ esp_err_t initNVSFlash()
             ESP_LOGE(TAG, "NVS flash init failed. No free NVS pages found");
         }
         else {
-            ESP_LOGE(TAG, "NVS flash init failed. Error code: " + intToHexString(ret));
+            ESP_LOGE(TAG, "NVS flash init failed. Check error code");
         }
     }
     

--- a/docs/Troubleshooting/StatusLED_BlinkCodes.md
+++ b/docs/Troubleshooting/StatusLED_BlinkCodes.md
@@ -14,8 +14,8 @@ The error code source definition can be found [here](https://github.com/Slider00
 
 # Overview
 
-| **source**    | source<br>blink count| error / warning / status         | status<br>blink count| repeat<br>infinite |
-| ------------- | ----------------- |---------------------------------------| ---------------- | -----------------|
+| **source**    | source<br>blink count| error / warning / status           | status<br>blink count| repeat<br>infinite |
+| ------------- | ----------------- |---------------------------------------| ---------------- | -----------------------|
 | WLAN_CONN     | 1                 | Disconnected (No Access Point)        | 1                |
 | WLAN_CONN     | 1                 | Disconnected (Authentication failure) | 2                |
 | WLAN_CONN     | 1                 | Disconnected (Timeout)                | 3                |
@@ -23,9 +23,12 @@ The error code source definition can be found [here](https://github.com/Slider00
 | WLAN_INIT     | 2                 | WLAN.ini empty or not readable        | 1                | X
 | WLAN_INIT     | 2                 | SSID or password empty                | 2                | X
 | WLAN_INIT     | 2                 | WIFI init error (details console)     | 3                | X
-| SDCARD_INIT   | 3                 | SD card filesystem mount failed       | 1                | X
-| SDCARD_INIT   | 3                 | SD card not found (0x107)             | 2                | X
-| SDCARD_INIT   | 3                 | SD card init failed (details console) | 3                | X
+| SDCARD_NVS_INIT | 3               | SD card filesystem mount failed       | 1                | X
+| SDCARD_NVS_INIT | 3               | SD card not found (0x107)             | 2                | X
+| SDCARD_NVS_INIT | 3               | SD card init failed (details console) | 3                | X
+| SDCARD_NVS_INIT | 3               | NVS init failed: No partition found   | 4                | X
+| SDCARD_NVS_INIT | 3               | NVS init failed: No free pages found  | 5                | X
+| SDCARD_NVS_INIT | 3               | NVS init failed (details console)     | 6                | X
 | SDCARD_CHECK  | 4                 | Basic check: file creation/write error| 1                | X
 | SDCARD_CHECK  | 4                 | Basic check: file read/CRC error      | 2                | X
 | SDCARD_CHECK  | 4                 | Basic check: file delete error        | 3                | X
@@ -92,6 +95,16 @@ SD card init failed. Check if SD card is properly inserted into SD card slot or 
 
 ### `SD card init failed (details console)`
 A general SD card initialization error occured. Please check serial console output.
+
+### `NVS init failed: No partition found`
+A general NVS initialization error occured. No parition for NVS found in partition table. Check parition table configuration `partitions.csv`
+
+### `NVS init failed: No free pages found`
+A general NVS initialization error occured. No free NVS pages found. Check NVS parition size.
+
+### `NVS init failed (details console)`
+A general NVS initialization error occured. Please check serial console output.
+
 
 
 ## Source SDCARD_CHECK: SD card basic check


### PR DESCRIPTION
- Add status LED blink codes for NVS init errors
- Add missing NVS init for test environment (unity tests) (bug introduced with #125)