### PR TITLE
chore(config file): Add config file version tag

### DIFF
--- a/code/components/jomjol_flowcontroll/ClassFlowControll.cpp
+++ b/code/components/jomjol_flowcontroll/ClassFlowControll.cpp
@@ -854,7 +854,7 @@ void ClassFlowControll::AnalogDrawROI(CImageBasis *_zw)
 #ifdef ENABLE_MQTT
 bool ClassFlowControll::StartMQTTService() 
 {
-    if (flowMQTT == NULL) // Service disabled
+    if (flowMQTT == NULL)
         return false;
     
     return flowMQTT->Start(AutoInterval);

--- a/code/components/jomjol_flowcontroll/ClassFlowControll.cpp
+++ b/code/components/jomjol_flowcontroll/ClassFlowControll.cpp
@@ -854,8 +854,8 @@ void ClassFlowControll::AnalogDrawROI(CImageBasis *_zw)
 #ifdef ENABLE_MQTT
 bool ClassFlowControll::StartMQTTService() 
 {
-    if (flowMQTT == NULL)
-        return false;
+    if (flowMQTT == NULL) // Service disabled
+        return true;
     
     return flowMQTT->Start(AutoInterval);
 }

--- a/code/components/jomjol_flowcontroll/ClassFlowControll.cpp
+++ b/code/components/jomjol_flowcontroll/ClassFlowControll.cpp
@@ -855,7 +855,7 @@ void ClassFlowControll::AnalogDrawROI(CImageBasis *_zw)
 bool ClassFlowControll::StartMQTTService() 
 {
     if (flowMQTT == NULL) // Service disabled
-        return true;
+        return false;
     
     return flowMQTT->Start(AutoInterval);
 }

--- a/code/components/jomjol_helper/Helper.cpp
+++ b/code/components/jomjol_helper/Helper.cpp
@@ -662,7 +662,7 @@ bool replaceString(std::string& s, std::string const& toReplace, std::string con
     std::string old = s;
     s.replace(pos, toReplace.length(), replaceWith);
     if (logIt) {
-        LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "Migrated config file line '" + old + "' > '" + s + "'");
+        LogFile.WriteToFile(ESP_LOG_WARN, TAG, "Config.ini: Migrate '" + old + "' > '" + s + "'");
     }
     return true;
 }

--- a/code/components/jomjol_helper/Helper.cpp
+++ b/code/components/jomjol_helper/Helper.cpp
@@ -662,7 +662,7 @@ bool replaceString(std::string& s, std::string const& toReplace, std::string con
     std::string old = s;
     s.replace(pos, toReplace.length(), replaceWith);
     if (logIt) {
-        LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "Migrated Configfile line '" + old + "' to '" + s + "'");
+        LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "Migrated config file line '" + old + "' > '" + s + "'");
     }
     return true;
 }

--- a/code/components/jomjol_helper/system.cpp
+++ b/code/components/jomjol_helper/system.cpp
@@ -86,6 +86,13 @@ std::string getIDFVersion(void)
 }
 
 
+int getConfigFileVersion(void)
+{
+	return (int)CONFIG_FILE_VERSION;
+}
+
+
+
 /////////////////////////////////////////////////////////////////////////////////////////////
 // CPU Temp
 extern "C" uint8_t temprature_sens_read();

--- a/code/components/jomjol_helper/system.h
+++ b/code/components/jomjol_helper/system.h
@@ -13,6 +13,7 @@ std::string getChipRevision(void);
 void printDeviceInfo(void);
 
 std::string getIDFVersion(void);
+int getConfigFileVersion(void);
 
 float temperatureRead();
 

--- a/code/include/defines.h
+++ b/code/include/defines.h
@@ -2,6 +2,14 @@
 #define DEFINES_H
 
 //**************************************************************************************
+// Define config file version for config.ini (sd-card/config/config.ini)
+// Needs to be increased whenever config.ini gets modified and migration is necessary
+// Add migration routine in main.cpp --> migrateConfiguration()
+//**************************************************************************************
+#define CONFIG_FILE_VERSION      1
+
+
+//**************************************************************************************
 // ENABLE/DISABLE SOFTWARE MODULE
 //**************************************************************************************
 

--- a/code/main/main.cpp
+++ b/code/main/main.cpp
@@ -454,299 +454,335 @@ esp_err_t initSDCard()
 
 void migrateConfiguration(void)
 {
-    bool migrated = false;
-
     if (!FileExists(CONFIG_FILE)) {
         LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "Config file seems to be missing");
         return;	
     }
 
+    const std::string sectionConfigFile= "[ConfigFile]";
+    bool configSectionFound = false;
+    int actualConfigFileVersion = 0;
+
+    bool migrated = false;
     std::string section = "";
-	std::ifstream ifs(CONFIG_FILE);
-  	std::string content((std::istreambuf_iterator<char>(ifs)), (std::istreambuf_iterator<char>()));
-	
-    /* Split config file it array of lines */
-    std::vector<std::string> configLines = splitString(content);
 
-    /* Process each line */
+    // Read config file
+    std::ifstream ifs(CONFIG_FILE);
+    std::string content((std::istreambuf_iterator<char>(ifs)), (std::istreambuf_iterator<char>()));
+    std::vector<std::string> configLines = splitString(content); // Split config file in array of lines
+
+    // Read config file version
     for (int i = 0; i < configLines.size(); i++) {
-        //ESP_LOGI(TAG, "Line %d: %s", i, configLines[i].c_str());
+        if (configLines[i] == sectionConfigFile) {
+            configSectionFound = true;
 
-        if (configLines[i].find("[") != std::string::npos) { // Start of new section
-            section = configLines[i];
-            replaceString(section, ";", "", false); // Remove possible semicolon (just for the string comparison)
-            //ESP_LOGI(TAG, "New section: %s", section.c_str());
+            std::vector<std::string> splitted = ZerlegeZeile(configLines[i+1]);
+            if (toUpper(splitted[0]) == "VERSION") {
+                actualConfigFileVersion = stoi(splitted[1]);
+            }
+            break;
         }
+    }
 
-        /* Migrate parameters as needed
-         * For all boolean and further more parameter, we make them enabled all the time now:
-         *  1. If they where disabled, set them to their default value
-         *  2. Enable them
-         * Notes:
-         * The migration has some simplifications:
-         *  - Case Sensitiveness must be like in the initial config.ini
-         *  - No Whitespace after a semicollon
-         *  - Only one whitespace before/after the equal sign
-         */
-        if (section == "[MakeImage]") {
-            migrated = migrated | replaceString(configLines[i], "[MakeImage]", "[TakeImage]"); // Rename the section itself
-        }
-
-        if (section == "[MakeImage]" || section == "[TakeImage]") {
-            migrated = migrated | replaceString(configLines[i], "LogImageLocation", "RawImagesLocation");
-            migrated = migrated | replaceString(configLines[i], "LogfileRetentionInDays", "RawImagesRetention");
-
-            migrated = migrated | replaceString(configLines[i], "WaitBeforeTakingPicture", "FlashTime"); // Rename
-            migrated = migrated | replaceString(configLines[i], "LEDIntensity", "FlashIntensity"); // Rename
-
-            migrated = migrated | replaceString(configLines[i], "FixedExposure", "UNUSED"); // Mark as unused
-
-            migrated = migrated | replaceString(configLines[i], ";Demo = true", ";Demo = false"); // Set it to its default value
-            migrated = migrated | replaceString(configLines[i], ";Demo", "Demo"); // Enable it
-        }
-
-        if (section == "[Alignment]") {
-            if (isInString(configLines[i], "AlignmentAlgo") && isInString(configLines[i], ";")) { // It is the parameter "AlignmentAlgo" and it is commented out
-                migrated = migrated | replaceString(configLines[i], "highAccuracy", "default"); // Set it to its default value and enable it
-                migrated = migrated | replaceString(configLines[i], "fast", "default"); // Set it to its default value and enable it
-                migrated = migrated | replaceString(configLines[i], "off", "default"); // Set it to its default value and enable it
-                migrated = migrated | replaceString(configLines[i], ";", ""); // Enable it
+    // If no [Config] section is available, add section and set config version to zero
+    if (!configSectionFound) {
+        configLines.insert(configLines.begin(), ""); // 3rd line
+        configLines.insert(configLines.begin(), "Version = 0"); //2nd line 
+	    configLines.insert(configLines.begin(), sectionConfigFile); // 1st line
+        migrated = true;
+    }
+    
+     // Process every version iteration beginning from actual version
+	for (int configFileVersion = actualConfigFileVersion; configFileVersion < (int)CONFIG_FILE_VERSION; configFileVersion++) {     
+        // Process each line of config
+        for (int i = 0; i < configLines.size(); i++) {
+            if (configLines[i].find("[") != std::string::npos) { // Detect start of new section
+                section = configLines[i];
+                replaceString(section, ";", "", false); // Remove possible semicolon (just for the string comparison)
             }
 
-            migrated = migrated | replaceString(configLines[i], ";FlipImageSize = true", ";FlipImageSize = false"); // Set it to its default value
-            migrated = migrated | replaceString(configLines[i], ";FlipImageSize", "FlipImageSize"); // Enable it
+            /* Notes:
+            * The migration has some simplifications:
+            *  - Case sensitiveness must be like in the config.ini
+            *  - No whitespace after a semicollon
+            *  - Only one whitespace before/after the equal sign
+            */
 
-            migrated = migrated | replaceString(configLines[i], "InitialMirror", "UNUSED"); // Mark as unused
-        }
-
-        if (section == "[Digits]") {
-            if (isInString(configLines[i], "CNNGoodThreshold")) { // It is the parameter "CNNGoodThreshold"
-                migrated = migrated | replaceString(configLines[i], "0.5", "0.0");
-                migrated = migrated | replaceString(configLines[i], ";", ""); // Enable it
-            }
-            migrated = migrated | replaceString(configLines[i], "LogImageLocation", "ROIImagesLocation");
-            migrated = migrated | replaceString(configLines[i], "LogfileRetentionInDays", "ROIImagesRetention");
-        }
-
-        if (section == "[Analog]") {
-            migrated = migrated | replaceString(configLines[i], "LogImageLocation", "ROIImagesLocation");
-            migrated = migrated | replaceString(configLines[i], "LogfileRetentionInDays", "ROIImagesRetention");
-            migrated = migrated | replaceString(configLines[i], "CNNGoodThreshold", ";UNUSED_PARAMETER"); // This parameter is no longer used          
-            migrated = migrated | replaceString(configLines[i], "ExtendedResolution", ";UNUSED_PARAMETER"); // This parameter is no longer used
-        }
-
-        if (section == "[PostProcessing]") {
-            migrated = migrated | replaceString(configLines[i], ";PreValueUse = true", ";PreValueUse = false"); // Set it to its default value
-            migrated = migrated | replaceString(configLines[i], ";PreValueUse", "PreValueUse"); // Enable it
-            migrated = migrated | replaceString(configLines[i], "PreValueUse", "FallbackValueUse"); // Rename it
-
-            migrated = migrated | replaceString(configLines[i], ";PreValueAgeStartup", "PreValueAgeStartup"); // Enable it
-            migrated = migrated | replaceString(configLines[i], "PreValueAgeStartup", "FallbackValueAgeStartup");
-
-            migrated = migrated | replaceString(configLines[i], ";CheckDigitIncreaseConsistency = true", ";CheckDigitIncreaseConsistency = false"); // Set it to its default value
-            migrated = migrated | replaceString(configLines[i], ";CheckDigitIncreaseConsistency", "CheckDigitIncreaseConsistency"); // Enable it
-
-            if (isInString(configLines[i], "DecimalShift") && isInString(configLines[i], ";")) { // It is the parameter "DecimalShift" and it is commented out
-                migrated = migrated | replaceString(configLines[i], ";", ""); // Enable it
-            }
-
-            /* AllowNegativeRates has a <NUMBER> as prefix! */
-            if (isInString(configLines[i], "AllowNegativeRates") && isInString(configLines[i], ";")) { // It is the parameter "AllowNegativeRates" and it is commented out
-                migrated = migrated | replaceString(configLines[i], "true", "false"); // Set it to its default value
-                migrated = migrated | replaceString(configLines[i], ";", ""); // Enable it
-            }
-
-            if (isInString(configLines[i], "AnalogDigitalTransitionStart") && isInString(configLines[i], ";")) { // It is the parameter "AnalogDigitalTransitionStart" and it is commented out
-                migrated = migrated | replaceString(configLines[i], ";", ""); // Enable it
-            }
-
-            /* MaxRateType has a <NUMBER> as prefix! */
-            if (isInString(configLines[i], "MaxRateType")) { // It is the parameter "MaxRateType"
-                if (isInString(configLines[i], ";")) { // if disabled
-                    migrated = migrated | replaceString(configLines[i], "= Off", "= RatePerMin"); // Convert it to its default value
-                    migrated = migrated | replaceString(configLines[i], "= RateChange", "= RatePerMin"); // Convert it to its default value
-                    migrated = migrated | replaceString(configLines[i], "= AbsoluteChange", "= RatePerMin"); // Convert it to its default value
-                    migrated = migrated | replaceString(configLines[i], ";", ""); // Enable it
+            //*************************************************************************************************
+            // Migrate from version 0 to version 1
+            // Version 0: All config file versions before 17.x
+            //*************************************************************************************************
+            if (configFileVersion == 0) {
+                // Update config version
+                // ---------------------
+                if (section == sectionConfigFile) {
+                    if(replaceString(configLines[i], "Version = " + std::to_string(configFileVersion), 
+                                                     "Version = " + std::to_string(configFileVersion+1))) {
+                        LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "Migrate config.ini: v" + std::to_string(configFileVersion) + 
+                                                                                " > v" + std::to_string(configFileVersion+1));
+                        migrated = true;
+                    }
                 }
-                else {
-                    migrated = migrated | replaceString(configLines[i], "= Off", "= RateOff"); // Convert it to its new name
-                    migrated = migrated | replaceString(configLines[i], "= RateChange", "= RatePerMin"); // Convert it to its new name
-                    migrated = migrated | replaceString(configLines[i], "= AbsoluteChange", "= RatePerInterval"); // Convert it to its new name
+
+                // Migrate parameter
+                // ---------------------
+                if (section == "[MakeImage]") {
+                    migrated = migrated | replaceString(configLines[i], "[MakeImage]", "[TakeImage]"); // Rename the section itself
+                }
+
+                if (section == "[MakeImage]" || section == "[TakeImage]") {
+                    migrated = migrated | replaceString(configLines[i], "LogImageLocation", "RawImagesLocation");
+                    migrated = migrated | replaceString(configLines[i], "LogfileRetentionInDays", "RawImagesRetention");
+
+                    migrated = migrated | replaceString(configLines[i], "WaitBeforeTakingPicture", "FlashTime"); // Rename
+                    migrated = migrated | replaceString(configLines[i], "LEDIntensity", "FlashIntensity"); // Rename
+
+                    migrated = migrated | replaceString(configLines[i], "FixedExposure", "UNUSED"); // Mark as unused
+
+                    migrated = migrated | replaceString(configLines[i], ";Demo = true", ";Demo = false"); // Set it to its default value
+                    migrated = migrated | replaceString(configLines[i], ";Demo", "Demo"); // Enable it
+                }
+
+                if (section == "[Alignment]") {
+                    if (isInString(configLines[i], "AlignmentAlgo") && isInString(configLines[i], ";")) { // It is the parameter "AlignmentAlgo" and it is commented out
+                        migrated = migrated | replaceString(configLines[i], "highAccuracy", "default"); // Set it to its default value and enable it
+                        migrated = migrated | replaceString(configLines[i], "fast", "default"); // Set it to its default value and enable it
+                        migrated = migrated | replaceString(configLines[i], "off", "default"); // Set it to its default value and enable it
+                        migrated = migrated | replaceString(configLines[i], ";", ""); // Enable it
+                    }
+
+                    migrated = migrated | replaceString(configLines[i], ";FlipImageSize = true", ";FlipImageSize = false"); // Set it to its default value
+                    migrated = migrated | replaceString(configLines[i], ";FlipImageSize", "FlipImageSize"); // Enable it
+
+                    migrated = migrated | replaceString(configLines[i], "InitialMirror", "UNUSED"); // Mark as unused
+                }
+
+                if (section == "[Digits]") {
+                    if (isInString(configLines[i], "CNNGoodThreshold")) { // It is the parameter "CNNGoodThreshold"
+                        migrated = migrated | replaceString(configLines[i], "0.5", "0.0");
+                        migrated = migrated | replaceString(configLines[i], ";", ""); // Enable it
+                    }
+                    migrated = migrated | replaceString(configLines[i], "LogImageLocation", "ROIImagesLocation");
+                    migrated = migrated | replaceString(configLines[i], "LogfileRetentionInDays", "ROIImagesRetention");
+                }
+
+                if (section == "[Analog]") {
+                    migrated = migrated | replaceString(configLines[i], "LogImageLocation", "ROIImagesLocation");
+                    migrated = migrated | replaceString(configLines[i], "LogfileRetentionInDays", "ROIImagesRetention");
+                    migrated = migrated | replaceString(configLines[i], "CNNGoodThreshold", ";UNUSED_PARAMETER"); // This parameter is no longer used          
+                    migrated = migrated | replaceString(configLines[i], "ExtendedResolution", ";UNUSED_PARAMETER"); // This parameter is no longer used
+                }
+
+                if (section == "[PostProcessing]") {
+                    migrated = migrated | replaceString(configLines[i], ";PreValueUse = true", ";PreValueUse = false"); // Set it to its default value
+                    migrated = migrated | replaceString(configLines[i], ";PreValueUse", "PreValueUse"); // Enable it
+                    migrated = migrated | replaceString(configLines[i], "PreValueUse", "FallbackValueUse"); // Rename it
+
+                    migrated = migrated | replaceString(configLines[i], ";PreValueAgeStartup", "PreValueAgeStartup"); // Enable it
+                    migrated = migrated | replaceString(configLines[i], "PreValueAgeStartup", "FallbackValueAgeStartup");
+
+                    migrated = migrated | replaceString(configLines[i], ";CheckDigitIncreaseConsistency = true", ";CheckDigitIncreaseConsistency = false"); // Set it to its default value
+                    migrated = migrated | replaceString(configLines[i], ";CheckDigitIncreaseConsistency", "CheckDigitIncreaseConsistency"); // Enable it
+
+                    if (isInString(configLines[i], "DecimalShift") && isInString(configLines[i], ";")) { // It is the parameter "DecimalShift" and it is commented out
+                        migrated = migrated | replaceString(configLines[i], ";", ""); // Enable it
+                    }
+
+                    /* AllowNegativeRates has a <NUMBER> as prefix! */
+                    if (isInString(configLines[i], "AllowNegativeRates") && isInString(configLines[i], ";")) { // It is the parameter "AllowNegativeRates" and it is commented out
+                        migrated = migrated | replaceString(configLines[i], "true", "false"); // Set it to its default value
+                        migrated = migrated | replaceString(configLines[i], ";", ""); // Enable it
+                    }
+
+                    if (isInString(configLines[i], "AnalogDigitalTransitionStart") && isInString(configLines[i], ";")) { // It is the parameter "AnalogDigitalTransitionStart" and it is commented out
+                        migrated = migrated | replaceString(configLines[i], ";", ""); // Enable it
+                    }
+
+                    /* MaxRateType has a <NUMBER> as prefix! */
+                    if (isInString(configLines[i], "MaxRateType")) { // It is the parameter "MaxRateType"
+                        if (isInString(configLines[i], ";")) { // if disabled
+                            migrated = migrated | replaceString(configLines[i], "= Off", "= RatePerMin"); // Convert it to its default value
+                            migrated = migrated | replaceString(configLines[i], "= RateChange", "= RatePerMin"); // Convert it to its default value
+                            migrated = migrated | replaceString(configLines[i], "= AbsoluteChange", "= RatePerMin"); // Convert it to its default value
+                            migrated = migrated | replaceString(configLines[i], ";", ""); // Enable it
+                        }
+                        else {
+                            migrated = migrated | replaceString(configLines[i], "= Off", "= RateOff"); // Convert it to its new name
+                            migrated = migrated | replaceString(configLines[i], "= RateChange", "= RatePerMin"); // Convert it to its new name
+                            migrated = migrated | replaceString(configLines[i], "= AbsoluteChange", "= RatePerInterval"); // Convert it to its new name
+                        }
+                    }
+
+                    if (isInString(configLines[i], "MaxRateValue") && isInString(configLines[i], ";")) { // It is the parameter "MaxRateValue" and it is commented out
+                        migrated = migrated | replaceString(configLines[i], ";", ""); // Enable it
+                    }
+
+                    /* ExtendedResolution has a <NUMBER> as prefix! */
+                    if (isInString(configLines[i], "ExtendedResolution") && isInString(configLines[i], ";")) { // It is the parameter "ExtendedResolution" and it is commented out
+                        migrated = migrated | replaceString(configLines[i], "true", "false"); // Set it to its default value
+                        migrated = migrated | replaceString(configLines[i], ";", ""); // Enable it
+                    }
+                
+                    /* IgnoreLeadingNaN has a <NUMBER> as prefix! */
+                    if (isInString(configLines[i], "IgnoreLeadingNaN") && isInString(configLines[i], ";")) { // It is the parameter "IgnoreLeadingNaN" and it is commented out
+                        migrated = migrated | replaceString(configLines[i], "true", "false"); // Set it to its default value
+                        migrated = migrated | replaceString(configLines[i], ";", ""); // Enable it
+                    }
+                }
+
+                if (section == "[MQTT]") {
+                    migrated = migrated | replaceString(configLines[i], ";Uri", "Uri"); // Enable it
+                    migrated = migrated | replaceString(configLines[i], ";MainTopic", "MainTopic"); // Enable it
+                    migrated = migrated | replaceString(configLines[i], ";ClientID", "ClientID"); // Enable it
+
+                    if (isInString(configLines[i], "CACert") && !isInString(configLines[i], "TLSCACert")) {
+                        migrated = migrated | replaceString(configLines[i], "CACert =", "TLSCACert ="); // Rename it
+                        migrated = migrated | replaceString(configLines[i], ";", ""); // Enable it
+                    }
+
+                    if (isInString(configLines[i], "ClientCert") && !isInString(configLines[i], "TLSClientCert")) {
+                        migrated = migrated | replaceString(configLines[i], "ClientCert =", "TLSClientCert ="); // Rename it
+                        migrated = migrated | replaceString(configLines[i], ";", ""); // Enable it
+                    }
+
+                    if (isInString(configLines[i], "ClientKey") && !isInString(configLines[i], "TLSClientKey")) {
+                        migrated = migrated | replaceString(configLines[i], "ClientKey =", "TLSClientKey ="); // Rename it
+                        migrated = migrated | replaceString(configLines[i], ";", ""); // Enable it
+                    }
+
+                    migrated = migrated | replaceString(configLines[i], "SetRetainFlag", "RetainMessages"); // First rename it, enable it with its default value
+                    migrated = migrated | replaceString(configLines[i], ";RetainMessages = true", ";RetainMessages = false"); // Set it to its default value
+                    migrated = migrated | replaceString(configLines[i], ";RetainMessages", "RetainMessages"); // Enable it
+                    migrated = migrated | replaceString(configLines[i], "RetainMessages", "RetainProcessData"); // Rename it
+
+                    migrated = migrated | replaceString(configLines[i], ";HomeassistantDiscovery = true", ";HomeassistantDiscovery = false"); // Set it to its default value
+                    migrated = migrated | replaceString(configLines[i], ";HomeassistantDiscovery", "HomeassistantDiscovery"); // Enable it
+
+                    if (isInString(configLines[i], "MeterType") && !isInString(configLines[i], "HAMeterType")) {
+                        migrated = migrated | replaceString(configLines[i], "MeterType =", "HAMeterType ="); // Rename it
+                        migrated = migrated | replaceString(configLines[i], ";", ""); // Enable it
+                        migrated = migrated | replaceString(configLines[i], "HAMeterType = other", "HAMeterType = water_m3"); // Enable it
+                    }
+                    
+                    if (configLines[i].rfind("Topic", 0) != std::string::npos) { // only if string starts with "Topic" (Was the naming in very old version)
+                        migrated = migrated | replaceString(configLines[i], "Topic", "MainTopic");
+                    }
+                }
+
+                if (section == "[InfluxDB]") {
+                    if (isInString(configLines[i], "Uri") && isInString(configLines[i], ";")) { // It is the parameter "Uri" and it is commented out
+                        migrated = migrated | replaceString(configLines[i], ";", ""); // Enable it
+                    }
+
+                    if (isInString(configLines[i], "Database") && isInString(configLines[i], ";")) { // It is the parameter "Database" and it is commented out
+                        migrated = migrated | replaceString(configLines[i], ";", ""); // Enable it
+                    }
+
+                    /* Measurement has a <NUMBER> as prefix! */
+                    if (isInString(configLines[i], "Measurement") && isInString(configLines[i], ";")) { // It is the parameter "Measurement" and is it disabled
+                        migrated = migrated | replaceString(configLines[i], ";", ""); // Enable it
+                    }
+
+                    /* Fieldname has a <NUMBER> as prefix! */
+                    if (isInString(configLines[i], "Fieldname")) { // It is the parameter "Fieldname"
+                        migrated = migrated | replaceString(configLines[i], "Fieldname", "Field"); // Rename it to Field
+                        migrated = migrated | replaceString(configLines[i], ";", ""); // Enable it
+                    }
+
+                    /* Field has a <NUMBER> as prefix! */
+                    if (isInString(configLines[i], "Field") && isInString(configLines[i], ";")) { // It is the parameter "Field" and is it disabled
+                        migrated = migrated | replaceString(configLines[i], ";", ""); // Enable it
+                    }
+                }
+
+                if (section == "[InfluxDBv2]") {
+                    if (isInString(configLines[i], "Uri") && isInString(configLines[i], ";")) { // It is the parameter "Uri" and it is commented out
+                        migrated = migrated | replaceString(configLines[i], ";", ""); // Enable it
+                    }
+
+                    if (isInString(configLines[i], "Database") && isInString(configLines[i], ";")) { // It is the parameter "Database" and it is commented out
+                        migrated = migrated | replaceString(configLines[i], ";", ""); // Enable it
+                    }
+                    if (isInString(configLines[i], "Database")) { // It is the parameter "Database"
+                        migrated = migrated | replaceString(configLines[i], "Database", "Bucket"); // Rename it to Bucket
+                    }
+                    
+                    /* Measurement has a <NUMBER> as prefix! */
+                    if (isInString(configLines[i], "Measurement") && isInString(configLines[i], ";")) { // It is the parameter "Measurement" and is it disabled
+                        migrated = migrated | replaceString(configLines[i], ";", ""); // Enable it
+                    }
+
+                    /* Fieldname has a <NUMBER> as prefix! */
+                    if (isInString(configLines[i], "Fieldname")) { // It is the parameter "Fieldname"
+                        migrated = migrated | replaceString(configLines[i], "Fieldname", "Field"); // Rename it to Field
+                        migrated = migrated | replaceString(configLines[i], ";", ""); // Enable it
+                    }
+
+                    /* Field has a <NUMBER> as prefix! */
+                    if (isInString(configLines[i], "Field") && isInString(configLines[i], ";")) { // It is the parameter "Field" and is it disabled
+                        migrated = migrated | replaceString(configLines[i], ";", ""); // Enable it
+                    }
+                }
+
+                if (section == "[DataLogging]") {
+                    /* DataLogActive is true by default! */
+                    migrated = migrated | replaceString(configLines[i], ";DataLogActive = false", ";DataLogActive = true"); // Set it to its default value
+                    migrated = migrated | replaceString(configLines[i], ";DataLogActive", "DataLogActive"); // Enable it
+
+                    migrated = migrated | replaceString(configLines[i], "DataLogRetentionInDays", "DataFilesRetention");
+                }
+
+                if (section == "[AutoTimer]") {
+                    migrated = migrated | replaceString(configLines[i], ";AutoStart = true", ";AutoStart = false"); // Set it to its default value
+                    migrated = migrated | replaceString(configLines[i], ";AutoStart", "AutoStart"); // Enable it
+
+                    migrated = migrated | replaceString(configLines[i], "Intervall", "Interval");
+                }
+
+                if (section == "[Debug]") {
+                    migrated = migrated | replaceString(configLines[i], "Logfile ", "LogLevel "); // Whitespace needed so it does not match `LogfileRetentionInDays`
+                    /* LogLevel (resp. LogFile) was originally a boolean, but we switched it to an int
+                    * For both cases (true/false), we set it to level 2 (WARNING) */
+                    migrated = migrated | replaceString(configLines[i], "LogLevel = true", "LogLevel = 2");
+                    migrated = migrated | replaceString(configLines[i], "LogLevel = false", "LogLevel = 2");
+                    
+                    migrated = migrated | replaceString(configLines[i], "LogfileRetentionInDays", "LogfilesRetention");
+                }
+
+                if (section == "[System]") {
+                    if (isInString(configLines[i], "TimeServer = undefined") && isInString(configLines[i], ";")) 
+                    { // It is the parameter "TimeServer" and is it disabled
+                        migrated = migrated | replaceString(configLines[i], "undefined", "pool.ntp.org");
+                        migrated = migrated | replaceString(configLines[i], ";", ""); // Enable it
+                    }
+
+                    if (isInString(configLines[i], "TimeZone") && isInString(configLines[i], ";")) { // It is the parameter "TimeZone" and it is commented out
+                        migrated = migrated | replaceString(configLines[i], ";", ""); // Enable it
+                    }
+
+                    if (isInString(configLines[i], "Hostname") && isInString(configLines[i], ";")) { // It is the parameter "Hostname" and is it disabled
+                        migrated = migrated | replaceString(configLines[i], "undefined", "watermeter");
+                        migrated = migrated | replaceString(configLines[i], ";", ""); // Enable it
+                    }
+                                        
+                    migrated = migrated | replaceString(configLines[i], "RSSIThreashold", "RSSIThreshold");
+
+                    if (isInString(configLines[i], "CPUFrequency") && isInString(configLines[i], ";")) { // It is the parameter "CPUFrequency" and is it disabled
+                        migrated = migrated | replaceString(configLines[i], "240", "160");
+                        migrated = migrated | replaceString(configLines[i], ";", ""); // Enable it
+                    }
+                    
+                    migrated = migrated | replaceString(configLines[i], "AutoAdjustSummertime", ";UNUSED_PARAMETER"); // This parameter is no longer used
+
+                    migrated = migrated | replaceString(configLines[i], ";SetupMode = true", ";SetupMode = false"); // Set it to its default value
+                    migrated = migrated | replaceString(configLines[i], ";SetupMode", "SetupMode"); // Enable it
                 }
             }
-
-            if (isInString(configLines[i], "MaxRateValue") && isInString(configLines[i], ";")) { // It is the parameter "MaxRateValue" and it is commented out
-                migrated = migrated | replaceString(configLines[i], ";", ""); // Enable it
-            }
-
-            /* ExtendedResolution has a <NUMBER> as prefix! */
-            if (isInString(configLines[i], "ExtendedResolution") && isInString(configLines[i], ";")) { // It is the parameter "ExtendedResolution" and it is commented out
-                migrated = migrated | replaceString(configLines[i], "true", "false"); // Set it to its default value
-                migrated = migrated | replaceString(configLines[i], ";", ""); // Enable it
-            }
-        
-            /* IgnoreLeadingNaN has a <NUMBER> as prefix! */
-            if (isInString(configLines[i], "IgnoreLeadingNaN") && isInString(configLines[i], ";")) { // It is the parameter "IgnoreLeadingNaN" and it is commented out
-                migrated = migrated | replaceString(configLines[i], "true", "false"); // Set it to its default value
-                migrated = migrated | replaceString(configLines[i], ";", ""); // Enable it
-            }
-        }
-
-        if (section == "[MQTT]") {
-            migrated = migrated | replaceString(configLines[i], ";Uri", "Uri"); // Enable it
-            migrated = migrated | replaceString(configLines[i], ";MainTopic", "MainTopic"); // Enable it
-            migrated = migrated | replaceString(configLines[i], ";ClientID", "ClientID"); // Enable it
-
-            if (isInString(configLines[i], "CACert") && !isInString(configLines[i], "TLSCACert")) {
-                migrated = migrated | replaceString(configLines[i], "CACert =", "TLSCACert ="); // Rename it
-                migrated = migrated | replaceString(configLines[i], ";", ""); // Enable it
-            }
-
-            if (isInString(configLines[i], "ClientCert") && !isInString(configLines[i], "TLSClientCert")) {
-                migrated = migrated | replaceString(configLines[i], "ClientCert =", "TLSClientCert ="); // Rename it
-                migrated = migrated | replaceString(configLines[i], ";", ""); // Enable it
-            }
-
-            if (isInString(configLines[i], "ClientKey") && !isInString(configLines[i], "TLSClientKey")) {
-                migrated = migrated | replaceString(configLines[i], "ClientKey =", "TLSClientKey ="); // Rename it
-                migrated = migrated | replaceString(configLines[i], ";", ""); // Enable it
-            }
-
-            migrated = migrated | replaceString(configLines[i], "SetRetainFlag", "RetainMessages"); // First rename it, enable it with its default value
-            migrated = migrated | replaceString(configLines[i], ";RetainMessages = true", ";RetainMessages = false"); // Set it to its default value
-            migrated = migrated | replaceString(configLines[i], ";RetainMessages", "RetainMessages"); // Enable it
-            migrated = migrated | replaceString(configLines[i], "RetainMessages", "RetainProcessData"); // Rename it
-
-            migrated = migrated | replaceString(configLines[i], ";HomeassistantDiscovery = true", ";HomeassistantDiscovery = false"); // Set it to its default value
-            migrated = migrated | replaceString(configLines[i], ";HomeassistantDiscovery", "HomeassistantDiscovery"); // Enable it
-
-            if (isInString(configLines[i], "MeterType") && !isInString(configLines[i], "HAMeterType")) {
-                migrated = migrated | replaceString(configLines[i], "MeterType =", "HAMeterType ="); // Rename it
-                migrated = migrated | replaceString(configLines[i], ";", ""); // Enable it
-                migrated = migrated | replaceString(configLines[i], "HAMeterType = other", "HAMeterType = water_m3"); // Enable it
-            }
-            
-            if (configLines[i].rfind("Topic", 0) != std::string::npos) { // only if string starts with "Topic" (Was the naming in very old version)
-                migrated = migrated | replaceString(configLines[i], "Topic", "MainTopic");
-            }
-        }
-
-        if (section == "[InfluxDB]") {
-            if (isInString(configLines[i], "Uri") && isInString(configLines[i], ";")) { // It is the parameter "Uri" and it is commented out
-                migrated = migrated | replaceString(configLines[i], ";", ""); // Enable it
-            }
-
-            if (isInString(configLines[i], "Database") && isInString(configLines[i], ";")) { // It is the parameter "Database" and it is commented out
-                migrated = migrated | replaceString(configLines[i], ";", ""); // Enable it
-            }
-
-            /* Measurement has a <NUMBER> as prefix! */
-            if (isInString(configLines[i], "Measurement") && isInString(configLines[i], ";")) { // It is the parameter "Measurement" and is it disabled
-                migrated = migrated | replaceString(configLines[i], ";", ""); // Enable it
-            }
-
-            /* Fieldname has a <NUMBER> as prefix! */
-            if (isInString(configLines[i], "Fieldname")) { // It is the parameter "Fieldname"
-                migrated = migrated | replaceString(configLines[i], "Fieldname", "Field"); // Rename it to Field
-                migrated = migrated | replaceString(configLines[i], ";", ""); // Enable it
-            }
-
-            /* Field has a <NUMBER> as prefix! */
-            if (isInString(configLines[i], "Field") && isInString(configLines[i], ";")) { // It is the parameter "Field" and is it disabled
-                migrated = migrated | replaceString(configLines[i], ";", ""); // Enable it
-            }
-        }
-
-        if (section == "[InfluxDBv2]") {
-            if (isInString(configLines[i], "Uri") && isInString(configLines[i], ";")) { // It is the parameter "Uri" and it is commented out
-                migrated = migrated | replaceString(configLines[i], ";", ""); // Enable it
-            }
-
-            if (isInString(configLines[i], "Database") && isInString(configLines[i], ";")) { // It is the parameter "Database" and it is commented out
-                migrated = migrated | replaceString(configLines[i], ";", ""); // Enable it
-            }
-            if (isInString(configLines[i], "Database")) { // It is the parameter "Database"
-                migrated = migrated | replaceString(configLines[i], "Database", "Bucket"); // Rename it to Bucket
-            }
-            
-            /* Measurement has a <NUMBER> as prefix! */
-            if (isInString(configLines[i], "Measurement") && isInString(configLines[i], ";")) { // It is the parameter "Measurement" and is it disabled
-                migrated = migrated | replaceString(configLines[i], ";", ""); // Enable it
-            }
-
-            /* Fieldname has a <NUMBER> as prefix! */
-            if (isInString(configLines[i], "Fieldname")) { // It is the parameter "Fieldname"
-                migrated = migrated | replaceString(configLines[i], "Fieldname", "Field"); // Rename it to Field
-                migrated = migrated | replaceString(configLines[i], ";", ""); // Enable it
-            }
-
-            /* Field has a <NUMBER> as prefix! */
-            if (isInString(configLines[i], "Field") && isInString(configLines[i], ";")) { // It is the parameter "Field" and is it disabled
-                migrated = migrated | replaceString(configLines[i], ";", ""); // Enable it
-            }
-        }
-
-        if (section == "[GPIO]") {
-
-        }
-
-        if (section == "[DataLogging]") {
-            /* DataLogActive is true by default! */
-            migrated = migrated | replaceString(configLines[i], ";DataLogActive = false", ";DataLogActive = true"); // Set it to its default value
-            migrated = migrated | replaceString(configLines[i], ";DataLogActive", "DataLogActive"); // Enable it
-
-            migrated = migrated | replaceString(configLines[i], "DataLogRetentionInDays", "DataFilesRetention");
-        }
-
-        if (section == "[AutoTimer]") {
-            migrated = migrated | replaceString(configLines[i], ";AutoStart = true", ";AutoStart = false"); // Set it to its default value
-            migrated = migrated | replaceString(configLines[i], ";AutoStart", "AutoStart"); // Enable it
-
-            migrated = migrated | replaceString(configLines[i], "Intervall", "Interval");
-        }
-
-        if (section == "[Debug]") {
-            migrated = migrated | replaceString(configLines[i], "Logfile ", "LogLevel "); // Whitespace needed so it does not match `LogfileRetentionInDays`
-            /* LogLevel (resp. LogFile) was originally a boolean, but we switched it to an int
-             * For both cases (true/false), we set it to level 2 (WARNING) */
-            migrated = migrated | replaceString(configLines[i], "LogLevel = true", "LogLevel = 2");
-            migrated = migrated | replaceString(configLines[i], "LogLevel = false", "LogLevel = 2");
-            
-            migrated = migrated | replaceString(configLines[i], "LogfileRetentionInDays", "LogfilesRetention");
-        }
-
-        if (section == "[System]") {
-            if (isInString(configLines[i], "TimeServer = undefined") && isInString(configLines[i], ";")) 
-            { // It is the parameter "TimeServer" and is it disabled
-                migrated = migrated | replaceString(configLines[i], "undefined", "pool.ntp.org");
-                migrated = migrated | replaceString(configLines[i], ";", ""); // Enable it
-            }
-
-            if (isInString(configLines[i], "TimeZone") && isInString(configLines[i], ";")) { // It is the parameter "TimeZone" and it is commented out
-                migrated = migrated | replaceString(configLines[i], ";", ""); // Enable it
-            }
-
-            if (isInString(configLines[i], "Hostname") && isInString(configLines[i], ";")) { // It is the parameter "Hostname" and is it disabled
-                migrated = migrated | replaceString(configLines[i], "undefined", "watermeter");
-                migrated = migrated | replaceString(configLines[i], ";", ""); // Enable it
-            }
-                                 
-            migrated = migrated | replaceString(configLines[i], "RSSIThreashold", "RSSIThreshold");
-
-            if (isInString(configLines[i], "CPUFrequency") && isInString(configLines[i], ";")) { // It is the parameter "CPUFrequency" and is it disabled
-                migrated = migrated | replaceString(configLines[i], "240", "160");
-                migrated = migrated | replaceString(configLines[i], ";", ""); // Enable it
-            }
-            
-            migrated = migrated | replaceString(configLines[i], "AutoAdjustSummertime", ";UNUSED_PARAMETER"); // This parameter is no longer used
-
-            migrated = migrated | replaceString(configLines[i], ";SetupMode = true", ";SetupMode = false"); // Set it to its default value
-            migrated = migrated | replaceString(configLines[i], ";SetupMode", "SetupMode"); // Enable it
         }
     }
 
     if (migrated) { // At least one replacement happened
-        if (! RenameFile(CONFIG_FILE, CONFIG_FILE_BACKUP)) {
+        if (!RenameFile(CONFIG_FILE, CONFIG_FILE_BACKUP)) {
             LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "Failed to create backup of config file");
             return;
         }

--- a/code/main/main.cpp
+++ b/code/main/main.cpp
@@ -518,7 +518,7 @@ void migrateConfiguration(void)
                 if (section == sectionConfigFile) {
                     if(replaceString(configLines[i], "Version = " + std::to_string(configFileVersion), 
                                                      "Version = " + std::to_string(configFileVersion+1))) {
-                        LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "Migrate config.ini: v" + std::to_string(configFileVersion) + 
+                        LogFile.WriteToFile(ESP_LOG_WARN, TAG, "Config.ini: Migrate v" + std::to_string(configFileVersion) + 
                                                                                 " > v" + std::to_string(configFileVersion+1));
                         migrated = true;
                     }

--- a/code/main/server_main.cpp
+++ b/code/main/server_main.cpp
@@ -177,6 +177,8 @@ esp_err_t handler_get_info(httpd_req_t *req)
             retVal = ESP_FAIL;
         if (cJSON_AddStringToObject(cJSONObject, "build_time", build_time()) == NULL)
             retVal = ESP_FAIL;
+        if (cJSON_AddNumberToObject(cJSONObject, "config_file_version", getConfigFileVersion()) == NULL)
+            retVal = ESP_FAIL;
         if (cJSON_AddStringToObject(cJSONObject, "idf_version", getIDFVersion().c_str()) == NULL)
             retVal = ESP_FAIL;
 

--- a/code/main/server_main.cpp
+++ b/code/main/server_main.cpp
@@ -453,7 +453,7 @@ esp_err_t handler_get_info(httpd_req_t *req)
         return ESP_OK;        
     }
     else if (type.compare("config_file_version") == 0) {
-        httpd_resp_sendstr(req, std::to_string(getConfigFileVersion()));
+        httpd_resp_sendstr(req, std::to_string(getConfigFileVersion()).c_str());
         return ESP_OK;        
     }
     else if (type.compare("idf_version") == 0) {

--- a/code/main/server_main.cpp
+++ b/code/main/server_main.cpp
@@ -34,7 +34,7 @@ extern std::string deviceStartTimestamp;
 
 esp_err_t handler_get_info(httpd_req_t *req)
 {
-    const char* APIName = "info:v2"; // API name and version
+    const char* APIName = "info:v3"; // API name and version
     char _query[200];
     char _valuechar[30];    
     std::string type;
@@ -450,6 +450,10 @@ esp_err_t handler_get_info(httpd_req_t *req)
     }
     else if (type.compare("build_time") == 0) {
         httpd_resp_sendstr(req, build_time());
+        return ESP_OK;        
+    }
+    else if (type.compare("config_file_version") == 0) {
+        httpd_resp_sendstr(req, std::to_string(getConfigFileVersion()));
         return ESP_OK;        
     }
     else if (type.compare("idf_version") == 0) {

--- a/docs/API/REST/info.md
+++ b/docs/API/REST/info.md
@@ -66,6 +66,7 @@ The following infos are available:
 | `firmware_version`                   | MCU Firmware Version                               | `Develop: HEAD (Commit: 3d7fed3)` 
 | `html_version`                       | WebUI / HTML Version                               | `Develop: HEAD (Commit: 3d7fed3)` 
 | `build_time`                         | Firmware Build Time                                | `2024-01-23T21:32:23+0000` 
+| `config_file_version`                | Config File Version (Requested by firmware)        | `1` 
 | `idf_version`                        | Espressif ESP IDF Development Framework Version    | `5.0.2` 
 
 1. JSON:
@@ -128,6 +129,7 @@ The following infos are available:
     "firmware_version": "Develop: HEAD (Commit: 3d7fed3)",
     "html_version": "Develop: HEAD (Commit: 3d7fed3)",
     "build_time": "2024-01-23T21:32:23+0000",
+    "config_file_version": 1,
     "idf_version": "5.0.2"
 }
 ```

--- a/sd-card/config/config.ini
+++ b/sd-card/config/config.ini
@@ -1,3 +1,6 @@
+[ConfigFile]
+Version = 1
+
 [TakeImage]
 ;RawImagesLocation = /log/source
 ;RawImagesRetention = 5

--- a/sd-card/html/info.html
+++ b/sd-card/html/info.html
@@ -450,6 +450,12 @@
 			</td>
 		</tr>
 		<tr>
+			<td>Config File Version</td>
+			<td>
+				<output id="config_file_version"></output>
+			</td>
+		</tr>
+		<tr>
 			<td>ESP-IDF Version</td>
 			<td>
 				<output id="idf_version"></output>
@@ -613,6 +619,7 @@
 				const HTMLVersionString = HTMLVersionSplit[0] + "Commit: <a href=\"https://github.com/Slider0007/AI-on-the-edge-device/commits/" + 
 									HTMLVersionCommit + "\" target=\"_blank\">" + HTMLVersionCommit + "</a>)";
 				document.getElementById("html_version").innerHTML = HTMLVersionString;
+				document.getElementById("config_file_version").value = _jsonData.config_file_version;
 
 				document.getElementById("idf_version").value = _jsonData.idf_version;
 			}

--- a/sd-card/html/readconfigparam.js
+++ b/sd-card/html/readconfigparam.js
@@ -107,8 +107,12 @@ function ParseConfig() {
      config_split = config_gesamt.split("\n");
      var aktline = 0;
 
-     //param = new Object();
-     //category = new Object(); 
+     var catname = "ConfigFile";
+     category[catname] = new Object(); 
+     category[catname]["enabled"] = true;
+     category[catname]["found"] = true;
+     param[catname] = new Object();
+     ParamAddSingleValueWithPreset(param, catname, "Version", true, "0");
 
      var catname = "TakeImage";
      category[catname] = new Object(); 


### PR DESCRIPTION
Implement config file version tag for config.ini to simplify upcoming parameter migration
-> In future only delta between two versions needs to be migrated

config.ini -> new section:
```
[ConfigFile]
Version = 1
```

Note: Usage of generic numeric version tag (not related to firmware version) to avoid unnecessary migration for only maintaining version tag

