### PR TITLE
fix(mqtt): Fix process init failed if MQTT not yet connected

### DIFF
--- a/code/components/jomjol_flowcontroll/ClassFlowMQTT.cpp
+++ b/code/components/jomjol_flowcontroll/ClassFlowMQTT.cpp
@@ -225,11 +225,10 @@ bool ClassFlowMQTT::Start(float _processingInterval)
                                             LWT_DISCONNECTED, TLSEncryption, TLSCACertFilename, TLSClientCertFilename,
                                             TLSClientKeyFilename, keepAlive, SetRetainFlag, (void *)&GotConnected);
 
-    if (!MQTTConfigCheck) {
-        return false;
-    }
+    if (MQTTConfigCheck)
+        MQTT_Init();
 
-    return (MQTT_Init() == 1);
+    return MQTTConfigCheck;
 }
 
 


### PR DESCRIPTION
Process init was aborted if mqtt config is ok, but connection not yet established.
--> Only abort process initialization state if config is not OK but independ of actual connection state.