### PR TITLE
fix(process init): Load fallback value only with valid system time

### DIFF
--- a/code/components/jomjol_flowcontroll/ClassFlowPostProcessing.cpp
+++ b/code/components/jomjol_flowcontroll/ClassFlowPostProcessing.cpp
@@ -26,6 +26,7 @@ ClassFlowPostProcessing::ClassFlowPostProcessing(std::vector<ClassFlow*>* lfc, C
     presetFlowStateHandler(true);
 
     UseFallbackValue = true;
+    fallbackValueLoaded = false;
     UpdateFallbackValue = false;
     FallbackValueAgeStartup = 60;
     IgnoreLeadingNaN = false;

--- a/code/components/jomjol_flowcontroll/ClassFlowPostProcessing.cpp
+++ b/code/components/jomjol_flowcontroll/ClassFlowPostProcessing.cpp
@@ -305,8 +305,9 @@ bool ClassFlowPostProcessing::ReadParameter(FILE* pfile, std::string& aktparamgr
     /* Set decimal shift and number of decimal places in relation to extended resolution parameter */
     setDecimalShift();
 
-    if (UseFallbackValue) {
+    if (UseFallbackValue && getTimeIsSet()) {
         LoadFallbackValue();
+        fallbackValueLoaded = true;
     }
 
     return true;
@@ -591,6 +592,11 @@ bool ClassFlowPostProcessing::doFlow(std::string zwtime)
         #endif
 
         if (UseFallbackValue) {
+            /* Load FallbackValue if not yet loaded during init (due to missing valid system time)*/
+            if (!fallbackValueLoaded) {
+                LoadFallbackValue();
+                fallbackValueLoaded = true;
+            }
             /* Is fallbackValue valid (== not outdated) */
             if (NUMBERS[j]->isFallbackValueValid) {
                 /* Update fallbackValue */

--- a/code/components/jomjol_flowcontroll/ClassFlowPostProcessing.cpp
+++ b/code/components/jomjol_flowcontroll/ClassFlowPostProcessing.cpp
@@ -306,7 +306,9 @@ bool ClassFlowPostProcessing::ReadParameter(FILE* pfile, std::string& aktparamgr
     /* Set decimal shift and number of decimal places in relation to extended resolution parameter */
     setDecimalShift();
 
-    if (UseFallbackValue && getTimeIsSet()) {
+    // Load fallback value only if valid system time is set
+    // If not already loaded here, force loading before first usage in function doFlow
+    if (UseFallbackValue && (!getUseNtp() || getTimeIsSet())) {
         LoadFallbackValue();
         fallbackValueLoaded = true;
     }
@@ -593,7 +595,7 @@ bool ClassFlowPostProcessing::doFlow(std::string zwtime)
         #endif
 
         if (UseFallbackValue) {
-            /* Load FallbackValue if not yet loaded during init (due to missing valid system time)*/
+            /* Load fallback value if not yet loaded during init due to missing valid system time */
             if (!fallbackValueLoaded) {
                 LoadFallbackValue();
                 fallbackValueLoaded = true;

--- a/code/components/jomjol_flowcontroll/ClassFlowPostProcessing.h
+++ b/code/components/jomjol_flowcontroll/ClassFlowPostProcessing.h
@@ -14,6 +14,7 @@ class ClassFlowPostProcessing : public ClassFlow
     protected:
         std::vector<NumberPost*> NUMBERS;
         bool UseFallbackValue;
+        bool fallbackValueLoaded;
         bool UpdateFallbackValue;
         int FallbackValueAgeStartup; 
         bool IgnoreLeadingNaN;

--- a/code/components/jomjol_time_sntp/time_sntp.cpp
+++ b/code/components/jomjol_time_sntp/time_sntp.cpp
@@ -314,7 +314,7 @@ void setupTimeServer(std::string _timeServer)
             sntp_restart();
         }
 
-        if (!time_manual_reset_sync())
+        if (!waitingForTimeSync())
             LogFile.WriteToFile(ESP_LOG_WARN, TAG, "Time sync failed. Continue anyway");
     }
 }

--- a/code/components/jomjol_time_sntp/time_sntp.cpp
+++ b/code/components/jomjol_time_sntp/time_sntp.cpp
@@ -28,7 +28,6 @@ static bool useNtp = true;
 static bool timeWasNotSetAtBoot = false;
 static bool timeWasNotSetAtBoot_PrintStartBlock = false;
 
-std::string getNtpStatusText(sntp_sync_status_t status);
 static void setTimeZone(std::string _tzstring);
 static std::string getServerName(void);
 
@@ -53,7 +52,7 @@ std::string getCurrentTimeString(const char * frm)
 }
 
 
-void time_sync_notification_cb(struct timeval *tv)
+void timeSyncNotificationCallback(struct timeval *tv)
 {
     if (timeWasNotSetAtBoot_PrintStartBlock) {
         LogFile.WriteToFile(ESP_LOG_INFO, TAG, "=================================================");
@@ -71,8 +70,9 @@ bool waitingForTimeSync(void)
     int retry = 0;
     const int retry_count = 10;
 
-    while (sntp_get_sync_status() == SNTP_SYNC_STATUS_RESET && ++retry < retry_count) {
-        LogFile.WriteToFile(ESP_LOG_INFO, TAG, "Waiting for time sync - " + std::to_string(retry) + "/" + std::to_string(retry_count));
+    while (sntp_get_sync_status() == SNTP_SYNC_STATUS_RESET && ++retry <= retry_count) {
+        LogFile.WriteToFile(ESP_LOG_INFO, TAG, "Waiting for time sync - " + std::to_string(retry) + 
+                                               "/" + std::to_string(retry_count));
         vTaskDelay(2000 / portTICK_PERIOD_MS);
     }
 
@@ -89,20 +89,6 @@ void setTimeZone(std::string _tzstring)
     tzset();    
     _tzstring = "Time zone set to " + _tzstring;
     LogFile.WriteToFile(ESP_LOG_INFO, TAG, _tzstring);
-}
-
-
-std::string getNtpStatusText(sntp_sync_status_t status)
-{
-    if (status == SNTP_SYNC_STATUS_COMPLETED) {
-        return "Synchronized";
-    }
-    else if (status == SNTP_SYNC_STATUS_IN_PROGRESS) {
-        return "In Progress";
-    }
-    else { // SNTP_SYNC_STATUS_RESET
-        return "Reset";
-    }
 }
 
 
@@ -162,7 +148,7 @@ bool setupTime()
 {
     ConfigFile configFile = ConfigFile(CONFIG_FILE); 
 
-    if (!configFile.ConfigFileExists()){
+    if (!configFile.ConfigFileExists()) {
         LogFile.WriteToFile(ESP_LOG_WARN, TAG, "No config file, exit setupTime()");
         return false;
     }
@@ -195,7 +181,7 @@ bool setupTime()
         if (toUpper(splitted[0]) == "TIMEZONE") {
             if (splitted.size() <= 1) { // parameter part is empty, use default time zone
                 timeZone = "CET-1CEST,M3.5.0,M10.5.0/3";
-                LogFile.WriteToFile(ESP_LOG_INFO, TAG, "Time zone not set, use default: " + timeZone);
+                LogFile.WriteToFile(ESP_LOG_INFO, TAG, "No time zone set, use default: " + timeZone);
             }
             else {
                 timeZone = splitted[1];
@@ -206,7 +192,7 @@ bool setupTime()
         if (toUpper(splitted[0]) == "TIMESERVER") {
             if (splitted.size() <= 1) { // parameter part is empty, use default time server
                 timeServer = "pool.ntp.org";
-                LogFile.WriteToFile(ESP_LOG_WARN, TAG, "Time server not set, use default: " + timeServer);
+                LogFile.WriteToFile(ESP_LOG_WARN, TAG, "No time server set, use default: " + timeServer);
             }
             else {
                 timeServer = splitted[1];
@@ -218,7 +204,7 @@ bool setupTime()
 
     // Time server disabled
     if (timeServer == "") {
-        LogFile.WriteToFile(ESP_LOG_INFO, TAG, "Time server deactivated, disable NTP client");
+        LogFile.WriteToFile(ESP_LOG_INFO, TAG, "NTP service disabled");
         useNtp = false;
     }
 
@@ -226,10 +212,10 @@ bool setupTime()
     setTimeZone(timeZone);
     
     if (useNtp) {
-        LogFile.WriteToFile(ESP_LOG_INFO, TAG, "Start NTP client");        
+        LogFile.WriteToFile(ESP_LOG_INFO, TAG, "Init NTP service");        
         sntp_setoperatingmode(SNTP_OPMODE_POLL);
         sntp_setservername(0, timeServer.c_str());
-        sntp_set_time_sync_notification_cb(time_sync_notification_cb);
+        sntp_set_time_sync_notification_cb(timeSyncNotificationCallback);
         sntp_init();
 
         // Wait for time sync to ensure start with proper time
@@ -246,7 +232,7 @@ bool setupTime()
         timeWasNotSetAtBoot_PrintStartBlock = true;
         
         if (useNtp)
-            LogFile.WriteToFile(ESP_LOG_INFO, TAG, "Time not yet synced");
+            LogFile.WriteToFile(ESP_LOG_INFO, TAG, "Time not yet synchronized");
     }
 
     LogFile.WriteToFile(ESP_LOG_INFO, TAG, "Current time: " + sTimeString);
@@ -263,13 +249,13 @@ void setupTimeZone(std::string _timeZone)
     if (timeZone.compare(_timeZone) == 0)
         return;
 
-    LogFile.WriteToFile(ESP_LOG_WARN, TAG, "Time zone gets adjusted");
+    LogFile.WriteToFile(ESP_LOG_WARN, TAG, "Time zone has been modified");
     
     timeZone = _timeZone;
 
     if (_timeZone == "") {
         _timeZone = "CET-1CEST,M3.5.0,M10.5.0/3";
-        LogFile.WriteToFile(ESP_LOG_INFO, TAG, "Time zone not set, using default: " + _timeZone);
+        LogFile.WriteToFile(ESP_LOG_INFO, TAG, "No time zone set, using default: " + _timeZone);
     }
 
     setTimeZone(_timeZone);
@@ -284,10 +270,10 @@ void setupTimeServer(std::string _timeServer)
     if (timeServer.compare(_timeServer) == 0)
         return;
 
-    LogFile.WriteToFile(ESP_LOG_WARN, TAG, "Time server gets adjusted");
+    LogFile.WriteToFile(ESP_LOG_WARN, TAG, "Time server has been modified");
 
     if (_timeServer == "") {
-        LogFile.WriteToFile(ESP_LOG_INFO, TAG, "Time server deactivated, disabling NTP");
+        LogFile.WriteToFile(ESP_LOG_INFO, TAG, "NTP service disabled");
         useNtp = false;
         sntp_stop();
     }
@@ -301,8 +287,9 @@ void setupTimeServer(std::string _timeServer)
     if (useNtp) {    
         sntp_setoperatingmode(SNTP_OPMODE_POLL);
         sntp_setservername(0, timeServer.c_str());
-        sntp_set_time_sync_notification_cb(time_sync_notification_cb);
+        sntp_set_time_sync_notification_cb(timeSyncNotificationCallback);
 
+        LogFile.WriteToFile(ESP_LOG_INFO, TAG, "Init NTP service");
         if (!sntp_enabled()) {
             setTimeZone(timeZone);
             sntp_init();
@@ -311,7 +298,9 @@ void setupTimeServer(std::string _timeServer)
             sntp_restart();
         }
 
-        if (!waitingForTimeSync())
-            LogFile.WriteToFile(ESP_LOG_WARN, TAG, "Time sync failed. Continue anyway");
+        waitingForTimeSync();
+
+        if (!getTimeIsSet())      
+            LogFile.WriteToFile(ESP_LOG_INFO, TAG, "Time not yet synchronized");
     }
 }

--- a/code/components/jomjol_time_sntp/time_sntp.cpp
+++ b/code/components/jomjol_time_sntp/time_sntp.cpp
@@ -232,7 +232,7 @@ bool setupTime()
         timeWasNotSetAtBoot_PrintStartBlock = true;
         
         if (useNtp)
-            LogFile.WriteToFile(ESP_LOG_INFO, TAG, "Time not yet synchronized");
+            LogFile.WriteToFile(ESP_LOG_WARN, TAG, "Time not yet synchronized");
     }
 
     LogFile.WriteToFile(ESP_LOG_INFO, TAG, "Current time: " + sTimeString);
@@ -301,6 +301,6 @@ void setupTimeServer(std::string _timeServer)
         waitingForTimeSync();
 
         if (!getTimeIsSet())      
-            LogFile.WriteToFile(ESP_LOG_INFO, TAG, "Time not yet synchronized");
+            LogFile.WriteToFile(ESP_LOG_WARN, TAG, "Time not yet synchronized");
     }
 }

--- a/code/components/jomjol_time_sntp/time_sntp.cpp
+++ b/code/components/jomjol_time_sntp/time_sntp.cpp
@@ -222,7 +222,7 @@ bool setupTime()
         useNtp = false;
     }
 
-    // Set timezone in any case, even no time source is selected.
+    // Set time zone in any case, even no time source is selected.
     setTimeZone(timeZone);
     
     if (useNtp) {
@@ -241,25 +241,22 @@ bool setupTime()
     time(&now);
     std::string sTimeString = ConvertTimeToString(now, "%Y-%m-%d %H:%M:%S");
 
-    if (getTimeIsSet()) {
-        LogFile.WriteToFile(ESP_LOG_INFO, TAG, "Time is set. Current time: " + sTimeString);
-    }
-    else {
+    if (!getTimeIsSet()) {
         timeWasNotSetAtBoot = true;
         timeWasNotSetAtBoot_PrintStartBlock = true;
         
         if (useNtp)
-            LogFile.WriteToFile(ESP_LOG_INFO, TAG, "Time not yet synced. Current time: " + sTimeString);
-        else
-            LogFile.WriteToFile(ESP_LOG_INFO, TAG, "Current time: " + sTimeString);
+            LogFile.WriteToFile(ESP_LOG_INFO, TAG, "Time not yet synced");
     }
+
+    LogFile.WriteToFile(ESP_LOG_INFO, TAG, "Current time: " + sTimeString);
 
     return true;
 }
 
 
 /**
- * Update TimeZone
+ * Update Time zone
  */
 void setupTimeZone(std::string _timeZone)
 {

--- a/code/components/jomjol_time_sntp/time_sntp.cpp
+++ b/code/components/jomjol_time_sntp/time_sntp.cpp
@@ -154,7 +154,7 @@ std::string getServerName(void)
 
 
 /**
- * Load the TimeZone and TimeServer from the config file and initialize the NTP client
+ * Load the Time zone and Time server from the config file and initialize the NTP client
  * The RTC keeps the time after a restart (Except on Power On or Pin Reset) 
  * There should only be a minor correction through NTP
  */
@@ -216,7 +216,7 @@ bool setupTime()
         }
     }
 
-    // Timeserver disabled
+    // Time server disabled
     if (timeServer == "") {
         LogFile.WriteToFile(ESP_LOG_INFO, TAG, "Time server deactivated, disable NTP client");
         useNtp = false;
@@ -242,16 +242,16 @@ bool setupTime()
     std::string sTimeString = ConvertTimeToString(now, "%Y-%m-%d %H:%M:%S");
 
     if (getTimeIsSet()) {
-        LogFile.WriteToFile(ESP_LOG_INFO, TAG, "Time is already set. Actual time: " + sTimeString);
+        LogFile.WriteToFile(ESP_LOG_INFO, TAG, "Time is set. Current time: " + sTimeString);
     }
     else {
         timeWasNotSetAtBoot = true;
         timeWasNotSetAtBoot_PrintStartBlock = true;
         
         if (useNtp)
-            LogFile.WriteToFile(ESP_LOG_INFO, TAG, "Time not yet synchronized, still retry. Actual time: " + sTimeString);
+            LogFile.WriteToFile(ESP_LOG_INFO, TAG, "Time not yet synced. Current time: " + sTimeString);
         else
-            LogFile.WriteToFile(ESP_LOG_INFO, TAG, "No time synchronized configured. Actual time: " + sTimeString);
+            LogFile.WriteToFile(ESP_LOG_INFO, TAG, "Current time: " + sTimeString);
     }
 
     return true;
@@ -266,13 +266,13 @@ void setupTimeZone(std::string _timeZone)
     if (timeZone.compare(_timeZone) == 0)
         return;
 
-    LogFile.WriteToFile(ESP_LOG_WARN, TAG, "TimeZone gets adjusted");
+    LogFile.WriteToFile(ESP_LOG_WARN, TAG, "Time zone gets adjusted");
     
     timeZone = _timeZone;
 
     if (_timeZone == "") {
         _timeZone = "CET-1CEST,M3.5.0,M10.5.0/3";
-        LogFile.WriteToFile(ESP_LOG_INFO, TAG, "TimeZone not set, using default: " + _timeZone);
+        LogFile.WriteToFile(ESP_LOG_INFO, TAG, "Time zone not set, using default: " + _timeZone);
     }
 
     setTimeZone(_timeZone);
@@ -280,22 +280,22 @@ void setupTimeZone(std::string _timeZone)
 
 
 /**
- * TimeServer and init or restart NTP client
+ * Time server and init or restart NTP client
  */
 void setupTimeServer(std::string _timeServer)
 {
     if (timeServer.compare(_timeServer) == 0)
         return;
 
-    LogFile.WriteToFile(ESP_LOG_WARN, TAG, "TimeServer gets adjusted");
+    LogFile.WriteToFile(ESP_LOG_WARN, TAG, "Time server gets adjusted");
 
     if (_timeServer == "") {
-        LogFile.WriteToFile(ESP_LOG_INFO, TAG, "TimeServer deactivated, disabling NTP");
+        LogFile.WriteToFile(ESP_LOG_INFO, TAG, "Time server deactivated, disabling NTP");
         useNtp = false;
         sntp_stop();
     }
     else {
-        LogFile.WriteToFile(ESP_LOG_INFO, TAG, "TimeServer: " + _timeServer);
+        LogFile.WriteToFile(ESP_LOG_INFO, TAG, "Time server: " + _timeServer);
         useNtp = true;
     }
 

--- a/code/components/jomjol_time_sntp/time_sntp.cpp
+++ b/code/components/jomjol_time_sntp/time_sntp.cpp
@@ -66,15 +66,16 @@ void time_sync_notification_cb(struct timeval *tv)
 }
 
 
-bool time_manual_reset_sync(void)
+bool waitingForTimeSync(void)
 {
-    sntp_restart();
     int retry = 0;
     const int retry_count = 10;
+
     while (sntp_get_sync_status() == SNTP_SYNC_STATUS_RESET && ++retry < retry_count) {
         LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "Waiting for time sync - " + std::to_string(retry) + "/" + std::to_string(retry_count));
         vTaskDelay(2000 / portTICK_PERIOD_MS);
     }
+
     if (retry >= retry_count)
         return false;
 

--- a/code/components/jomjol_time_sntp/time_sntp.cpp
+++ b/code/components/jomjol_time_sntp/time_sntp.cpp
@@ -155,6 +155,8 @@ std::string getServerName(void)
 
 /**
  * Load the TimeZone and TimeServer from the config file and initialize the NTP client
+ * The RTC keeps the time after a restart (Except on Power On or Pin Reset) 
+ * There should only be a minor correction through NTP
  */
 bool setupTime()
 {
@@ -231,8 +233,9 @@ bool setupTime()
         sntp_init();
     }
 
-    /* The RTC keeps the time after a restart (Except on Power On or Pin Reset) 
-     * There should only be a minor correction through NTP */
+    // Wait for time sync to ensure start with proper time
+    if (!waitingForTimeSync())
+        LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "Initial time sync failed, still retry" );
 
     // Get current time from RTC
     time_t now;

--- a/code/components/jomjol_time_sntp/time_sntp.h
+++ b/code/components/jomjol_time_sntp/time_sntp.h
@@ -28,7 +28,7 @@ bool setupTime();
 void setupTimeZone(std::string _timeZone);
 void setupTimeServer(std::string _timeServer);
 
-bool time_manual_reset_sync(void);
+bool waitingForTimeSync(void);
 
 
 #endif //TIMESNTP_H

--- a/code/main/main.cpp
+++ b/code/main/main.cpp
@@ -248,7 +248,7 @@ extern "C" void app_main(void)
     // Init time (as early as possible, but SD card needs to be initialized and wifi needs to be connected)
     // ********************************************
     setupTime();    // NTP time service: Status of time synchronization will be checked after every cycle (server_tflite.cpp)
-s
+
     // Init external PSRAM
     // ********************************************
     esp_err_t PSRAMStatus = esp_psram_init();

--- a/code/main/main.cpp
+++ b/code/main/main.cpp
@@ -248,12 +248,7 @@ extern "C" void app_main(void)
     // Init time (as early as possible, but SD card needs to be initialized and wifi needs to be connected)
     // ********************************************
     setupTime();    // NTP time service: Status of time synchronization will be checked after every cycle (server_tflite.cpp)
-
-    // manual reset the time
-    // ********************************************
-    if (!waitingForTimeSync())
-        LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "Initial time sync failed, still retry" );
-   
+s
     // Init external PSRAM
     // ********************************************
     esp_err_t PSRAMStatus = esp_psram_init();

--- a/code/main/main.cpp
+++ b/code/main/main.cpp
@@ -251,8 +251,8 @@ extern "C" void app_main(void)
 
     // manual reset the time
     // ********************************************
-    if (!time_manual_reset_sync())
-        LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "Manual Time Sync failed during startup" );
+    if (!waitingForTimeSync())
+        LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "Initial time sync failed, still retry" );
    
     // Init external PSRAM
     // ********************************************

--- a/code/main/main.cpp
+++ b/code/main/main.cpp
@@ -247,7 +247,7 @@ extern "C" void app_main(void)
 
     // Init time (as early as possible, but SD card needs to be initialized and wifi needs to be connected)
     // ********************************************
-    setupTime();    // NTP time service: Status of time synchronization will be checked after every cycle (server_tflite.cpp)
+    setupTime();    // Setup system time / NTP client: Status of time synchronization will be checked after every cycle (server_tflite.cpp)
 
     // Init external PSRAM
     // ********************************************


### PR DESCRIPTION
- Load saved fallback value during init state only with valid system time to ensure proper determination of fallback value age, but load saved fallback value the latest before first usage (in doFlow() function)
- Refactor SNTP functions
- Init NTP service after WLAN init is completed