### PR TITLE
refactor(source code): Remove trailing whitespaces

### DIFF
--- a/code/components/jomjol_configfile/configFile.h
+++ b/code/components/jomjol_configfile/configFile.h
@@ -15,7 +15,7 @@ class ConfigFile
         bool GetNextParagraph(std::string& aktparamgraph, bool &disabled, bool &eof);
         bool getNextLine(std::string* rt, bool &disabled, bool &eof);
         bool ConfigFileExists() {return pFile;};
-        
+
     private:
         FILE* pFile;
 };

--- a/code/components/jomjol_controlGPIO/GpioControl.cpp
+++ b/code/components/jomjol_controlGPIO/GpioControl.cpp
@@ -29,11 +29,11 @@ static GpioHandler *gpioHandler = NULL;
 QueueHandle_t gpio_queue_handle = NULL;
 
 static const gpio_num_t gpio_spare[] {GPIO_SPARE_1, GPIO_SPARE_2, GPIO_SPARE_3, GPIO_SPARE_4, GPIO_SPARE_5, GPIO_SPARE_6};
-static const char* gpio_spare_usage[] {GPIO_SPARE_1_USAGE, GPIO_SPARE_2_USAGE, GPIO_SPARE_3_USAGE, 
+static const char* gpio_spare_usage[] {GPIO_SPARE_1_USAGE, GPIO_SPARE_2_USAGE, GPIO_SPARE_3_USAGE,
                                         GPIO_SPARE_4_USAGE, GPIO_SPARE_5_USAGE, GPIO_SPARE_6_USAGE};
 
 
-GpioHandler::GpioHandler(std::string _configFileName, httpd_handle_t _httpServer) 
+GpioHandler::GpioHandler(std::string _configFileName, httpd_handle_t _httpServer)
 {
     configFileName = _configFileName;
     httpServer = _httpServer;
@@ -68,10 +68,10 @@ static void gpioHandlerTask(void *arg)
             while(uxQueueMessagesWaiting(gpio_queue_handle)) {
                 GpioResult gpioResult;
                 xQueueReceive(gpio_queue_handle, (void*)&gpioResult, 5);
-                //LogFile.WriteToFile(ESP_LOG_INFO, TAG, "Pin interrupt: GPIO" + std::to_string((int)gpioResult.gpio) + 
+                //LogFile.WriteToFile(ESP_LOG_INFO, TAG, "Pin interrupt: GPIO" + std::to_string((int)gpioResult.gpio) +
                 //                    ", State: " + std::to_string(gpioResult.state));
                 ((GpioHandler*)arg)->gpioPinInterrupt(&gpioResult);
-            }  
+            }
         }
 
         ((GpioHandler*)arg)->gpioInputStatePolling();
@@ -84,7 +84,7 @@ void GpioHandler::gpioInputStatePolling()
 {
     if (gpioMap != NULL) {
         for(std::map<gpio_num_t, GpioPin*>::iterator it = gpioMap->begin(); it != gpioMap->end(); ++it) {
-            if (it->second->getMode() == GPIO_PIN_MODE_INPUT || it->second->getMode() == GPIO_PIN_MODE_INPUT_PULLUP || 
+            if (it->second->getMode() == GPIO_PIN_MODE_INPUT || it->second->getMode() == GPIO_PIN_MODE_INPUT_PULLUP ||
                 it->second->getMode() == GPIO_PIN_MODE_INPUT_PULLDOWN || it->second->getMode() == GPIO_PIN_MODE_TRIGGER_CYCLE_START)
             {
                 it->second->updatePinState();
@@ -96,10 +96,10 @@ void GpioHandler::gpioInputStatePolling()
 
 void GpioHandler::ledcInitGpio(ledc_timer_t _timer, ledc_channel_t _channel, int _gpioNum, int _frequency)
 {
-    LogFile.WriteToFile(ESP_LOG_INFO, TAG, "Init LEDC timer " + std::to_string((int)_timer) + 
-                            ", Frequency: " + std::to_string(_frequency) + 
+    LogFile.WriteToFile(ESP_LOG_INFO, TAG, "Init LEDC timer " + std::to_string((int)_timer) +
+                            ", Frequency: " + std::to_string(_frequency) +
                             ", Duty Resolution: " + std::to_string((int)calcDutyResolution(_frequency)));
-    
+
     // Prepare and then apply the LEDC PWM timer configuration
     ledc_timer_config_t ledc_timer = { };
 
@@ -112,7 +112,7 @@ void GpioHandler::ledcInitGpio(ledc_timer_t _timer, ledc_channel_t _channel, int
     esp_err_t retVal = ledc_timer_config(&ledc_timer);
 
     if (retVal != ESP_OK)
-        LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "Failed to init LEDC timer " + 
+        LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "Failed to init LEDC timer " +
                     std::to_string((int)_timer) + ", Error: " +intToHexString(retVal));
 
     // Prepare and then apply the LEDC PWM channel configuration
@@ -129,7 +129,7 @@ void GpioHandler::ledcInitGpio(ledc_timer_t _timer, ledc_channel_t _channel, int
     retVal = ledc_channel_config(&ledc_channel);
 
     if (retVal != ESP_OK)
-        LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "Failed to init LEDC channel " + 
+        LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "Failed to init LEDC channel " +
                     std::to_string((int)_channel) + ", Error: " +intToHexString(retVal));
 }
 
@@ -151,7 +151,7 @@ bool GpioHandler::init()
         gpioMap = NULL;
         return false;
     }
-    else if (retVal == 0) { // GPIO disabled 
+    else if (retVal == 0) { // GPIO disabled
         return true;
     }
 
@@ -162,9 +162,9 @@ bool GpioHandler::init()
     for(std::map<gpio_num_t, GpioPin*>::iterator it = gpioMap->begin(); it != gpioMap->end(); ++it) {
         it->second->init();
 
-        if (it->second->getMode() == GPIO_PIN_MODE_FLASHLIGHT_SMARTLED) {           
+        if (it->second->getMode() == GPIO_PIN_MODE_FLASHLIGHT_SMARTLED) {
             LogFile.WriteToFile(ESP_LOG_INFO, TAG, "Init SmartLED (Flashlight): GPIO" + std::to_string((int)it->second->getGPIO()));
-            it->second->setSmartLed(new SmartLed(it->second->getLEDType(), it->second->getLEDQuantity(), 
+            it->second->setSmartLed(new SmartLed(it->second->getLEDType(), it->second->getLEDQuantity(),
                                                  it->second->getGPIO(), smartLedChannel, DoubleBuffer));
             smartLedChannel++;
             if (smartLedChannel == detail::CHANNEL_COUNT) {
@@ -208,8 +208,8 @@ bool GpioHandler::init()
         }
 
         // Handler task is only needed to maintain input pin state (interrupt or polling)
-        if (it->second->getMode() == GPIO_PIN_MODE_INPUT || it->second->getMode() == GPIO_PIN_MODE_INPUT_PULLUP || 
-            it->second->getMode() == GPIO_PIN_MODE_INPUT_PULLDOWN || it->second->getMode() == GPIO_PIN_MODE_TRIGGER_CYCLE_START) 
+        if (it->second->getMode() == GPIO_PIN_MODE_INPUT || it->second->getMode() == GPIO_PIN_MODE_INPUT_PULLUP ||
+            it->second->getMode() == GPIO_PIN_MODE_INPUT_PULLDOWN || it->second->getMode() == GPIO_PIN_MODE_TRIGGER_CYCLE_START)
         {
             initHandlerTask = true;
         }
@@ -224,9 +224,9 @@ bool GpioHandler::init()
     // Handler task is only needed to maintain input pin state (interrupt or polling)
     if (initHandlerTask && xHandleTaskGpio == NULL) {
         gpio_queue_handle = xQueueCreate(10, sizeof(GpioResult));
-        BaseType_t xReturned = xTaskCreate(&gpioHandlerTask, "gpioHandlerTask", 3 * 1024, (void *)this, 
+        BaseType_t xReturned = xTaskCreate(&gpioHandlerTask, "gpioHandlerTask", 3 * 1024, (void *)this,
                                             tskIDLE_PRIORITY + 4, &xHandleTaskGpio);
-        
+
         if (xReturned != pdPASS ) {
             LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "Failed to create gpioHandlerTask");
             return false;
@@ -237,9 +237,9 @@ bool GpioHandler::init()
 }
 
 
-int GpioHandler::readConfig() 
+int GpioHandler::readConfig()
 {
-    ConfigFile configFile = ConfigFile(configFileName); 
+    ConfigFile configFile = ConfigFile(configFileName);
     std::string line = "";
     bool disabledLine = false;
     bool eof = false;
@@ -249,7 +249,7 @@ int GpioHandler::readConfig()
     #endif // ENABLE_MQTT
 
     isEnabled = false;
-        
+
     while ((!configFile.GetNextParagraph(line, disabledLine, eof) || (line.compare("[GPIO]") != 0)) && !eof) {}
 
     if (disabledLine || eof) {
@@ -257,9 +257,9 @@ int GpioHandler::readConfig()
         // Special case: Flashlight default uses SmartLED functionality -> init smartLED functionality only
         for (int i= 0; i < GPIO_SPARE_PIN_COUNT; ++i) {
             if (strcmp(gpio_spare_usage[i], FLASHLIGHT_SMARTLED) == 0) {
-                GpioPin* gpioPin = new GpioPin((gpio_num_t)gpio_spare[i], ("gpio" + std::to_string((int)gpio_spare[i])).c_str(), 
-                                        GPIO_PIN_MODE_FLASHLIGHT_SMARTLED, GPIO_INTR_DISABLE, 200, 5000, false, false, "", 
-                                        GPIO_FLASHLIGHT_DEFAULT_SMARTLED_TYPE, GPIO_FLASHLIGHT_DEFAULT_SMARTLED_QUANTITY, 
+                GpioPin* gpioPin = new GpioPin((gpio_num_t)gpio_spare[i], ("gpio" + std::to_string((int)gpio_spare[i])).c_str(),
+                                        GPIO_PIN_MODE_FLASHLIGHT_SMARTLED, GPIO_INTR_DISABLE, 200, 5000, false, false, "",
+                                        GPIO_FLASHLIGHT_DEFAULT_SMARTLED_TYPE, GPIO_FLASHLIGHT_DEFAULT_SMARTLED_QUANTITY,
                                         Rgb{255,255,255}, 100);
                 (*gpioMap)[(gpio_num_t)gpio_spare[i]] = gpioPin;
                 return 1;
@@ -272,7 +272,7 @@ int GpioHandler::readConfig()
 
         return 0;
     }
-    
+
     std::vector<std::string> splitted;
     bool gpioInstallISR = false;
 
@@ -347,8 +347,8 @@ int GpioHandler::readConfig()
             else
                 sprintf(gpioName, "gpio%d", gpioNr);
 
-            #ifdef ENABLE_MQTT 
-                bool mqttAccess = (toUpper(splitted[5]) == "TRUE");           
+            #ifdef ENABLE_MQTT
+                bool mqttAccess = (toUpper(splitted[5]) == "TRUE");
                 std::string mqttTopic = mqttAccess ? (gpioMQTTMainTopic + "/" + gpioName) : "";
             #else
                 bool mqttAccess = false;
@@ -356,16 +356,16 @@ int GpioHandler::readConfig()
             #endif
 
             LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "Pin Config: GPIO" + std::to_string((int)gpioNr) +
-                    ", Name: " + std::string(gpioName) + ", Mode: " + splitted[1] + ", Interrupt Type: " + 
-                    splitted[2] + ", Debounce Time: " + std::to_string(debounceTime) + ", Frequency: " + 
-                    std::to_string(frequency) + ", HTTP Access: " + std::to_string(httpAccess) + 
-                    ", MQTT Access: " + std::to_string(mqttAccess) +", MQTT Topic: " + mqttTopic + 
-                    ", LED Type: " + splitted[7] + ", LED Quantity: " + std::to_string(LEDQuantity) + 
-                    ", LED Color: R:" + std::to_string(LEDColor.r) + " | G:" + std::to_string(LEDColor.g) + 
-                    " | B:" + std::to_string(LEDColor.b) + ", LED Intensity Correction: " + 
+                    ", Name: " + std::string(gpioName) + ", Mode: " + splitted[1] + ", Interrupt Type: " +
+                    splitted[2] + ", Debounce Time: " + std::to_string(debounceTime) + ", Frequency: " +
+                    std::to_string(frequency) + ", HTTP Access: " + std::to_string(httpAccess) +
+                    ", MQTT Access: " + std::to_string(mqttAccess) +", MQTT Topic: " + mqttTopic +
+                    ", LED Type: " + splitted[7] + ", LED Quantity: " + std::to_string(LEDQuantity) +
+                    ", LED Color: R:" + std::to_string(LEDColor.r) + " | G:" + std::to_string(LEDColor.g) +
+                    " | B:" + std::to_string(LEDColor.b) + ", LED Intensity Correction: " +
                     std::to_string(intensityCorrection));
-            
-            GpioPin* gpioPin = new GpioPin(gpioNr, gpioName, pinMode, intType, debounceTime, frequency, httpAccess, 
+
+            GpioPin* gpioPin = new GpioPin(gpioNr, gpioName, pinMode, intType, debounceTime, frequency, httpAccess,
                                     mqttAccess, mqttTopic, LEDType, LEDQuantity, LEDColor, intensityCorrection);
             (*gpioMap)[gpioNr] = gpioPin;
         }
@@ -383,7 +383,7 @@ int GpioHandler::readConfig()
 }
 
 
-void GpioHandler::clear() 
+void GpioHandler::clear()
 {
     if (gpioMap != NULL) {
         for(std::map<gpio_num_t, GpioPin*>::iterator it = gpioMap->begin(); it != gpioMap->end(); ++it) {
@@ -396,7 +396,7 @@ void GpioHandler::clear()
         }
         gpioMap->clear();
     }
-    
+
     frequencyTable.clear();
 
     // gpio_uninstall_isr_service(); can't uninstall, ISR service is also used by camera
@@ -418,7 +418,7 @@ void GpioHandler::deinit()
 }
 
 
-void GpioHandler::gpioFlashlightControl(bool _state, int _intensity) 
+void GpioHandler::gpioFlashlightControl(bool _state, int _intensity)
 {
     if (gpioMap == NULL)
         return;
@@ -426,24 +426,24 @@ void GpioHandler::gpioFlashlightControl(bool _state, int _intensity)
     for (std::map<gpio_num_t, GpioPin*>::iterator it = gpioMap->begin(); it != gpioMap->end(); ++it) {
         if (it->second->getMode() == GPIO_PIN_MODE_FLASHLIGHT_PWM) {
             int dutyResultionMaxValue = calcDutyResultionMaxValue(it->second->getFrequency());
-            int intensityValueCorrected = std::min(std::max(0, it->second->getIntensityCorrection() * 
+            int intensityValueCorrected = std::min(std::max(0, it->second->getIntensityCorrection() *
                                                     _intensity * dutyResultionMaxValue / 10000), dutyResultionMaxValue);
 
             esp_err_t retVal = it->second->setPinState(_state, intensityValueCorrected, GPIO_SET_SOURCE_INTERNAL);
 
             if (retVal != ESP_OK) {
-                LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "Flashlight PWM: GPIO" + std::to_string((int)it->first) + 
+                LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "Flashlight PWM: GPIO" + std::to_string((int)it->first) +
                     " failed to set state | Error: " + intToHexString(retVal));
                 return;
             }
-            
+
             if (_state) {
-                LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "Flashlight PWM: GPIO" + std::to_string((int)it->first) + 
-                                    ", State: " + std::to_string(_state) + ", Intensity: " + std::to_string(intensityValueCorrected) + 
+                LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "Flashlight PWM: GPIO" + std::to_string((int)it->first) +
+                                    ", State: " + std::to_string(_state) + ", Intensity: " + std::to_string(intensityValueCorrected) +
                                     "/" +  std::to_string(dutyResultionMaxValue));
             }
             else {
-                LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "Flashlight PWM: GPIO" + std::to_string((int)it->first) + 
+                LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "Flashlight PWM: GPIO" + std::to_string((int)it->first) +
                                     ", State: " + std::to_string(_state));
             }
         }
@@ -455,15 +455,15 @@ void GpioHandler::gpioFlashlightControl(bool _state, int _intensity)
                 LEDColorIntensityCorrected.r = std::min(std::max(0, (LEDColorIntensityCorrected.r * intensityValueCorrected) / 8191), 255);
                 LEDColorIntensityCorrected.g = std::min(std::max(0, (LEDColorIntensityCorrected.g * intensityValueCorrected) / 8191), 255);
                 LEDColorIntensityCorrected.b = std::min(std::max(0, (LEDColorIntensityCorrected.b * intensityValueCorrected) / 8191), 255);
-  
+
                 for (int i = 0; i < it->second->getLEDQuantity(); ++i) {
                     (*it->second->getSmartLed())[i] = LEDColorIntensityCorrected;
                 }
 
-                LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "Flashlight SmartLED: GPIO" + std::to_string((int)it->first) + 
-                                    ", State: " + std::to_string(_state) + ", Intensity: " + std::to_string(intensityValueCorrected) + 
-                                    "/8191, | R: " + std::to_string(LEDColorIntensityCorrected.r) + 
-                                    ", G:" + std::to_string(LEDColorIntensityCorrected.g) + 
+                LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "Flashlight SmartLED: GPIO" + std::to_string((int)it->first) +
+                                    ", State: " + std::to_string(_state) + ", Intensity: " + std::to_string(intensityValueCorrected) +
+                                    "/8191, | R: " + std::to_string(LEDColorIntensityCorrected.r) +
+                                    ", G:" + std::to_string(LEDColorIntensityCorrected.g) +
                                     ", B:" + std::to_string(LEDColorIntensityCorrected.b));
             }
             else {
@@ -471,7 +471,7 @@ void GpioHandler::gpioFlashlightControl(bool _state, int _intensity)
                     (*it->second->getSmartLed())[i] = Rgb{0, 0, 0};
                 }
 
-                LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "Flashlight SmartLED: GPIO" + std::to_string((int)it->first) + 
+                LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "Flashlight SmartLED: GPIO" + std::to_string((int)it->first) +
                                         ", State: " + std::to_string(_state));
             }
 
@@ -479,7 +479,7 @@ void GpioHandler::gpioFlashlightControl(bool _state, int _intensity)
             it->second->updatePinState(_state ? 1 : 0);
 
             if (retVal != ESP_OK) {
-                LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "Flashlight SmartLED: GPIO" + std::to_string((int)it->first) + 
+                LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "Flashlight SmartLED: GPIO" + std::to_string((int)it->first) +
                 " failed to set state | Error: " + intToHexString(retVal));
             }
         }
@@ -487,17 +487,17 @@ void GpioHandler::gpioFlashlightControl(bool _state, int _intensity)
             esp_err_t retVal = it->second->setPinState(_state, GPIO_SET_SOURCE_INTERNAL);
 
             if (retVal != ESP_OK) {
-                LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "Flashlight Digital: GPIO" + std::to_string((int)it->first) + 
+                LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "Flashlight Digital: GPIO" + std::to_string((int)it->first) +
                     " failed to set state | Error: " + intToHexString(retVal));
                 return;
             }
 
             if (_state) {
-                LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "Flashlight Digital: GPIO" + std::to_string((int)it->first) + 
+                LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "Flashlight Digital: GPIO" + std::to_string((int)it->first) +
                                     ", State: " + std::to_string(_state));
             }
             else {
-                LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "Flashlight Digital: GPIO" + std::to_string((int)it->first) + 
+                LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "Flashlight Digital: GPIO" + std::to_string((int)it->first) +
                                     ", State: " + std::to_string(_state));
             }
         }
@@ -505,7 +505,7 @@ void GpioHandler::gpioFlashlightControl(bool _state, int _intensity)
 }
 
 
-gpio_num_t GpioHandler::resolveSparePinNr(uint8_t _sparePinNr) 
+gpio_num_t GpioHandler::resolveSparePinNr(uint8_t _sparePinNr)
 {
     for (int i = 0; i < GPIO_SPARE_PIN_COUNT; ++i) {
         if (gpio_spare[i] == _sparePinNr)
@@ -515,7 +515,7 @@ gpio_num_t GpioHandler::resolveSparePinNr(uint8_t _sparePinNr)
 }
 
 
-gpio_pin_mode_t GpioHandler::resolvePinMode(std::string input) 
+gpio_pin_mode_t GpioHandler::resolvePinMode(std::string input)
 {
     if (input == "disabled")
         return GPIO_PIN_MODE_DISABLED;
@@ -551,7 +551,7 @@ gpio_pin_mode_t GpioHandler::resolvePinMode(std::string input)
 }
 
 
-std::string GpioHandler::getPinModeDecription(gpio_pin_mode_t _mode) 
+std::string GpioHandler::getPinModeDecription(gpio_pin_mode_t _mode)
 {
     switch(_mode) {
         case 0:
@@ -569,18 +569,18 @@ std::string GpioHandler::getPinModeDecription(gpio_pin_mode_t _mode)
         case 6:
             return FLASHLIGHT_PWM;
         case 7:
-            return FLASHLIGHT_SMARTLED;            
+            return FLASHLIGHT_SMARTLED;
         case 8:
             return FLASHLIGHT_DIGITAL;
         case 9:
             return "trigger-cycle-start";
-        default: 
-            return "disabled";   
+        default:
+            return "disabled";
     }
 }
 
 
-gpio_int_type_t GpioHandler::resolveIntType(std::string input) 
+gpio_int_type_t GpioHandler::resolveIntType(std::string input)
 {
     if ( input == "cyclic-polling" )
         return GPIO_INTR_DISABLE;
@@ -599,7 +599,7 @@ gpio_int_type_t GpioHandler::resolveIntType(std::string input)
 }
 
 
-std::string GpioHandler::getPinInterruptDecription(gpio_int_type_t _type) 
+std::string GpioHandler::getPinInterruptDecription(gpio_int_type_t _type)
 {
     switch(_type) {
         case 0:
@@ -614,8 +614,8 @@ std::string GpioHandler::getPinInterruptDecription(gpio_int_type_t _type)
             return "interrupt-low-level";
         case 5:
             return "interrupt-high-level";
-        default: 
-            return "cyclic-polling";   
+        default:
+            return "cyclic-polling";
     }
 }
 
@@ -639,9 +639,9 @@ ledc_timer_t GpioHandler::getFreeTimer(int _frequency)
     auto it = frequencyTable.find(_frequency);
 
     // Return timer related to already registered frequency
-    if (it != frequencyTable.end()) 
+    if (it != frequencyTable.end())
         return it->second;
-    
+
     // Insert new frequency and return timer
     if (frequencyTable.size() == 0) {
         frequencyTable.insert({_frequency, LEDC_TIMER_1});
@@ -714,10 +714,10 @@ esp_err_t GpioHandler::handleHttpRequest(httpd_req_t *req)
         if (httpd_query_key_value(query, "pwm_duty", value, sizeof(value)) == ESP_OK) {
             requestedPWMDuty = std::stoi(value);
         }
-    } 
+    }
     else {
         httpd_resp_set_type(req, "text/html");
-        httpd_resp_sendstr(req, "Error in call. Use /gpio?gpio=12&state=1");    
+        httpd_resp_sendstr(req, "Error in call. Use /gpio?gpio=12&state=1");
         return ESP_OK;
     }
 
@@ -726,7 +726,7 @@ esp_err_t GpioHandler::handleHttpRequest(httpd_req_t *req)
         esp_err_t retVal = ESP_OK;
         cJSON *cJSONObject, *pins, *pin, *mods, *default_config, *pinModes, *pinInterrupt;
 
-        cJSONObject = cJSON_CreateObject();         
+        cJSONObject = cJSON_CreateObject();
         if (cJSONObject == NULL) {
             httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "E91: Error, JSON object cannot be created");
             return ESP_FAIL;
@@ -734,7 +734,7 @@ esp_err_t GpioHandler::handleHttpRequest(httpd_req_t *req)
 
         if (!cJSON_AddItemToObject(cJSONObject, "default_config", default_config = cJSON_CreateObject()))
             retVal = ESP_FAIL;
-        
+
         if ((pinModes = cJSON_AddArrayToObject(default_config, "gpio_modes")) == NULL)
             retVal = ESP_FAIL;
         for (int i = 1; i < GPIO_PIN_MODE_MAX; ++i) {
@@ -751,11 +751,11 @@ esp_err_t GpioHandler::handleHttpRequest(httpd_req_t *req)
 
         if (!cJSON_AddItemToObject(cJSONObject, "gpio", pins = cJSON_CreateArray()))
             retVal = ESP_FAIL;
-        
+
         for (int i = 0; i < GPIO_SPARE_PIN_COUNT; ++i) {
             if (gpio_spare[i] == GPIO_NUM_NC)   // Skip not usable GPIOs
                 continue;
-            
+
             if (!cJSON_AddItemToArray(pins, pin = cJSON_CreateObject()))
                 retVal = ESP_FAIL;
             if (!cJSON_AddItemToObject(pin, "name", cJSON_CreateNumber(gpio_spare[i])))
@@ -766,7 +766,7 @@ esp_err_t GpioHandler::handleHttpRequest(httpd_req_t *req)
 
         char *jsonString = cJSON_PrintBuffered(cJSONObject, 1024, true); // Print to predefined buffer, avoid dynamic allocations
         std::string sReturnMessage = std::string(jsonString);
-        cJSON_free(jsonString);  
+        cJSON_free(jsonString);
         cJSON_Delete(cJSONObject);
 
         if (retVal == ESP_OK) {
@@ -780,7 +780,7 @@ esp_err_t GpioHandler::handleHttpRequest(httpd_req_t *req)
             return ESP_FAIL;
         }
     }
-    else if (task.compare("get_state") == 0 || task.compare("set_state") == 0) {           
+    else if (task.compare("get_state") == 0 || task.compare("set_state") == 0) {
         if (gpioMap == NULL || !isEnabled) {
             httpd_resp_set_type(req, "text/plain");
             httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST, "GPIO handler not initialized or disabled");
@@ -804,17 +804,17 @@ esp_err_t GpioHandler::handleHttpRequest(httpd_req_t *req)
 
         if  (!(*gpioMap)[gpioNum]->getHttpAccess()) {
             httpd_resp_set_type(req, "text/plain");
-            httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST, "Skip request, HTTP access disabled");        
-            return ESP_FAIL;    
+            httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST, "Skip request, HTTP access disabled");
+            return ESP_FAIL;
         }
 
         if (task.compare("get_state") == 0) {
             requestedGpioState = "{ \"state\": " + std::to_string((*gpioMap)[gpioNum]->getPinState());
-            
+
             if ((*gpioMap)[gpioNum]->getMode() == GPIO_PIN_MODE_OUTPUT_PWM ||
                 (*gpioMap)[gpioNum]->getMode() == GPIO_PIN_MODE_FLASHLIGHT_PWM)
             {
-                requestedGpioState += ", \"pwm_duty\": " + std::to_string(ledc_get_duty(LEDC_LOW_SPEED_MODE, 
+                requestedGpioState += ", \"pwm_duty\": " + std::to_string(ledc_get_duty(LEDC_LOW_SPEED_MODE,
                                                 (*gpioMap)[gpioNum]->getLedcChannel()));
             }
 
@@ -830,30 +830,30 @@ esp_err_t GpioHandler::handleHttpRequest(httpd_req_t *req)
             {
                 respStr = "Skip request, invalid state: " + requestedGpioState;
                 httpd_resp_set_type(req, "text/plain");
-                httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST, respStr.c_str());        
-                return ESP_FAIL;    
+                httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST, respStr.c_str());
+                return ESP_FAIL;
             }
 
             esp_err_t retVal = ESP_OK;
             if (requestedPWMDuty == -1) { // Use ON/OFF
                 retVal = (*gpioMap)[gpioNum]->setPinState(requestedGpioState == "1", GPIO_SET_SOURCE_HTTP);
-                respStr = "GPIO" + std::to_string(requestedGpioNum) + 
+                respStr = "GPIO" + std::to_string(requestedGpioNum) +
                         ", State: " + std::to_string((*gpioMap)[gpioNum]->getPinState());
             }
             else { // Use PWM
                 requestedPWMDuty = std::min(std::max(0, requestedPWMDuty), calcDutyResultionMaxValue((*gpioMap)[gpioNum]->getFrequency()));
-                retVal = (*gpioMap)[gpioNum]->setPinState(requestedGpioState == "1", requestedPWMDuty, GPIO_SET_SOURCE_HTTP); 
-                respStr = "GPIO" + std::to_string(requestedGpioNum) + 
-                        ", State: " + std::to_string((*gpioMap)[gpioNum]->getPinState()) + 
+                retVal = (*gpioMap)[gpioNum]->setPinState(requestedGpioState == "1", requestedPWMDuty, GPIO_SET_SOURCE_HTTP);
+                respStr = "GPIO" + std::to_string(requestedGpioNum) +
+                        ", State: " + std::to_string((*gpioMap)[gpioNum]->getPinState()) +
                         ", PWM Duty: " + std::to_string(requestedPWMDuty);
             }
-            
+
             if (retVal != ESP_OK) {
                 httpd_resp_set_type(req, "text/plain");
                 httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST, "Skip request, wrong GPIO pin mode");
                 return ESP_FAIL;
             }
-            
+
             httpd_resp_set_type(req, "text/plain");
             httpd_resp_sendstr(req, respStr.c_str());
             return ESP_OK;
@@ -864,34 +864,34 @@ esp_err_t GpioHandler::handleHttpRequest(httpd_req_t *req)
         httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST, "E90: Task not found");
         return ESP_FAIL;
     }
-          
-    return ESP_OK;    
+
+    return ESP_OK;
 }
 
 
-void GpioHandler::registerGpioUri() 
+void GpioHandler::registerGpioUri()
 {
     ESP_LOGI(TAG, "Registering URI handlers");
-    
+
     httpd_uri_t camuri = { };
     camuri.method    = HTTP_GET;
     camuri.uri       = "/gpio";
     camuri.handler   = callHandleHttpRequest;
-    camuri.user_ctx  = (void*)this;    
+    camuri.user_ctx  = (void*)this;
     httpd_register_uri_handler(httpServer, &camuri);
 }
 
 
 // GPIO handler interface
 // ***********************************
-void gpio_handler_create(httpd_handle_t _server) 
+void gpio_handler_create(httpd_handle_t _server)
 {
     if (gpioHandler == NULL)
         gpioHandler = new GpioHandler(CONFIG_FILE, _server);
 }
 
 
-bool gpio_handler_init() 
+bool gpio_handler_init()
 {
     if (gpioHandler != NULL) {
         return (gpioHandler->init());

--- a/code/components/jomjol_controlGPIO/GpioControl.h
+++ b/code/components/jomjol_controlGPIO/GpioControl.h
@@ -26,13 +26,13 @@ class GpioHandler
 
         int readConfig();
         void clear();
-        
+
         gpio_num_t resolveSparePinNr(uint8_t _sparePinNr);
         gpio_pin_mode_t resolvePinMode(std::string input);
         std::string getPinModeDecription(gpio_pin_mode_t _mode);
         gpio_int_type_t resolveIntType(std::string input);
         std::string getPinInterruptDecription(gpio_int_type_t _type);
-    
+
     public:
         GpioHandler(std::string _configFileName, httpd_handle_t _httpServer);
         ~GpioHandler();
@@ -45,7 +45,7 @@ class GpioHandler
         ledc_timer_bit_t calcDutyResolution(int frequency);
         ledc_timer_t getFreeTimer(int _frequency);
 
-        void gpioPinInterrupt(GpioResult* gpioResult);  
+        void gpioPinInterrupt(GpioResult* gpioResult);
         void gpioInputStatePolling();
 
         void gpioFlashlightControl(bool _state, int _intensity);

--- a/code/components/jomjol_controlGPIO/GpioPin.cpp
+++ b/code/components/jomjol_controlGPIO/GpioPin.cpp
@@ -22,9 +22,9 @@ extern QueueHandle_t gpio_queue_handle;
 //********************************************************************************
 // GPIO Pin
 //********************************************************************************
-GpioPin::GpioPin(gpio_num_t _gpio, const char* _name, gpio_pin_mode_t _mode, gpio_int_type_t _interruptType, 
-                 int _debounceTime, int _frequency, bool _httpAccess, bool _mqttAccess, std::string _mqttTopic, 
-                 LedType _LEDType, int _LEDQuantity, Rgb _LEDColor, int _intensityCorrection) 
+GpioPin::GpioPin(gpio_num_t _gpio, const char* _name, gpio_pin_mode_t _mode, gpio_int_type_t _interruptType,
+                 int _debounceTime, int _frequency, bool _httpAccess, bool _mqttAccess, std::string _mqttTopic,
+                 LedType _LEDType, int _LEDQuantity, Rgb _LEDColor, int _intensityCorrection)
 {
     gpioISR.gpio = gpio = _gpio;
     name = _name;
@@ -48,7 +48,7 @@ GpioPin::GpioPin(gpio_num_t _gpio, const char* _name, gpio_pin_mode_t _mode, gpi
 GpioPin::~GpioPin()
 {
     LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "Reset GPIO" + std::to_string((int)gpio));
-    
+
     if (interruptType != GPIO_INTR_DISABLE) {
         gpio_isr_handler_remove(gpio);
     }
@@ -71,9 +71,9 @@ static void IRAM_ATTR gpioPinISRHandler(void* arg)
         gpioResult.gpio = ((struct GpioISR*)arg)->gpio;
         gpioResult.state = gpio_get_level(gpioResult.gpio);
         BaseType_t ContextSwitchRequest = pdFALSE;
-    
+
         xQueueSendToBackFromISR(gpio_queue_handle, (void*)&gpioResult, &ContextSwitchRequest);
-    
+
         if (ContextSwitchRequest)
             taskYIELD();
     }
@@ -87,10 +87,10 @@ void GpioPin::init()
     gpio_config_t io_conf;
 
     //set interrupt
-    io_conf.intr_type = mode == GPIO_PIN_MODE_INPUT || mode == GPIO_PIN_MODE_INPUT_PULLUP || 
-                        mode == GPIO_PIN_MODE_INPUT_PULLDOWN || mode == GPIO_PIN_MODE_TRIGGER_CYCLE_START ? 
+    io_conf.intr_type = mode == GPIO_PIN_MODE_INPUT || mode == GPIO_PIN_MODE_INPUT_PULLUP ||
+                        mode == GPIO_PIN_MODE_INPUT_PULLDOWN || mode == GPIO_PIN_MODE_TRIGGER_CYCLE_START ?
                                                                         interruptType : GPIO_INTR_DISABLE;
-    
+
     //set input / output mode
     io_conf.mode = mode == GPIO_PIN_MODE_OUTPUT || mode == GPIO_PIN_MODE_OUTPUT_PWM ||
                    mode == GPIO_PIN_MODE_FLASHLIGHT_PWM || mode == GPIO_PIN_MODE_FLASHLIGHT_SMARTLED ||
@@ -98,20 +98,20 @@ void GpioPin::init()
 
     //bit mask of the pins that you want to set, e.g. GPIO12
     io_conf.pin_bit_mask = (1ULL << gpio);
-    
+
     //set pull-down mode
-    io_conf.pull_down_en = mode == GPIO_PIN_MODE_INPUT_PULLDOWN ? 
+    io_conf.pull_down_en = mode == GPIO_PIN_MODE_INPUT_PULLDOWN ?
                             gpio_pulldown_t::GPIO_PULLDOWN_ENABLE : gpio_pulldown_t::GPIO_PULLDOWN_DISABLE;
-    
+
     //set pull-up mode
-    io_conf.pull_up_en = mode == GPIO_PIN_MODE_INPUT_PULLUP || mode == GPIO_PIN_MODE_TRIGGER_CYCLE_START ? 
+    io_conf.pull_up_en = mode == GPIO_PIN_MODE_INPUT_PULLUP || mode == GPIO_PIN_MODE_TRIGGER_CYCLE_START ?
                             gpio_pullup_t::GPIO_PULLUP_ENABLE : gpio_pullup_t::GPIO_PULLUP_DISABLE;
-    
+
     //configure GPIO with the given settings
     gpio_config(&io_conf);
 
     if (io_conf.intr_type != GPIO_INTR_DISABLE) {
-        LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "Register ISR handler for GPIO" + std::to_string((int)gpioISR.gpio) + 
+        LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "Register ISR handler for GPIO" + std::to_string((int)gpioISR.gpio) +
                                                 ", Debounce time: " + std::to_string(gpioISR.debounceTime));
         gpio_isr_handler_add(gpio, gpioPinISRHandler, (void*)&gpioISR); // Hook ISR handler for specific gpio pin
     }
@@ -121,7 +121,7 @@ void GpioPin::init()
     #ifdef ENABLE_MQTT
     if (mqttAccess && (mode == GPIO_PIN_MODE_OUTPUT || mode == GPIO_PIN_MODE_OUTPUT_PWM)) {
         // Subcribe to [mainTopic]/device/gpio/[GpioName]/ctrl
-        std::function<bool(std::string, char*, int)> func = std::bind(&GpioPin::mqttControlPinState, this, std::placeholders::_1, 
+        std::function<bool(std::string, char*, int)> func = std::bind(&GpioPin::mqttControlPinState, this, std::placeholders::_1,
                                                                         std::placeholders::_2, std::placeholders::_3);
         MQTTregisterSubscribeFunction(mqttTopic + "/ctrl", func);
     }
@@ -138,7 +138,7 @@ void GpioPin::updatePinState(int _state)
     if (newState != pinState) {
         pinState = newState;
 
-        LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "updatePinState: GPIO" + std::to_string((int)gpio) + 
+        LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "updatePinState: GPIO" + std::to_string((int)gpio) +
                     ", State: " + std::to_string(pinState));
 
         if (mode == GPIO_PIN_MODE_TRIGGER_CYCLE_START && pinState == 0) // Pullup enabled, trigger with falling edge / low level
@@ -178,7 +178,7 @@ esp_err_t GpioPin::setPinState(bool _value, int _intensity, gpio_set_source _set
 
     if (_value) {
         ledc_set_duty(LEDC_LOW_SPEED_MODE, ledcChannel, _intensity);
-        ledc_update_duty(LEDC_LOW_SPEED_MODE, ledcChannel); // Apply the new value    
+        ledc_update_duty(LEDC_LOW_SPEED_MODE, ledcChannel); // Apply the new value
     }
     else {
         ledc_set_duty(LEDC_LOW_SPEED_MODE, ledcChannel, 0);
@@ -194,7 +194,7 @@ esp_err_t GpioPin::setPinState(bool _value, int _intensity, gpio_set_source _set
 
 
 int GpioPin::getPinState()
-{   
+{
     return pinState;
 }
 
@@ -213,12 +213,12 @@ bool GpioPin::mqttPublishPinState(int _pwmDuty)
 
         if (cJSON_AddNumberToObject(cJSONObject, "state", pinState) == NULL)
             retVal = false;
-        
+
         if (mode == GPIO_PIN_MODE_OUTPUT_PWM || mode == GPIO_PIN_MODE_FLASHLIGHT_PWM) {
             if (cJSON_AddNumberToObject(cJSONObject, "pwm_duty", _pwmDuty) == NULL)
                 retVal = false;
         }
-        
+
         char *jsonString = cJSON_PrintBuffered(cJSONObject, 256, 1); // Print to predefined buffer, avoid dynamic allocations
         std::string jsonData = std::string(jsonString);
         cJSON_free(jsonString);
@@ -255,9 +255,9 @@ bool GpioPin::mqttControlPinState(std::string _topic, char* _data, int _data_len
             if (retVal == ESP_OK) {
                 cJSON_Delete(jsonData);
                 return true;
-            } 
+            }
             else {
-                LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "mqttControlPinStateHandler: GPIO" + std::to_string((int)gpio) + 
+                LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "mqttControlPinStateHandler: GPIO" + std::to_string((int)gpio) +
                         " failed to set state | Error: " + intToHexString(retVal));
             }
         }
@@ -269,7 +269,7 @@ bool GpioPin::mqttControlPinState(std::string _topic, char* _data, int _data_len
         if (cJSON_IsNumber(pinState)) {    // Check if pinState is a number
             cJSON *pwmDuty = cJSON_GetObjectItemCaseSensitive(jsonData, "pwm_duty");
             if (cJSON_IsNumber(pwmDuty)) {   // Check if pwmDuty is a number
-                LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "mqttControlPinStateHandler: state: " + std::to_string(pinState->valueint) + 
+                LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "mqttControlPinStateHandler: state: " + std::to_string(pinState->valueint) +
                                                                                 ", pwm_duty: " + std::to_string(pwmDuty->valueint));
                 esp_err_t retVal = setPinState(pinState->valueint, pwmDuty->valueint, GPIO_SET_SOURCE_MQTT);
                 if (retVal == ESP_OK) {
@@ -277,7 +277,7 @@ bool GpioPin::mqttControlPinState(std::string _topic, char* _data, int _data_len
                     return true;
                 }
                 else {
-                    LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "mqttControlPinStateHandler: GPIO" + std::to_string((int)gpio) + 
+                    LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "mqttControlPinStateHandler: GPIO" + std::to_string((int)gpio) +
                                         " failed to set state | Error: " + intToHexString(retVal));
                 }
             }
@@ -288,7 +288,7 @@ bool GpioPin::mqttControlPinState(std::string _topic, char* _data, int _data_len
         else {
             LogFile.WriteToFile(ESP_LOG_WARN, TAG, "mqttControlPinStateHandler: state not a valid number (\"state\": 1)");
         }
-        
+
     }
     else {
         LogFile.WriteToFile(ESP_LOG_WARN, TAG, "mqttControlPinStateHandler: Wrong pin mode, GPIO cannot be controlled)");

--- a/code/components/jomjol_controlGPIO/GpioPin.h
+++ b/code/components/jomjol_controlGPIO/GpioPin.h
@@ -67,10 +67,10 @@ class GpioPin
         Rgb LEDColor;
 
         int intensityCorrection;
-    
+
     public:
-        GpioPin(gpio_num_t _gpio, const char* _name, gpio_pin_mode_t _mode, gpio_int_type_t _interruptType, 
-                int _debounceTime, int _frequency, bool _httpAccess, bool _mqttAccess, std::string _mqttTopic, 
+        GpioPin(gpio_num_t _gpio, const char* _name, gpio_pin_mode_t _mode, gpio_int_type_t _interruptType,
+                int _debounceTime, int _frequency, bool _httpAccess, bool _mqttAccess, std::string _mqttTopic,
                 LedType _LEDType, int _LEDQuantity, Rgb _LEDColor, int _intensityCorrection);
         ~GpioPin();
         void init();

--- a/code/components/jomjol_controlcamera/ClassControllCamera.cpp
+++ b/code/components/jomjol_controlcamera/ClassControllCamera.cpp
@@ -29,7 +29,7 @@
 #include "MainFlowControl.h"
 
 
-static const char *TAG = "CAM_CTRL"; 
+static const char *TAG = "CAM_CTRL";
 
 CCamera Camera;
 
@@ -62,7 +62,7 @@ static camera_config_t camera_config = {
     .pin_pclk       = PCLK_GPIO_NUM,
 
     .xclk_freq_hz = 20000000,           // Frequency (20Mhz)
-    
+
     .ledc_timer = LEDC_TIMER_0,
     .ledc_channel = LEDC_CHANNEL_0,
 
@@ -83,7 +83,7 @@ void CCamera::ledcInitFlashlightDefault(void)
     conf.pin_bit_mask = 1LL << GPIO_FLASHLIGHT_DEFAULT;
     conf.mode = GPIO_MODE_OUTPUT;
     gpio_config(&conf);
-    
+
     // Prepare LEDC PWM timer configuration
     ledc_timer_config_t ledc_timer = { };
 
@@ -96,7 +96,7 @@ void CCamera::ledcInitFlashlightDefault(void)
     esp_err_t retVal = ledc_timer_config(&ledc_timer);
 
     if (retVal != ESP_OK)
-        LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "Failed to init LEDC timer " + 
+        LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "Failed to init LEDC timer " +
                     std::to_string((int)FLASHLIGHT_DEFAULT_LEDC_TIMER) + ", Error: " +intToHexString(retVal));
 
     // Prepare LEDC PWM channel configuration
@@ -113,7 +113,7 @@ void CCamera::ledcInitFlashlightDefault(void)
     retVal = ledc_channel_config(&ledc_channel);
 
     if (retVal != ESP_OK)
-        LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "Failed to init LEDC channel " + 
+        LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "Failed to init LEDC channel " +
                     std::to_string((int)FLASHLIGHT_DEFAULT_LEDC_CHANNEL) + ", Error: " +intToHexString(retVal));
 }
 #endif
@@ -178,7 +178,7 @@ esp_err_t CCamera::initCam()
 {
     if (cameraInitSuccessful)
         deinitCam(); // De-init in case it was already initialized
-    
+
     esp_err_t err = esp_camera_init(&camera_config);
     if (err != ESP_OK) {
             LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "Camera init failed: " + intToHexString(err));
@@ -187,7 +187,7 @@ esp_err_t CCamera::initCam()
                 LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "Camera module not found, check camera module and electrical connection");
             else if (err == ESP_ERR_NOT_SUPPORTED)
                 LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "Camera module or feature not supported");
-        
+
         return err;
     }
 
@@ -209,7 +209,7 @@ esp_err_t CCamera::deinitCam()
 }
 
 
-bool CCamera::testCamera(void) 
+bool CCamera::testCamera(void)
 {
     bool retval;
     camera_fb_t *fb = esp_camera_fb_get();
@@ -235,7 +235,7 @@ void CCamera::printCamInfo(void)
     }
     camera_sensor_info_t *info = esp_camera_sensor_get_info(&s->id);
 
-    sprintf(caminfo, "TYPE: %s, PID: 0x%02x, VER: 0x%02x, MIDL: 0x%02x, MIDH: 0x%02x, FREQ: %dMhz", 
+    sprintf(caminfo, "TYPE: %s, PID: 0x%02x, VER: 0x%02x, MIDL: 0x%02x, MIDH: 0x%02x, FREQ: %dMhz",
                 info->name, s->id.PID, s->id.VER, s->id.MIDH, s->id.MIDL, s->xclk_freq_hz/1000000);
     LogFile.WriteToFile(ESP_LOG_INFO, TAG, "Info: " + std::string(caminfo));
 }
@@ -251,13 +251,13 @@ void CCamera::printCamConfig(void)
     if (s == NULL) {
         LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "printCamConfig: Failed to get control structure");
         return;
-    }        
+    }
 
     sprintf(camconfig, "ae_level:%d, aec2:%d, aec:%d, aec_value:%d, agc:%d, agc_gain:%d, awb:%d, awb_gain:%d, "
                 "binning:%d, bpc:%d, brightness:%d, colorbar:%d, contrast:%d, dcw:%d, deonoise:%d, framesize:%d, "
                 "gainceiling:%d, hmirror:%d, lenc:%d, quality:%d, raw_gma:%d, saturation:%d, scale:%d, sharpness:%d, "
-                "special_effect:%d, vflip:%d, wb_mode:%d, wpc:%d", 
-                s->status.ae_level, s->status.aec2, s->status.aec, s->status.aec_value, 
+                "special_effect:%d, vflip:%d, wb_mode:%d, wpc:%d",
+                s->status.ae_level, s->status.aec2, s->status.aec, s->status.aec_value,
                 s->status.agc, s->status.agc_gain, s->status.awb, s->status.awb_gain, s->status.binning,
                 s->status.bpc, s->status.brightness, s->status.colorbar, s->status.contrast, s->status.dcw,
                 s->status.denoise, s->status.framesize, s->status.gainceiling, s->status.hmirror, s->status.lenc,
@@ -319,7 +319,7 @@ void CCamera::setCameraFrequency(int _frequency)
 {
     if (camera_config.xclk_freq_hz == (_frequency * 1000000)) // If frequency is matching, return without any action
         return;
-    
+
     if (_frequency >= 5 && _frequency <= 20)
         camera_config.xclk_freq_hz = _frequency * 1000000;
     else
@@ -370,7 +370,7 @@ void CCamera::setImageWidthHeightFromResolution(framesize_t _resol)
 }
 
 
-void CCamera::setSizeQuality(int _qual, framesize_t _resol, int _zoomMode, 
+void CCamera::setSizeQuality(int _qual, framesize_t _resol, int _zoomMode,
                                 int _zoomOffsetX, int _zoomOffsetY)
 {
     if (!getcameraInitSuccessful())
@@ -445,7 +445,7 @@ void CCamera::setZoom(int _zoomMode, int _zoomOffsetX, int _zoomOffsetY)
         // Maintain max x,y values
         x = std::min(x, maxX);
         y = std::min(y, maxY);
-        
+
         setCamWindow(s, resolMode, x, y, image_width, image_height);
     }
     else {
@@ -454,8 +454,8 @@ void CCamera::setZoom(int _zoomMode, int _zoomOffsetX, int _zoomOffsetY)
 }
 
 
-bool CCamera::setImageManipulation(int _brightness, int _contrast, int _saturation, int _sharpness, int _exposureControlMode, 
-                                   int _autoExposureLevel, int _manualExposureValue, int _gainControlMode, 
+bool CCamera::setImageManipulation(int _brightness, int _contrast, int _saturation, int _sharpness, int _exposureControlMode,
+                                   int _autoExposureLevel, int _manualExposureValue, int _gainControlMode,
                                    int _manualGainValue, int _specialEffect, bool _mirror, bool _flip)
 {
     if (!getcameraInitSuccessful())
@@ -485,7 +485,7 @@ bool CCamera::setImageManipulation(int _brightness, int _contrast, int _saturati
     s->set_contrast(s, std::min(2, std::max(-2, camParameter.contrast )));       // [-2 .. 2]
     s->set_brightness(s, std::min(2, std::max(-2, camParameter.brightness)));   // [-2 .. 2] (IMPORTANT: Apply brightness after saturation and conrast)
     s->set_sharpness(s, 0); // Default: Sharpness not supported, use owm implementation
-    
+
     // Set special effect (0: None, 1: Negative, 2: Grayscale, 3: Reddish, 4: Greenish, 5: Blueish, 6: Sepia)
     if (camParameter.specialEffect >= 0 && camParameter.specialEffect <= 6)
         s->set_special_effect(s, camParameter.specialEffect); // [0 .. 6]
@@ -500,7 +500,7 @@ bool CCamera::setImageManipulation(int _brightness, int _contrast, int _saturati
 
     // Auto exposure control
     s->set_exposure_ctrl(s, camParameter.exposureControlMode > 0 ? 1 : 0); // Enable auto exposure control
-    
+
     if (s->status.aec) { // Auto exposure control --> Use exposure level correction
         s->set_ae_level(s, std:: min(2, std::max(-2, camParameter.autoExposureLevel))); // Adjust auto exposure level [-2 .. 2]
         s->set_aec2(s, camParameter.exposureControlMode == 2 ? 1 : 0); // Switch to alternative auto exposure control alogrithm
@@ -535,9 +535,9 @@ bool CCamera::setImageManipulation(int _brightness, int _contrast, int _saturati
         // Sharpness implementation (not officially supported)
         if (camParameter.sharpness > -4) { // Sharpness == -4 -> Auto sharpness
             ov2640_set_sharpness(s, std::min(3, std::max(-3, std::min(camParameter.sharpness, 3)))); // -3 .. 3
-        } 
+        }
         else {
-            ov2640_enable_auto_sharpness(s);    
+            ov2640_enable_auto_sharpness(s);
         }
 
         // Enable brightness, contrast, saturation and optional special effects
@@ -548,7 +548,7 @@ bool CCamera::setImageManipulation(int _brightness, int _contrast, int _saturati
         //s->set_reg(s, OV2640_IRA_BPDATA, 0xFF, 0x80); // Optional feature - hue setting: Hue value 0 - 255
 
         int registerValue = 0x07; // Set bit 0, 1, 2 to enable saturation, contrast, brightness and hue control
-        
+
         // Bitwise OR of special effect enable bits
         if (camParameter.specialEffect == 1) { // Sepcial effect: 1: negative
             registerValue |= 0x40;
@@ -571,7 +571,7 @@ bool CCamera::setImageManipulation(int _brightness, int _contrast, int _saturati
     }
     else {
         LogFile.WriteToFile(ESP_LOG_WARN, TAG, "setImageManipulation: Camera model not fully supported. "
-                            "Sharpness, brightness, contrast, saturation and special effects not properly set"); 
+                            "Sharpness, brightness, contrast, saturation and special effects not properly set");
     }
 
     return true;
@@ -628,11 +628,11 @@ esp_err_t CCamera::captureToBasisImage(CImageBasis *_Image)
     }
 
     camera_fb_t * fb = esp_camera_fb_get();
-    esp_camera_fb_return(fb);        
+    esp_camera_fb_return(fb);
     fb = esp_camera_fb_get();
 
     if (camParameter.flashTime > 0) {    // Switch off if flashlight was on
-        setStatusLED(false);  
+        setStatusLED(false);
         setFlashlight(false);
     }
 
@@ -664,9 +664,9 @@ esp_err_t CCamera::captureToBasisImage(CImageBasis *_Image)
     else {
         LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "captureToBasisImage: rawImage not allocated");
     }
-    esp_camera_fb_return(fb);        
+    esp_camera_fb_return(fb);
 
-    return ESP_OK;    
+    return ESP_OK;
 }
 
 
@@ -689,7 +689,7 @@ esp_err_t CCamera::captureToFile(std::string _nm)
     fb = esp_camera_fb_get();
 
     if (camParameter.flashTime > 0) {    // Switch off if flashlight was on
-        setStatusLED(false);    
+        setStatusLED(false);
         setFlashlight(false);
     }
 
@@ -698,7 +698,7 @@ esp_err_t CCamera::captureToFile(std::string _nm)
         return ESP_FAIL;
     }
 
-    #ifdef DEBUG_DETAIL_ON    
+    #ifdef DEBUG_DETAIL_ON
         ESP_LOGD(TAG, "w %d, h %d, size %d", fb->width, fb->height, fb->len);
     #endif
 
@@ -715,8 +715,8 @@ esp_err_t CCamera::captureToFile(std::string _nm)
     #endif
 
     uint8_t * buf = NULL;
-    size_t buf_len = 0;   
-    bool converted = false; 
+    size_t buf_len = 0;
+    bool converted = false;
 
     if (ftype.compare("BMP") == 0) {
         frame2bmp(fb, &buf, &buf_len);
@@ -729,7 +729,7 @@ esp_err_t CCamera::captureToFile(std::string _nm)
             if (!jpeg_converted) {
                 ESP_LOGE(TAG, "JPEG compression failed");
             }
-        } 
+        }
         else {
             buf_len = fb->len;
             buf = fb->buf;
@@ -748,14 +748,14 @@ esp_err_t CCamera::captureToFile(std::string _nm)
         // Set buffer to SD card allocation size of 512 byte (newlib default: 128 byte) -> reduce system read/write calls
         setvbuf(fp, NULL, _IOFBF, 512);
 
-        fwrite(buf, sizeof(uint8_t), buf_len, fp); 
+        fwrite(buf, sizeof(uint8_t), buf_len, fp);
         fclose(fp);
-    }   
+    }
 
     if (converted)
         free(buf);
 
-    return retVal;    
+    return retVal;
 }
 
 
@@ -781,7 +781,7 @@ esp_err_t CCamera::captureToHTTP(httpd_req_t *_req)
 {
     if (!getcameraInitSuccessful())
         return ESP_FAIL;
-    
+
     esp_err_t res = ESP_OK;
     size_t fb_len = 0;
     int64_t fr_start = esp_timer_get_time();
@@ -797,7 +797,7 @@ esp_err_t CCamera::captureToHTTP(httpd_req_t *_req)
     fb = esp_camera_fb_get();
 
     if (camParameter.flashTime > 0) {    // Switch off if flashlight was on
-        setStatusLED(false); 
+        setStatusLED(false);
         setFlashlight(false);
     }
 
@@ -806,7 +806,7 @@ esp_err_t CCamera::captureToHTTP(httpd_req_t *_req)
         httpd_resp_send_500(_req);
         return ESP_FAIL;
     }
-  
+
     res = httpd_resp_set_type(_req, "image/jpeg");
     if (res == ESP_OK) {
         res = httpd_resp_set_hdr(_req, "Content-Disposition", "inline; filename=raw.jpg");
@@ -824,7 +824,7 @@ esp_err_t CCamera::captureToHTTP(httpd_req_t *_req)
             if (fb->format == PIXFORMAT_JPEG) {
                 fb_len = fb->len;
                 res = httpd_resp_send(_req, (const char *)fb->buf, fb->len);
-            } 
+            }
             else {
                 jpg_chunking_t jchunk = {_req, 0};
                 res = frame2jpg_cb(fb, 80, jpg_encode_stream, &jchunk)?ESP_OK:ESP_FAIL;
@@ -834,7 +834,7 @@ esp_err_t CCamera::captureToHTTP(httpd_req_t *_req)
         }
     }
     esp_camera_fb_return(fb);
-    
+
     int64_t fr_end = esp_timer_get_time();
     ESP_LOGI(TAG, "JPG: %dKB %dms", (int)(fb_len/1024), (int)((fr_end - fr_start)/1000));
 
@@ -846,7 +846,7 @@ esp_err_t CCamera::captureToStream(httpd_req_t *_req, bool _flashlightOn)
 {
     if (!getcameraInitSuccessful())
         return ESP_FAIL;
-    
+
     esp_err_t res = ESP_OK;
     size_t fb_len = 0;
     int64_t fr_start;
@@ -874,7 +874,7 @@ esp_err_t CCamera::captureToStream(httpd_req_t *_req, bool _flashlightOn)
             break;
         }
         fb_len = fb->len;
-   
+
         if (res == ESP_OK) {
             size_t hlen = snprintf((char *)part_buf, sizeof(part_buf), _STREAM_PART, fb_len);
             res = httpd_resp_send_chunk(_req, (const char *)part_buf, hlen);
@@ -885,7 +885,7 @@ esp_err_t CCamera::captureToStream(httpd_req_t *_req, bool _flashlightOn)
         if (res == ESP_OK) {
             res = httpd_resp_send_chunk(_req, _STREAM_BOUNDARY, strlen(_STREAM_BOUNDARY));
         }
-        
+
         esp_camera_fb_return(fb);
 
         int64_t fr_end = esp_timer_get_time();
@@ -899,7 +899,7 @@ esp_err_t CCamera::captureToStream(httpd_req_t *_req, bool _flashlightOn)
         if (CAM_LIVESTREAM_REFRESHRATE > fr_delta_ms) {
             const TickType_t xDelay = (CAM_LIVESTREAM_REFRESHRATE - fr_delta_ms)  / portTICK_PERIOD_MS;
             ESP_LOGD(TAG, "Stream: sleep for: %ldms", (long) xDelay*10);
-            vTaskDelay(xDelay);        
+            vTaskDelay(xDelay);
         }
     }
 
@@ -927,25 +927,25 @@ void CCamera::setFlashlight(bool _status)
         #ifdef GPIO_FLASHLIGHT_DEFAULT_USE_PWM
             if (_status) {
                 int intensityValue = (camParameter.flashIntensity * FLASHLIGHT_DEFAULT_RESOLUTION_RANGE) / 100;
-                LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "Default flashlight PWM: GPIO" + 
-                                    std::to_string((int)GPIO_FLASHLIGHT_DEFAULT) + ", State: 1, Intensity: " + 
+                LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "Default flashlight PWM: GPIO" +
+                                    std::to_string((int)GPIO_FLASHLIGHT_DEFAULT) + ", State: 1, Intensity: " +
                                     std::to_string(intensityValue) + "/" +  std::to_string(FLASHLIGHT_DEFAULT_RESOLUTION_RANGE));
-                
+
                 ledc_set_duty(LEDC_LOW_SPEED_MODE, FLASHLIGHT_DEFAULT_LEDC_CHANNEL, intensityValue);
                 ledc_update_duty(LEDC_LOW_SPEED_MODE, FLASHLIGHT_DEFAULT_LEDC_CHANNEL); // Update duty to apply the new value
             }
             else {
-                LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "Default flashlight PWM: GPIO" + 
+                LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "Default flashlight PWM: GPIO" +
                                     std::to_string((int)GPIO_FLASHLIGHT_DEFAULT) + ", State: 0");
-                
+
                 ledc_set_duty(LEDC_LOW_SPEED_MODE, FLASHLIGHT_DEFAULT_LEDC_CHANNEL, 0);
                 ledc_update_duty(LEDC_LOW_SPEED_MODE, FLASHLIGHT_DEFAULT_LEDC_CHANNEL);
             }
         #else
             esp_rom_gpio_pad_select_gpio(GPIO_FLASHLIGHT_DEFAULT); // Init the GPIO
-            gpio_set_direction(GPIO_FLASHLIGHT_DEFAULT, GPIO_MODE_OUTPUT); // Set the GPIO as a push/pull output 
+            gpio_set_direction(GPIO_FLASHLIGHT_DEFAULT, GPIO_MODE_OUTPUT); // Set the GPIO as a push/pull output
 
-            if (_status)  
+            if (_status)
                 gpio_set_level(GPIO_FLASHLIGHT_DEFAULT, 1);
             else
                 gpio_set_level(GPIO_FLASHLIGHT_DEFAULT, 0);
@@ -961,12 +961,12 @@ void CCamera::setStatusLED(bool _status)
         // Init the GPIO
         esp_rom_gpio_pad_select_gpio(GPIO_STATUS_LED_ONBOARD);
         /* Set the GPIO as a push/pull output */
-        gpio_set_direction(GPIO_STATUS_LED_ONBOARD, GPIO_MODE_OUTPUT);  
+        gpio_set_direction(GPIO_STATUS_LED_ONBOARD, GPIO_MODE_OUTPUT);
 
-        if (!_status)  
+        if (!_status)
             gpio_set_level(GPIO_STATUS_LED_ONBOARD, 1);
         else
-            gpio_set_level(GPIO_STATUS_LED_ONBOARD, 0);   
+            gpio_set_level(GPIO_STATUS_LED_ONBOARD, 0);
     }
 }
 
@@ -984,13 +984,13 @@ framesize_t CCamera::textToFramesize(const char * _size)
     else if (strcmp(_size, "SXGA") == 0)
         return FRAMESIZE_SXGA;     // 1280x1024
     else if (strcmp(_size, "UXGA") == 0)
-        return FRAMESIZE_UXGA;     // 1600x1200  
+        return FRAMESIZE_UXGA;     // 1600x1200
 
     return camParameter.actualResolution;
 }
 
 
-bool CCamera::getcameraInitSuccessful() 
+bool CCamera::getcameraInitSuccessful()
 {
     return cameraInitSuccessful;
 }
@@ -1019,10 +1019,10 @@ void CCamera::enableDemoMode()
         line[strlen(line) - 1] = '\0';
         demoFiles.push_back(line);
     }
-    
+
     fclose(fd);
 
-    LogFile.WriteToFile(ESP_LOG_INFO, TAG, "Using demo images (" + std::to_string(demoFiles.size()) + 
+    LogFile.WriteToFile(ESP_LOG_INFO, TAG, "Using demo images (" + std::to_string(demoFiles.size()) +
             " files) instead of real camera image");
 
     /*// Print all file to log

--- a/code/components/jomjol_controlcamera/ClassControllCamera.h
+++ b/code/components/jomjol_controlcamera/ClassControllCamera.h
@@ -49,7 +49,7 @@ class CCamera
 
     public:
         int image_height, image_width;
-        
+
         CCamera();
         ~CCamera();
         void freeMemoryOnly();
@@ -60,7 +60,7 @@ class CCamera
         void printCamInfo(void);
         void printCamConfig(void);
         bool getcameraInitSuccessful();
-        
+
         CameraParameter getCameraParameter();
         std::string getCamType(void);
         std::string getCamPID(void);
@@ -84,8 +84,8 @@ class CCamera
         void setCameraFrequency(int _frequency);
         void setSizeQuality(int _qual, framesize_t _resol, int _zoomMode, int _zoomOffsetX, int _zoomOffsetY);
         void setZoom(int _zoomMode, int _zoomOffsetX, int _zoomOffsetY);
-        bool setImageManipulation(int _brightness, int _contrast, int _saturation, int _sharpness, int _exposureControlMode, 
-                                  int _autoExposureLevel, int _manualExposureValue, int _gainControlMode, int _manualGainValue, 
+        bool setImageManipulation(int _brightness, int _contrast, int _saturation, int _sharpness, int _exposureControlMode,
+                                  int _autoExposureLevel, int _manualExposureValue, int _gainControlMode, int _manualGainValue,
                                   int _specialEffect, bool _mirror, bool _flip);
         bool setMirrorFlip(bool _mirror, bool _flip);
 

--- a/code/components/jomjol_controlcamera/ov2640_sharpness.cpp
+++ b/code/components/jomjol_controlcamera/ov2640_sharpness.cpp
@@ -101,14 +101,14 @@ static bool table_mask_write(sensor_t *_sensor, const uint8_t* _ptab)
         return false;
 
     while (1)
-    {   
+    {
         address = *pdata++;
         value = *pdata++;
         mask = *pdata++;
         if ((address == 0) && (value == 0) && (mask == 0))
             break;
         _sensor->set_reg(_sensor, address, mask, value);
-    }   
+    }
 
     return true;
 }

--- a/code/components/jomjol_controlcamera/server_camera.cpp
+++ b/code/components/jomjol_controlcamera/server_camera.cpp
@@ -23,7 +23,7 @@ esp_err_t handler_camera(httpd_req_t *req)
     int flashtime = 0;
 
     // Default usage message when handler gets called without any parameter
-    const std::string RESTUsageInfo = 
+    const std::string RESTUsageInfo =
         "Handler usage:<br>"
         "1. Set camera parameter:<br>"
         "-  '/camera?task=set_parameter&flashtime=0.1&flashintensity=1&brightness=-2&contrast=0& "
@@ -45,7 +45,7 @@ esp_err_t handler_camera(httpd_req_t *req)
         if (httpd_query_key_value(_query, "task", _valuechar, sizeof(_valuechar)) == ESP_OK) {
             task = std::string(_valuechar);
         }
-        if (httpd_query_key_value(_query, "flashtime", _flashtime, sizeof(_flashtime)) == ESP_OK) {     
+        if (httpd_query_key_value(_query, "flashtime", _flashtime, sizeof(_flashtime)) == ESP_OK) {
             flashtime = std::max(0, atoi(_flashtime));
         }
         if (httpd_query_key_value(_query, "filename", _filename, sizeof(_filename)) == ESP_OK) {
@@ -60,11 +60,11 @@ esp_err_t handler_camera(httpd_req_t *req)
 
     if (task.compare("api_name") == 0) {
         httpd_resp_sendstr(req, APIName);
-        return ESP_OK;        
-    }  
+        return ESP_OK;
+    }
     else if (task.compare("set_parameter") == 0) {
         if (!Camera.getcameraInitSuccessful()) {
-            httpd_resp_send_err(req, HTTPD_403_FORBIDDEN, 
+            httpd_resp_send_err(req, HTTPD_403_FORBIDDEN,
                                 "Camera not initialized: REST API /lighton not available");
             return ESP_ERR_NOT_FOUND;
         }
@@ -108,11 +108,11 @@ esp_err_t handler_camera(httpd_req_t *req)
             camParameter.specialEffect = stoi(std::string(_valuechar));
         }
         if (httpd_query_key_value(_query, "mirror", _valuechar, sizeof(_valuechar)) == ESP_OK) {
-            (std::string(_valuechar) == "1" || std::string(_valuechar) == "true") ? 
+            (std::string(_valuechar) == "1" || std::string(_valuechar) == "true") ?
                 camParameter.mirrorImage = true : camParameter.mirrorImage = false;
         }
         if (httpd_query_key_value(_query, "flip", _valuechar, sizeof(_valuechar)) == ESP_OK) {
-            (std::string(_valuechar) == "1" || std::string(_valuechar) == "true") ? 
+            (std::string(_valuechar) == "1" || std::string(_valuechar) == "true") ?
                 camParameter.flipImage = true : camParameter.flipImage = false;
         }
         if (httpd_query_key_value(_query, "zoommode", _valuechar, sizeof(_valuechar)) == ESP_OK) {
@@ -128,9 +128,9 @@ esp_err_t handler_camera(httpd_req_t *req)
         Camera.setFlashIntensity(camParameter.flashIntensity);
         Camera.setFlashTime(camParameter.flashTime);
         Camera.setZoom(camParameter.zoomMode, camParameter.zoomOffsetX, camParameter.zoomOffsetY);
-        Camera.setImageManipulation(camParameter.brightness, camParameter.contrast, camParameter.saturation, 
-                                    camParameter.sharpness, camParameter.exposureControlMode, camParameter.autoExposureLevel, 
-                                    camParameter.manualExposureValue, camParameter.gainControlMode, camParameter.manualGainValue, 
+        Camera.setImageManipulation(camParameter.brightness, camParameter.contrast, camParameter.saturation,
+                                    camParameter.sharpness, camParameter.exposureControlMode, camParameter.autoExposureLevel,
+                                    camParameter.manualExposureValue, camParameter.gainControlMode, camParameter.manualGainValue,
                                     camParameter.specialEffect, camParameter.mirrorImage, camParameter.flipImage);
 
         httpd_resp_sendstr(req, "001: Camera parameter set");
@@ -147,12 +147,12 @@ esp_err_t handler_camera(httpd_req_t *req)
         }
         else {
             httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "E91: Camera capture error");
-        } 
-        return result;        
+        }
+        return result;
     }
     else if (task.compare("capture_with_flashlight") == 0) {
         if (flashtime == 0) {
-            httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST, 
+            httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST,
                 "E93: No flashtime provided, e.g. '/capture?task=capture_with_flashlight&flashtime=1000'");
             return ESP_FAIL;
         }
@@ -167,19 +167,19 @@ esp_err_t handler_camera(httpd_req_t *req)
         }
         else {
             httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "E91: Camera capture error");
-        } 
+        }
 
         return result;
     }
     else if (task.compare("capture_to_file") == 0) {
         if (flashtime == 0) {
-            httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST, 
+            httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST,
                 "E93: No flashtime provided, e.g. '/capture?task=capture_to_file&flashtime=1000&filename=/img_tmp/test.jpg'");
             return ESP_FAIL;
         }
 
         if (fn.compare("/sdcard/") == 0) {
-            httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST, 
+            httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST,
                 "E94: No destination provided, e.g. '/capture?task=capture_to_file&flashtime=1000&filename=/img_tmp/test.jpg'");
             return ESP_FAIL;
         }
@@ -194,18 +194,18 @@ esp_err_t handler_camera(httpd_req_t *req)
         }
         else {
             httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "E91: Camera capture error");
-        } 
+        }
         return result;
     }
     else if (task.compare("flashlight_on") == 0) {
         Camera.setFlashlight(true);
         httpd_resp_sendstr(req, "005: Flashlight on");
-        return ESP_OK;        
+        return ESP_OK;
     }
     else if (task.compare("flashlight_off") == 0) {
         Camera.setFlashlight(false);
         httpd_resp_sendstr(req, "006: Flashlight off");
-        return ESP_OK;        
+        return ESP_OK;
     }
     else if (task.compare("stream") == 0) {
         Camera.captureToStream(req, false);
@@ -230,9 +230,9 @@ void register_server_camera_uri(httpd_handle_t server)
 
     httpd_uri_t camuri = { };
     camuri.method    = HTTP_GET;
-  
+
     camuri.uri       = "/camera";
     camuri.handler   = handler_camera;
-    camuri.user_ctx  = NULL; 
+    camuri.user_ctx  = NULL;
     httpd_register_uri_handler(server, &camuri);
 }

--- a/code/components/jomjol_fileserver_ota/server_file.cpp
+++ b/code/components/jomjol_fileserver_ota/server_file.cpp
@@ -52,7 +52,7 @@ esp_err_t get_data_file_handler(httpd_req_t *req)
 
     std::string _filename, _fileext;
     size_t pos = 0;
-    
+
     const char verz_name[] = "/sdcard/log/data";
 
     httpd_resp_set_hdr(req, "Access-Control-Allow-Origin", "*");
@@ -60,7 +60,7 @@ esp_err_t get_data_file_handler(httpd_req_t *req)
     httpd_resp_set_type(req, "text/plain");
 
     DIR *dir = opendir(verz_name);
-    while ((entry = readdir(dir)) != NULL) 
+    while ((entry = readdir(dir)) != NULL)
     {
         _filename = std::string(entry->d_name);
         ESP_LOGD(TAG, "File: %s", _filename.c_str());
@@ -96,7 +96,7 @@ esp_err_t get_tflite_file_handler(httpd_req_t *req)
 
     std::string _filename, _fileext;
     size_t pos = 0;
-    
+
     const char verz_name[] = "/sdcard/config";
 
     httpd_resp_set_hdr(req, "Access-Control-Allow-Origin", "*");
@@ -104,7 +104,7 @@ esp_err_t get_tflite_file_handler(httpd_req_t *req)
     httpd_resp_set_type(req, "text/plain");
 
     DIR *dir = opendir(verz_name);
-    while ((entry = readdir(dir)) != NULL) 
+    while ((entry = readdir(dir)) != NULL)
     {
         _filename = std::string(entry->d_name);
         ESP_LOGD(TAG, "File: %s", _filename.c_str());
@@ -162,7 +162,7 @@ static esp_err_t send_logfile(httpd_req_t *req, bool send_full_file)
     if (!send_full_file) { // Send only last part of file
         ESP_LOGD(TAG, "Sending last %d bytes of the actual logfile", LOGFILE_LAST_PART_BYTES);
         long pos = 0;
-        
+
         /* Adapted from https://www.geeksforgeeks.org/implement-your-own-tail-read-last-n-lines-of-a-huge-file/ */
         if (fseek(fd, 0, SEEK_END)) {
             LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "send_logfile: Failed to get to end of file");
@@ -173,10 +173,10 @@ static esp_err_t send_logfile(httpd_req_t *req, bool send_full_file)
             ESP_LOGD(TAG, "File contains %ld bytes", pos);
 
             // Calc start position -> either beginning of LAST PART (EOF - LAST_PART_BYTES) or beginning of file (pos = 0)
-            pos = pos - std::min((long)LOGFILE_LAST_PART_BYTES, pos); 
+            pos = pos - std::min((long)LOGFILE_LAST_PART_BYTES, pos);
 
             if (fseek(fd, pos, SEEK_SET)) { // Go to start position
-                LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "send_logfile: Failed to go back " + 
+                LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "send_logfile: Failed to go back " +
                                     std::to_string(std::min((long)LOGFILE_LAST_PART_BYTES, pos)) + " bytes within the file");
                 return ESP_FAIL;
             }
@@ -227,17 +227,17 @@ static esp_err_t handler_logfiles(httpd_req_t *req)
 {
     const char* APIName = "log:v2"; // API name and version
     char _query[100];
-    char _valuechar[30];    
+    char _valuechar[30];
     std::string type;
 
-    if (httpd_req_get_url_query_str(req, _query, sizeof(_query)) == ESP_OK) {        
+    if (httpd_req_get_url_query_str(req, _query, sizeof(_query)) == ESP_OK) {
         if (httpd_query_key_value(_query, "type", _valuechar, sizeof(_valuechar)) == ESP_OK) {
             type = std::string(_valuechar);
         }
     }
 
     if (type.empty()) {
-        return send_logfile(req, false);    
+        return send_logfile(req, false);
     }
     else if (type.compare("full") == 0) {
         return send_logfile(req, true);
@@ -246,7 +246,7 @@ static esp_err_t handler_logfiles(httpd_req_t *req)
         httpd_resp_set_hdr(req, "Access-Control-Allow-Origin", "*");
         httpd_resp_set_type(req, "text/plain");
         httpd_resp_sendstr(req, APIName);
-        return ESP_OK;        
+        return ESP_OK;
     }
     else {
         httpd_resp_set_hdr(req, "Access-Control-Allow-Origin", "*");
@@ -293,17 +293,17 @@ static esp_err_t send_datafile(httpd_req_t *req, bool send_full_file)
             ESP_LOGD(TAG, "File contains %ld bytes", pos);
 
             // Calc start position -> either beginning of LAST PART (EOF - LAST_PART_BYTES) or beginning of file (pos = 0)
-            pos = pos - std::min((long)LOGFILE_LAST_PART_BYTES, pos); 
+            pos = pos - std::min((long)LOGFILE_LAST_PART_BYTES, pos);
 
             if (fseek(fd, pos, SEEK_SET)) { // Go to start position
-                LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "send_datafile: Failed to go back " + 
+                LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "send_datafile: Failed to go back " +
                                     std::to_string(std::min((long)LOGFILE_LAST_PART_BYTES, pos)) + " bytes within the file");
                 return ESP_FAIL;
             }
         }
 
         /* Find end of line */
-        while (pos > 0) { // Only search end of line if pos is pointing to "beginning of LAST PART" 
+        while (pos > 0) { // Only search end of line if pos is pointing to "beginning of LAST PART"
                           // (skip if start is from beginning of file to ensure first line is included)
             if (fgetc(fd) == '\n') {
                 break;
@@ -347,17 +347,17 @@ static esp_err_t handler_datafiles(httpd_req_t *req)
 {
     const char* APIName = "data:v2"; // API name and version
     char _query[100];
-    char _valuechar[30];    
+    char _valuechar[30];
     std::string type;
 
-    if (httpd_req_get_url_query_str(req, _query, sizeof(_query)) == ESP_OK) {        
+    if (httpd_req_get_url_query_str(req, _query, sizeof(_query)) == ESP_OK) {
         if (httpd_query_key_value(_query, "type", _valuechar, sizeof(_valuechar)) == ESP_OK) {
             type = std::string(_valuechar);
         }
     }
 
     if (type.empty()) {
-        return send_datafile(req, false);    
+        return send_datafile(req, false);
     }
     else if (type.compare("full") == 0) {
         return send_datafile(req, true);
@@ -366,7 +366,7 @@ static esp_err_t handler_datafiles(httpd_req_t *req)
         httpd_resp_set_hdr(req, "Access-Control-Allow-Origin", "*");
         httpd_resp_set_type(req, "text/plain");
         httpd_resp_sendstr(req, APIName);
-        return ESP_OK;        
+        return ESP_OK;
     }
     else {
         httpd_resp_set_hdr(req, "Access-Control-Allow-Origin", "*");
@@ -452,7 +452,7 @@ static esp_err_t http_resp_dir_html(httpd_req_t *req, const char *dirpath, const
 
     std::string _zw = std::string(dirpath);
     _zw = _zw.substr(8, _zw.length() - 8);
-    _zw = "/delete/" + _zw + "?task=deldircontent"; 
+    _zw = "/delete/" + _zw + "?task=deldircontent";
 
 
     /* Send file-list table definition and column labels */
@@ -479,7 +479,7 @@ static esp_err_t http_resp_dir_html(httpd_req_t *req, const char *dirpath, const
             strlcpy(entrypath + dirpath_len, entry->d_name, sizeof(entrypath) - dirpath_len);
             ESP_LOGD(TAG, "Entrypath: %s", entrypath);
             if (stat(entrypath, &entry_stat) == -1) {
-                LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "http_resp_dir_html: Failed to read " + 
+                LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "http_resp_dir_html: Failed to read " +
                                     std::string(entrytype) + ": " + std::string(entry->d_name));
                 continue;
             }
@@ -546,7 +546,7 @@ static esp_err_t download_get_handler(httpd_req_t *req)
     ESP_LOGD(TAG, "uri: %s", req->uri);
 
     const char *filename = get_path_from_uri(filepath, ((struct file_server_data *)req->user_ctx)->base_path,
-                                             req->uri  + sizeof("/fileserver") - 1, sizeof(filepath));    
+                                             req->uri  + sizeof("/fileserver") - 1, sizeof(filepath));
 
     ESP_LOGD(TAG, "uri: %s, filename: %s, filepath: %s", req->uri, filename, filepath);
 
@@ -683,7 +683,7 @@ static esp_err_t upload_post_handler(httpd_req_t *req)
     }
 
     // +++++++++++++++++++++++
-    // Special case config.ini: Use config.tmp to save posted chunked web server data. 
+    // Special case config.ini: Use config.tmp to save posted chunked web server data.
     // Update config.ini only if data reception is successful -> Reduce data loss risk (e.g. network interruption during transfer)
     if (strcmp(filename, "/config/config.tmp") == 0 && stat(filepath, &file_stat) == 0) // Delete config.tmp if existing
         unlink(filepath);
@@ -763,7 +763,7 @@ static esp_err_t upload_post_handler(httpd_req_t *req)
     ESP_LOGI(TAG, "File reception completed");
 
     // +++++++++++++++++++++++
-    // Special case config.ini: Use config.tmp to save posted chunked web server data. 
+    // Special case config.ini: Use config.tmp to save posted chunked web server data.
     // Update config.ini only if data reception is successful -> Reduce data loss risk (e.g. network interruption during transfer)
     if (strcmp(filename, "/config/config.tmp") == 0) {
         unlink(CONFIG_FILE); // Delete config.ini
@@ -776,7 +776,7 @@ static esp_err_t upload_post_handler(httpd_req_t *req)
 	size_t found = zw;
 	while (zw != std::string::npos)
 	{
-		zw = directory.find("/", found+1);  
+		zw = directory.find("/", found+1);
 		if (zw != std::string::npos)
 			found = zw;
 	}
@@ -795,8 +795,8 @@ static esp_err_t upload_post_handler(httpd_req_t *req)
         strcmp(filename, "/config/reference.jpg") == 0 ||
         strcmp(filename, "/img_tmp/ref0.jpg") == 0 ||
         strcmp(filename, "/img_tmp/ref1.jpg") == 0 ||
-        strcmp(filename, "/img_tmp/reference.jpg") == 0 ) 
-    { 
+        strcmp(filename, "/img_tmp/reference.jpg") == 0 )
+    {
         httpd_resp_set_status(req, HTTPD_200); // Response without redirection request -> Avoid reloading of folder content
     }
     else {
@@ -820,18 +820,18 @@ static esp_err_t delete_post_handler(httpd_req_t *req)
 
     //////////////////////////////////////////////////////////////
     char _query[200];
-    char _valuechar[30];    
+    char _valuechar[30];
     std::string fn = "/sdcard/firmware/";
     std::string _task;
     std::string directory;
-    std::string zw; 
+    std::string zw;
 
     httpd_resp_set_hdr(req, "Access-Control-Allow-Origin", "*");
 
     if (httpd_req_get_url_query_str(req, _query, sizeof(_query)) == ESP_OK)
     {
         ESP_LOGD(TAG, "Query: %s", _query);
-        
+
         if (httpd_query_key_value(_query, "task", _valuechar, sizeof(_valuechar)) == ESP_OK)
         {
             LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "delete_post_handler: Task: " + std::string(_valuechar));
@@ -864,7 +864,7 @@ static esp_err_t delete_post_handler(httpd_req_t *req)
         //        httpd_resp_set_status(req, "303 See Other");
         //        httpd_resp_set_hdr(req, "Location", directory.c_str());
         //        httpd_resp_sendstr(req, "File deleted successfully");
-        //        return ESP_OK;        
+        //        return ESP_OK;
     }
     else
     {
@@ -901,7 +901,7 @@ static esp_err_t delete_post_handler(httpd_req_t *req)
             /* Delete file */
             unlink(filepath);
         }
-        
+
         /* Avoid redirect to root folder after deletion for system processed files */
         if (strcmp(filename, "/config/config.ini") == 0 ||
             strcmp(filename, "/config/ref0.jpg") == 0 ||
@@ -909,8 +909,8 @@ static esp_err_t delete_post_handler(httpd_req_t *req)
             strcmp(filename, "/config/reference.jpg") == 0 ||
             strcmp(filename, "/img_tmp/ref0.jpg") == 0 ||
             strcmp(filename, "/img_tmp/ref1.jpg") == 0 ||
-            strcmp(filename, "/img_tmp/reference.jpg") == 0 ) 
-        { 
+            strcmp(filename, "/img_tmp/reference.jpg") == 0 )
+        {
             httpd_resp_set_status(req, HTTPD_200); // Response without redirection request -> Avoid reloading of folder content
         }
         else {
@@ -938,7 +938,7 @@ void register_server_file_uri(httpd_handle_t server, const char *base_path)
     /* Validate file storage base path */
     if (!base_path) {
         //if (!base_path || strcmp(base_path, "/spiffs") != 0) {
-        LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "File server base_path not set");   
+        LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "File server base_path not set");
         //return ESP_ERR_INVALID_ARG;
     }
 

--- a/code/components/jomjol_fileserver_ota/server_help.cpp
+++ b/code/components/jomjol_fileserver_ota/server_help.cpp
@@ -71,7 +71,7 @@ esp_err_t send_file(httpd_req_t *req, std::string filename)
         endsWith(filename, ".txt"))
     {
 
-        if (filename == "/sdcard/html/index.html") {    
+        if (filename == "/sdcard/html/index.html") {
             httpd_resp_set_hdr(req, "Cache-Control", "max-age=0");
         }
         else if (filename == "/sdcard/html/setup.html") {
@@ -108,8 +108,8 @@ esp_err_t send_file(httpd_req_t *req, std::string filename)
 
     /* Close file after sending complete */
     fclose(fd);
-    ESP_LOGD(TAG, "File sending complete");    
-    return ESP_OK;    
+    ESP_LOGD(TAG, "File sending complete");
+    return ESP_OK;
 }
 
 

--- a/code/components/jomjol_fileserver_ota/server_ota.cpp
+++ b/code/components/jomjol_fileserver_ota/server_ota.cpp
@@ -69,8 +69,8 @@ static bool ota_update_firmware(std::string fn)
     const esp_partition_t *configured = esp_ota_get_boot_partition();
     const esp_partition_t *running = esp_ota_get_running_partition();
 
-    if (configured != running) {        
-        LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "Configured OTA boot partition at offset " + std::to_string(configured->address) + 
+    if (configured != running) {
+        LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "Configured OTA boot partition at offset " + std::to_string(configured->address) +
                 ", but running from offset " + std::to_string(running->address));
         LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "This can happen if either the OTA boot data or preferred boot image become somehow corrupted.");
     }
@@ -90,8 +90,8 @@ static bool ota_update_firmware(std::string fn)
     }
 
     int binary_file_length = 0;
-    //deal with all receive packet 
-    bool image_header_was_checked = false;  
+    //deal with all receive packet
+    bool image_header_was_checked = false;
 
     int data_read = fread(ota_write_data, 1, SERVER_OTA_SCRATCH_BUFSIZE, f);
 
@@ -119,7 +119,7 @@ static bool ota_update_firmware(std::string fn)
                     if (last_invalid_app != NULL) {
                         if (memcmp(invalid_app_info.version, new_app_info.version, sizeof(new_app_info.version)) == 0) {
                             LogFile.WriteToFile(ESP_LOG_WARN, TAG, "New version is the same as invalid version");
-                            LogFile.WriteToFile(ESP_LOG_WARN, TAG, "Previously, there was an attempt to launch the firmware with " + 
+                            LogFile.WriteToFile(ESP_LOG_WARN, TAG, "Previously, there was an attempt to launch the firmware with " +
                                     std::string(invalid_app_info.version) + " version, but it failed");
                             LogFile.WriteToFile(ESP_LOG_WARN, TAG, "The firmware has been rolled back to the previous version");
                             infinite_loop();
@@ -148,7 +148,7 @@ static bool ota_update_firmware(std::string fn)
                 return false;
             }
         }
-                  
+
         err = esp_ota_write(update_handle, (const void *)ota_write_data, data_read);
         if (err != ESP_OK) {
             LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "ota_update_firmware: esp_ota_write failed. Error: " + intToHexString(err));
@@ -158,7 +158,7 @@ static bool ota_update_firmware(std::string fn)
         binary_file_length += data_read;
         data_read = fread(ota_write_data, 1, SERVER_OTA_SCRATCH_BUFSIZE, f);
     }
-    fclose(f);  
+    fclose(f);
 
     ESP_LOGI(TAG, "Total written image length: %d", binary_file_length);
 
@@ -184,7 +184,7 @@ static bool ota_update_firmware(std::string fn)
 // OTA update: 2nd step
 void task_ota_update(void *pvParameter)
 {
-  	StatusLED(AP_OR_OTA, 1, true);  // Signaling an OTA update  
+  	StatusLED(AP_OR_OTA, 1, true);  // Signaling an OTA update
 
     std::string filetype = toUpper(getFileType(file_name_update));
     LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "File name: " + file_name_update + " | File type: " + filetype);
@@ -212,7 +212,7 @@ void task_ota_update(void *pvParameter)
        	LogFile.WriteToFile(ESP_LOG_INFO, TAG, "Processing BIN file: " + file_name_update);
         if (!ota_update_firmware(file_name_update))
             LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "Firmware update failed");
-        
+
         LogFile.WriteToFile(ESP_LOG_INFO, TAG, "Reboot to finalize update process");
         doRebootOTA();
     }
@@ -316,7 +316,7 @@ esp_err_t handler_ota_update(httpd_req_t *req)
     LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "handler_ota_update");
     char _query[200];
     char _filename[100];
-    char _valuechar[30];    
+    char _valuechar[30];
     std::string fn = "/sdcard/firmware/";
     std::string _task = "";
     bool _file_del = false;
@@ -324,7 +324,7 @@ esp_err_t handler_ota_update(httpd_req_t *req)
     httpd_resp_set_hdr(req, "Access-Control-Allow-Origin", "*");
 
     if (httpd_req_get_url_query_str(req, _query, 200) == ESP_OK) {
-        //ESP_LOGD(TAG, "Query: %s", _query);    
+        //ESP_LOGD(TAG, "Query: %s", _query);
         if (httpd_query_key_value(_query, "task", _valuechar, sizeof(_valuechar)) == ESP_OK) {
             //ESP_LOGD(TAG, "task is found: %s", _valuechar);
             _task = std::string(_valuechar);
@@ -344,7 +344,7 @@ esp_err_t handler_ota_update(httpd_req_t *req)
 
     if (_task.compare("emptyfirmwaredir") == 0) {
         deleteAllFilesInDirectory("/sdcard/firmware");
-        httpd_resp_sendstr(req, "Directory /sdcard/firmware deleted"); 
+        httpd_resp_sendstr(req, "Directory /sdcard/firmware deleted");
         return ESP_OK;
     }
 
@@ -369,13 +369,13 @@ esp_err_t handler_ota_update(httpd_req_t *req)
             fclose(pfile);
 
             httpd_resp_sendstr(req, "reboot"); // String needs to be started with "reboot" -> Trigger reboot from WebUI
-            return ESP_OK;  
+            return ESP_OK;
         }
 
         std::string zw = "task=update: No valid file (.zip, .bin, .tfl, .tlite)";
         LogFile.WriteToFile(ESP_LOG_ERROR, TAG, zw);
-        httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST, zw.c_str()); 
-        return ESP_FAIL;        
+        httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST, zw.c_str());
+        return ESP_FAIL;
     }
 
     else if (_task.compare("unziphtml") == 0) {
@@ -391,16 +391,16 @@ esp_err_t handler_ota_update(httpd_req_t *req)
 
         LogFile.WriteToFile(ESP_LOG_INFO, TAG, "Web interface: Update completed");
         httpd_resp_sendstr(req, "Web interface: Update completed. No reboot required");
-        return ESP_OK;        
+        return ESP_OK;
     }
 
     if (_file_del) {
         if(!DeleteFile(fn)) {
             LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "Deletetion failed. File does not exist: " + fn);
-            httpd_resp_send_err(req, HTTPD_404_NOT_FOUND, "File deletion failed"); 
+            httpd_resp_send_err(req, HTTPD_404_NOT_FOUND, "File deletion failed");
             return ESP_FAIL;
         }
-        
+
         std::string zw = "File deleted: " + fn;
         LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, zw);
         httpd_resp_sendstr(req, zw.c_str());
@@ -409,7 +409,7 @@ esp_err_t handler_ota_update(httpd_req_t *req)
 
     std::string zw = "No valid task/action: OTA handler called without any parameter";
     LogFile.WriteToFile(ESP_LOG_ERROR, TAG, zw);
-    httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST, zw.c_str()); 
+    httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST, zw.c_str());
     return ESP_FAIL;
 }
 
@@ -443,13 +443,13 @@ std::string unzip_ota(std::string _in_zip_file, std::string _root_folder)
         mz_zip_archive_file_stat file_stat;
         mz_zip_reader_file_stat(&zip_archive, i, &file_stat);
         sprintf(archive_filename, file_stat.m_filename);
-        
+
         if (!file_stat.m_is_directory) {
             // Extract file to heap
             // IMPORTANT NOTE -> miniz v3.x crashes here with ESP32S3, more details --> miniz changelog
             p = mz_zip_reader_extract_file_to_heap(&zip_archive, archive_filename, &uncomp_size, 0);
             if (!p) {
-                LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "unzip_ota: mz_zip_reader_extract_file_to_heap() failed | file: " + 
+                LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "unzip_ota: mz_zip_reader_extract_file_to_heap() failed | file: " +
                                                          std::string(archive_filename));
                 mz_zip_reader_end(&zip_archive);
                 return "ERROR";
@@ -483,7 +483,7 @@ std::string unzip_ota(std::string _in_zip_file, std::string _root_folder)
             uint writtenbytes = fwrite(p, 1, (uint)uncomp_size, fpTargetFile);
             fclose(fpTargetFile);
             mz_free(p);
-            
+
             bool isokay = true;
 
             if (writtenbytes != (uint)uncomp_size) {
@@ -553,7 +553,7 @@ void unzip(std::string _in_zip_file, std::string _target_directory)
             mz_zip_archive_file_stat file_stat;
             mz_zip_reader_file_stat(&zip_archive, i, &file_stat);
             sprintf(archive_filename, file_stat.m_filename);
- 
+
             // Try to extract all the files to the heap.
             p = mz_zip_reader_extract_file_to_heap(&zip_archive, archive_filename, &uncomp_size, 0);
             if (!p) {
@@ -582,7 +582,7 @@ void unzip(std::string _in_zip_file, std::string _target_directory)
 }
 
 
-void hard_restart() 
+void hard_restart()
 {
     esp_task_wdt_config_t twdt_config = {
         .timeout_ms = 1,
@@ -672,7 +672,7 @@ esp_err_t handler_reboot(httpd_req_t *req)
     httpd_resp_set_hdr(req, "Cache-Control", "no-cache");
     httpd_resp_set_type(req, "text/plain");
     httpd_resp_sendstr(req, "Reboot initiated");
-    
+
     doReboot();
 
     return ESP_OK;
@@ -682,18 +682,18 @@ esp_err_t handler_reboot(httpd_req_t *req)
 void register_server_ota_sdcard_uri(httpd_handle_t server)
 {
     ESP_LOGI(TAG, "Registering URI handlers");
-    
+
     httpd_uri_t camuri = { };
     camuri.method    = HTTP_GET;
     camuri.uri       = "/ota";
     camuri.handler   = handler_ota_update;
-    camuri.user_ctx  = NULL;    
+    camuri.user_ctx  = NULL;
     httpd_register_uri_handler(server, &camuri);
 
     camuri.method    = HTTP_GET;
     camuri.uri       = "/reboot";
     camuri.handler   = handler_reboot;
-    camuri.user_ctx  = NULL;    
+    camuri.user_ctx  = NULL;
     httpd_register_uri_handler(server, &camuri);
 
 }

--- a/code/components/jomjol_flowcontroll/ClassFlow.cpp
+++ b/code/components/jomjol_flowcontroll/ClassFlow.cpp
@@ -14,7 +14,7 @@ static const char *TAG = "CLASSFLOW";
 void ClassFlow::SetInitialParameter(void)
 {
 	ListFlowControll = NULL;
-	previousElement = NULL;	
+	previousElement = NULL;
 	disabled = false;
 }
 
@@ -45,14 +45,14 @@ ClassFlow::ClassFlow(void)
 
 ClassFlow::ClassFlow(std::vector<ClassFlow*> * lfc)
 {
-	SetInitialParameter();	
+	SetInitialParameter();
 	ListFlowControll = lfc;
 }
 
 
 ClassFlow::ClassFlow(std::vector<ClassFlow*> * lfc, ClassFlow *_prev)
 {
-	SetInitialParameter();	
+	SetInitialParameter();
 	ListFlowControll = lfc;
 	previousElement = _prev;
 }
@@ -73,7 +73,7 @@ void ClassFlow::presetFlowStateHandler(bool _init, std::string _time)
 
 
 void ClassFlow::setFlowStateHandlerEvent(int _eventCode)
-{	
+{
 	FlowState.isSuccessful = false;
 	FlowState.EventCode.push_back(_eventCode); // negative event code -> error; positive event code -> warning
 }

--- a/code/components/jomjol_flowcontroll/ClassFlow.h
+++ b/code/components/jomjol_flowcontroll/ClassFlow.h
@@ -36,32 +36,32 @@ class ClassFlow
     	bool isNewParagraph(std::string input);
     	bool GetNextParagraph(FILE* pfile, std::string& aktparamgraph);
     	bool getNextLine(FILE* pfile, std::string* rt);
-    
+
     	std::vector<ClassFlow*>* ListFlowControll;
     	ClassFlow *previousElement;
-    
+
     	virtual void SetInitialParameter(void);
-    
+
     	std::string GetParameterName(std::string _input);
-    
+
     	bool disabled;
     	strFlowState FlowState;
-    
+
     public:
     	ClassFlow(void);
     	ClassFlow(std::vector<ClassFlow*> * lfc);
     	ClassFlow(std::vector<ClassFlow*> * lfc, ClassFlow *_prev);
-    	
+
         void presetFlowStateHandler(bool _init = false, std::string _time = "");
     	void setFlowStateHandlerEvent(int _eventCode = 0);
     	struct strFlowState* getFlowState();
     	virtual void doPostProcessEventHandling();
-    	
+
     	virtual bool ReadParameter(FILE* pfile, std::string &aktparamgraph);
     	virtual bool doFlow(std::string time);
     	virtual std::string getHTMLSingleStep(std::string host);
     	virtual std::string getReadout();
-    
+
     	virtual std::string name() {return "ClassFlow";};
 };
 

--- a/code/components/jomjol_flowcontroll/ClassFlowAlignment.cpp
+++ b/code/components/jomjol_flowcontroll/ClassFlowAlignment.cpp
@@ -17,7 +17,7 @@
 
 static const char *TAG = "ALIGN";
 
-// #define DEBUG_DETAIL_ON  
+// #define DEBUG_DETAIL_ON
 
 
 void ClassFlowAlignment::SetInitialParameter(void)
@@ -71,7 +71,7 @@ bool ClassFlowAlignment::ReadParameter(FILE* pfile, std::string& aktparamgraph)
 
     while (this->getNextLine(pfile, &aktparamgraph) && !this->isNewParagraph(aktparamgraph)) {
         splitted = ZerlegeZeile(aktparamgraph);
-        
+
         if ((toUpper(splitted[0]) == "ALIGNMENTALGO") && (splitted.size() > 1)) {
             if (toUpper(splitted[1]) == "HIGHACCURACY")
                 alg_algo = 1;
@@ -89,15 +89,15 @@ bool ClassFlowAlignment::ReadParameter(FILE* pfile, std::string& aktparamgraph)
                 LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, zw2);
             #endif
         }
-        
+
         if ((toUpper(splitted[0]) == "SEARCHFIELDX") && (splitted.size() > 1)) {
             search_x = std::stoi(splitted[1]);
-        } 
+        }
 
         if ((toUpper(splitted[0]) == "SEARCHFIELDY") && (splitted.size() > 1)) {
             search_y = std::stoi(splitted[1]);
         }
-    
+
         if ((toUpper(splitted[0]) == "INITIALROTATE") && (splitted.size() > 1)) {
             this->initalrotate = std::stof(splitted[1]);
         }
@@ -147,7 +147,7 @@ bool ClassFlowAlignment::ReadParameter(FILE* pfile, std::string& aktparamgraph)
             STBIObjectPSRAM.PreallocatedMemory = References[anz_ref].refImage->RGBImageGet();
             STBIObjectPSRAM.PreallocatedMemorySize = References[anz_ref].refImage->getMemsize();
 
-            if (!References[anz_ref].refImage->LoadFromFilePreallocated("refImage" + 
+            if (!References[anz_ref].refImage->LoadFromFilePreallocated("refImage" +
                                 std::to_string(anz_ref), References[anz_ref].image_file.c_str()))
             {
                 return false;
@@ -163,7 +163,7 @@ bool ClassFlowAlignment::ReadParameter(FILE* pfile, std::string& aktparamgraph)
                 img_width = Camera.image_height;
                 img_height = Camera.image_width;
             }
-            
+
             if (References[anz_ref].target_x < 1 || (References[anz_ref].target_x > (img_width - 1 - References[anz_ref].refImage->width))) {
                 LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "One or more alignment marker out of image area (x). Check alignment marker");
                 return false;
@@ -200,11 +200,11 @@ std::string ClassFlowAlignment::getHTMLSingleStep(std::string host)
 }
 
 
-bool ClassFlowAlignment::doFlow(std::string time) 
+bool ClassFlowAlignment::doFlow(std::string time)
 {
     presetFlowStateHandler(false, time);
     if (AlgROI == NULL) { // AlgROI needs to be allocated before ImageTMP to avoid heap fragmentation
-        AlgROI = (ImageData*)heap_caps_realloc(AlgROI, sizeof(ImageData), MALLOC_CAP_8BIT | MALLOC_CAP_SPIRAM);     
+        AlgROI = (ImageData*)heap_caps_realloc(AlgROI, sizeof(ImageData), MALLOC_CAP_8BIT | MALLOC_CAP_SPIRAM);
         if (AlgROI == NULL) {
             LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "Failed to allocate AlgROI");
             LogFile.WriteHeapInfo("ClassFlowAlignment-doFlow");
@@ -242,16 +242,16 @@ bool ClassFlowAlignment::doFlow(std::string time)
         ImageTMP->width = ImageTMP->height;
         ImageTMP->height = _zw;
     }
- 
+
     if ((initalrotate != 0) || flipImageSize) {
         if (References[0].alignment_algo == 4)  // alignment off: no initial rotation and no additional alignment algo
             initalrotate = 0;
-        
+
         if (use_antialiasing)
             rt.RotateAntiAliasing(initalrotate);
         else
             rt.Rotate(initalrotate);
-        
+
         if (SaveAllFiles)
             AlignAndCutImage->SaveToFile(FormatFileName("/sdcard/img_tmp/rot.jpg"));
     }
@@ -264,7 +264,7 @@ bool ClassFlowAlignment::doFlow(std::string time)
         if (AlignRetval >= 0) {
             SaveReferenceAlignmentValues();
         }
-        else if (AlignRetval == -1) {   // Alignment failed         
+        else if (AlignRetval == -1) {   // Alignment failed
             LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "Alignment by algorithm failed. Verify image rotation and alignment marker");
             setFlowStateHandlerEvent(-1); // Set error event code for post cycle error handler 'doPostProcessEventHandling'
         }
@@ -280,7 +280,7 @@ bool ClassFlowAlignment::doFlow(std::string time)
         }
         ImageTMP->writeToMemoryAsJPG((ImageData*)AlgROI, 90);
     }
-    
+
     if (SaveAllFiles) {
         AlignAndCutImage->SaveToFile(FormatFileName("/sdcard/img_tmp/alg.jpg"));
         ImageTMP->SaveToFile(FormatFileName("/sdcard/img_tmp/alg_roi.jpg"));
@@ -306,9 +306,9 @@ void ClassFlowAlignment::doPostProcessEventHandling()
             time(&actualtime);
 
             // Define path, e.g. /sdcard/log/debug/20230814/20230814-125528/ClassFlowAlignment
-            std::string destination = std::string(LOG_DEBUG_ROOT_FOLDER) + "/" + getFlowState()->ExecutionTime.DEFAULT_TIME_FORMAT_DATE_EXTR + "/" + 
+            std::string destination = std::string(LOG_DEBUG_ROOT_FOLDER) + "/" + getFlowState()->ExecutionTime.DEFAULT_TIME_FORMAT_DATE_EXTR + "/" +
                                         getFlowState()->ExecutionTime + "/" + getFlowState()->ClassName;
-            
+
             if (!MakeDir(destination))
                 return;
 
@@ -317,7 +317,7 @@ void ClassFlowAlignment::doPostProcessEventHandling()
             FILE* fpResult = fopen((destination + resultFileName).c_str(), "w");
             fwrite(References[0].error_details.c_str(), (References[0].error_details).length(), 1, fpResult);
             fclose(fpResult);
-            
+
             // Draw alignment marker and save image
             DrawRef(AlignAndCutImage);
             AlignAndCutImage->SaveToFile(FormatFileName(destination + "/alg_misalign.jpg"));
@@ -329,9 +329,9 @@ void ClassFlowAlignment::doPostProcessEventHandling()
 
 
 bool ClassFlowAlignment::SaveReferenceAlignmentValues()
-{ 
+{
     esp_err_t err = ESP_OK;
-    
+
     nvs_handle_t align_nvshandle;
     err = nvs_open("align", NVS_READWRITE, &align_nvshandle);
     if (err != ESP_OK) {
@@ -405,9 +405,9 @@ bool ClassFlowAlignment::LoadReferenceAlignmentValues(void)
         LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "LoadReferenceAlignmentValues: Ref1fastalg_y - error code: " + std::to_string(err));
         return false;
     }
-    
+
     nvs_close(align_nvshandle);
-    
+
     return true;
 }
 
@@ -431,7 +431,7 @@ ClassFlowAlignment::~ClassFlowAlignment()
 {
     free_psram_heap("AlgROI", AlgROI);
     delete References[0].refImage;
-    delete References[1].refImage;  
+    delete References[1].refImage;
     delete ImageTMP;
     delete AlignAndCutImage;
 }

--- a/code/components/jomjol_flowcontroll/ClassFlowAlignment.h
+++ b/code/components/jomjol_flowcontroll/ClassFlowAlignment.h
@@ -22,19 +22,19 @@ class ClassFlowAlignment : public ClassFlow
         bool SaveDebugInfo;
         bool SaveAllFiles;
         int AlignFAST_SADThreshold;
-    
+
         void SetInitialParameter(void);
         bool LoadReferenceAlignmentValues(void);
         bool SaveReferenceAlignmentValues(void);
         void doPostProcessEventHandling();
-    
+
     public:
         CImageBasis *ImageBasis;
         ImageData *AlgROI;
-        
+
         ClassFlowAlignment(std::vector<ClassFlow*>* lfc);
         virtual ~ClassFlowAlignment();
-    
+
         CAlignAndCutImage* GetAlignAndCutImage() {return AlignAndCutImage;};
         void DrawRef(CImageBasis *_zw);
         bool ReadParameter(FILE* pfile, std::string& aktparamgraph);

--- a/code/components/jomjol_flowcontroll/ClassFlowCNNGeneral.cpp
+++ b/code/components/jomjol_flowcontroll/ClassFlowCNNGeneral.cpp
@@ -2,7 +2,7 @@
 #include "../../include/defines.h"
 
 #include <math.h>
-#include <iomanip> 
+#include <iomanip>
 #include <sys/types.h>
 #include <sstream>      // std::stringstream
 
@@ -34,7 +34,7 @@ ClassFlowCNNGeneral::ClassFlowCNNGeneral(ClassFlowAlignment *_flowalign, std::st
     modelchannel = 3;
     CNNGoodThreshold = 0.0;
     ListFlowControll = NULL;
-    previousElement = NULL;   
+    previousElement = NULL;
     SaveAllFiles = false;
     disabled = false;
     isLogImageSelect = false;
@@ -45,18 +45,18 @@ ClassFlowCNNGeneral::ClassFlowCNNGeneral(ClassFlowAlignment *_flowalign, std::st
 
 std::string ClassFlowCNNGeneral::getReadout(int _seqNo, bool _extendedResolution, int _valuePreviousNumber,
                                              int _resultPreviousNumber, int analogDigitalTransitionStart)
-{ 
+{
     if (GENERAL[_seqNo]->ROI.size() == 0) {
         LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "getReadout: No numbers in selected number sequence");
         return std::string("");
     }
-    
-    LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "getReadout: Number sequence: " + std::to_string(_seqNo) + 
-                                                ", extendedResolution: " + std::to_string(_extendedResolution) + 
-                                                ", valuePreviousNumber: " + to_stringWithPrecision(_valuePreviousNumber/10.0, 1) + 
-                                                ", resultPreviousNumber: " + std::to_string(_resultPreviousNumber) + 
+
+    LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "getReadout: Number sequence: " + std::to_string(_seqNo) +
+                                                ", extendedResolution: " + std::to_string(_extendedResolution) +
+                                                ", valuePreviousNumber: " + to_stringWithPrecision(_valuePreviousNumber/10.0, 1) +
+                                                ", resultPreviousNumber: " + std::to_string(_resultPreviousNumber) +
                                                 ", analogDigitalTransitionStart: " + to_stringWithPrecision(analogDigitalTransitionStart/10.0, 1));
- 
+
     if (CNNType == Analogue || CNNType == Analogue100) { // Class-analog-model, ana-class100-model
         std::string result = "";
         int resultTemp = -1;
@@ -77,7 +77,7 @@ std::string ClassFlowCNNGeneral::getReadout(int _seqNo, bool _extendedResolution
         for (int i = lastROI - 1; i >= 0; --i) // Evaluate all remaining number of number sequence (and potentially correct)
         {
             LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "ROI #" + std::to_string(i));
-            resultTemp = EvalAnalogNumber(GENERAL[_seqNo]->ROI[i]->CNNResult, resultTemp); 
+            resultTemp = EvalAnalogNumber(GENERAL[_seqNo]->ROI[i]->CNNResult, resultTemp);
             result = std::to_string(resultTemp) + result;
         }
 
@@ -100,11 +100,11 @@ std::string ClassFlowCNNGeneral::getReadout(int _seqNo, bool _extendedResolution
             }
             else {
                 if (_valuePreviousNumber >= 0) // If previous number available (analog value should be handed over)
-                    resultTemp = EvalDigitNumber(GENERAL[_seqNo]->ROI[lastROI]->CNNResult, _valuePreviousNumber, 
+                    resultTemp = EvalDigitNumber(GENERAL[_seqNo]->ROI[lastROI]->CNNResult, _valuePreviousNumber,
                                                         _resultPreviousNumber, true, analogDigitalTransitionStart);
                 else
                     resultTemp = EvalDigitNumber(GENERAL[_seqNo]->ROI[lastROI]->CNNResult, -1, -1); // No previous number
-                
+
                 result = std::to_string(resultTemp);
             }
         }
@@ -112,14 +112,14 @@ std::string ClassFlowCNNGeneral::getReadout(int _seqNo, bool _extendedResolution
             result = "N";
             if (_extendedResolution)
                 result = "NN";
-            
+
             LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "getReadout Digit (dig-cont/dig-class100): Rejected, substitude with N");
         }
 
         for (int i = lastROI - 1; i >= 0; --i) {
             LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "ROI #" + std::to_string(i));
             if (!GENERAL[_seqNo]->ROI[i]->isRejected) { // valid result (e.g. model 'dig-cont*' --> bad fit)?
-                resultTemp = EvalDigitNumber(GENERAL[_seqNo]->ROI[i]->CNNResult, GENERAL[_seqNo]->ROI[i+1]->CNNResult, resultTemp);                
+                resultTemp = EvalDigitNumber(GENERAL[_seqNo]->ROI[i]->CNNResult, GENERAL[_seqNo]->ROI[i+1]->CNNResult, resultTemp);
                 result = std::to_string(resultTemp) + result;
             }
             else {
@@ -174,18 +174,18 @@ int ClassFlowCNNGeneral::EvalAnalogNumber(int _value, int _resultPreviousNumber)
     int valueMax = _value + Analog_error;
     if (valueMax >= 100) // e.g. 10.2 -> 0.2 (value = 02)
         valueMax = valueMax - 100;
-    
+
     int valueMin = _value - Analog_error;
     if (valueMin < 0) // e.g. -0.3 -> 9.7 (value = 97)
         valueMin = 100 + valueMin;
-    
+
     if (((valueMin / 10 - valueMax / 10)) != 0)
     {
         if (_resultPreviousNumber <= Analog_error)
         {
             result = valueMax / 10;
             LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "EvalAnalogNumber (Ambiguous, use value + corretion): Result: " + std::to_string(result) +
-                                                        ", Value: " + to_stringWithPrecision(_value/10.0, 1) + 
+                                                        ", Value: " + to_stringWithPrecision(_value/10.0, 1) +
                                                         ", resultPreviousNumber: " + std::to_string(_resultPreviousNumber));
             return result;
         }
@@ -193,22 +193,22 @@ int ClassFlowCNNGeneral::EvalAnalogNumber(int _value, int _resultPreviousNumber)
         {
             result = valueMin / 10;
             LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "EvalAnalogNumber (Ambiguous, use value - corretion): Result: " + std::to_string(result) +
-                                                        ", Value: " + to_stringWithPrecision(_value/10.0, 1) + 
+                                                        ", Value: " + to_stringWithPrecision(_value/10.0, 1) +
                                                         ", resultPreviousNumber: " + std::to_string(_resultPreviousNumber));
             return result;
         }
     }
-    
+
     result = _value / 10;
     LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "EvalAnalogNumber (Unambiguous, use value): Result: " + std::to_string(result) +
-                                                ", Value: " + to_stringWithPrecision(_value/10.0, 1) + 
+                                                ", Value: " + to_stringWithPrecision(_value/10.0, 1) +
                                                 ", resultPreviousNumber: " + std::to_string(_resultPreviousNumber));
     return result;
 }
 
 
 /* Evaluate digit number */
-int ClassFlowCNNGeneral::EvalDigitNumber(int _value, int _valuePreviousNumber, int _resultPreviousNumber, 
+int ClassFlowCNNGeneral::EvalDigitNumber(int _value, int _valuePreviousNumber, int _resultPreviousNumber,
                                               bool _isPreviousAnalog, int digitalAnalogTransitionStart)
 {
     int result = - 1;
@@ -222,21 +222,21 @@ int ClassFlowCNNGeneral::EvalDigitNumber(int _value, int _valuePreviousNumber, i
         return result;
     }
 
-    // previous number is analog (_valuePreviousNumber: 0-99), special transistion check needed 
+    // previous number is analog (_valuePreviousNumber: 0-99), special transistion check needed
     if (_isPreviousAnalog) {
         result = EvalAnalogToDigitTransition(_value, _valuePreviousNumber, _resultPreviousNumber, digitalAnalogTransitionStart);
         LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "EvalDigitNumber (Analog previous number): Result: " + std::to_string(result) +
-                                                    ", Value: " + to_stringWithPrecision(_value/10.0, 1) + 
-                                                    ", valuePreviousNumber: " + to_stringWithPrecision(_valuePreviousNumber/10.0, 1) + 
+                                                    ", Value: " + to_stringWithPrecision(_value/10.0, 1) +
+                                                    ", valuePreviousNumber: " + to_stringWithPrecision(_valuePreviousNumber/10.0, 1) +
                                                     ", resultPreviousNumber: " + std::to_string(_resultPreviousNumber));
         return result;
     }
 
     // Previous number is digital (_valuePreviousNumber: 0-99) No digit change, because predecessor is far enough away (+/- Digital_Transition_Area_Predecessor)
-    if ((_valuePreviousNumber >= Digital_Transition_Area_Predecessor) && (_valuePreviousNumber <= (100 - Digital_Transition_Area_Predecessor))) { 
+    if ((_valuePreviousNumber >= Digital_Transition_Area_Predecessor) && (_valuePreviousNumber <= (100 - Digital_Transition_Area_Predecessor))) {
         // Band around the digit --> Round, as digit reaches inaccuracy in the frame
-        if ((resultDecimalPlace <= DigitalBand) || (resultDecimalPlace >= (10-DigitalBand))) {    
-            if (resultDecimalPlace >= 5) { 
+        if ((resultDecimalPlace <= DigitalBand) || (resultDecimalPlace >= (10-DigitalBand))) {
+            if (resultDecimalPlace >= 5) {
                 result = resultIntergerPart + 1; // "Round"
 
                 if (result >= 10)
@@ -251,15 +251,15 @@ int ClassFlowCNNGeneral::EvalDigitNumber(int _value, int _valuePreviousNumber, i
         }
 
         LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "EvalDigitNumber (Digit previous number: no zero crossing, \'safe area\'): Result: " + std::to_string(result) +
-                                                    ", Value: " + to_stringWithPrecision(_value/10.0, 1) + 
-                                                    ", valuePreviousNumber: " + to_stringWithPrecision(_valuePreviousNumber/10.0, 1) + 
+                                                    ", Value: " + to_stringWithPrecision(_value/10.0, 1) +
+                                                    ", valuePreviousNumber: " + to_stringWithPrecision(_valuePreviousNumber/10.0, 1) +
                                                     ", resultPreviousNumber: " + std::to_string(_resultPreviousNumber));
         return result;
-    } 
+    }
 
     // Zero crossing at the predecessor has taken place (! evaluation via result of previous number and not value !)
     // --> round up here (2.8 --> 3, but also 3.1 --> 3)
-    if (_resultPreviousNumber <= 1) { 
+    if (_resultPreviousNumber <= 1) {
         // We simply assume that the current digit after the zero crossing of the predecessor
         // has passed through at least half (x.5)
         if (resultDecimalPlace >= 5) {
@@ -271,23 +271,23 @@ int ClassFlowCNNGeneral::EvalDigitNumber(int _value, int _valuePreviousNumber, i
         else {
             result =  resultIntergerPart; // "Trunc": Act. digit and predecessor have zero crossing
         }
-        
+
         LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "EvalDigitNumber (Digit previous number: zero crossing): Result: " + std::to_string(result) +
-                                                    ", Value: " + to_stringWithPrecision(_value/10.0, 1) + 
-                                                    ", valuePreviousNumber: " + to_stringWithPrecision(_valuePreviousNumber/10.0, 1) + 
+                                                    ", Value: " + to_stringWithPrecision(_value/10.0, 1) +
+                                                    ", valuePreviousNumber: " + to_stringWithPrecision(_valuePreviousNumber/10.0, 1) +
                                                     ", resultPreviousNumber: " + std::to_string(_resultPreviousNumber));
         return result;
     }
 
-    // remains only >= 9.x --> no zero crossing yet --> 2.8 --> 2, 
+    // remains only >= 9.x --> no zero crossing yet --> 2.8 --> 2,
     // and from 9.7(Digital_Transition_Area_Forward) 3.1 --> 2
     // everything >=x.4 can be considered as current number in transition. With 9.x predecessor the current
-    // number can still be x.6 - x.7. 
+    // number can still be x.6 - x.7.
     // Preceding (else - branch) does not already happen from 9.
-    if (((_valuePreviousNumber <= Digital_Transition_Area_Forward) && (_resultPreviousNumber == (int)(_valuePreviousNumber/10.0))) || 
+    if (((_valuePreviousNumber <= Digital_Transition_Area_Forward) && (_resultPreviousNumber == (int)(_valuePreviousNumber/10.0))) ||
         resultDecimalPlace >= 4)
     {
-        result =  resultIntergerPart; // The current digit, like the previous digit, does not yet have a zero crossing. 
+        result =  resultIntergerPart; // The current digit, like the previous digit, does not yet have a zero crossing.
     }
     else {
         // current digit precedes the smaller digit (9.x). So already >=x.0 while the previous digit has not yet
@@ -299,10 +299,10 @@ int ClassFlowCNNGeneral::EvalDigitNumber(int _value, int _valuePreviousNumber, i
     }
 
     LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "EvalDigitNumber (Digit previous number: no zero crossing yet): Result: " + std::to_string(result) +
-                                                ", Value: " + to_stringWithPrecision(_value/10.0, 1) + 
-                                                ", valuePreviousNumber: " + to_stringWithPrecision(_valuePreviousNumber/10.0, 1) + 
+                                                ", Value: " + to_stringWithPrecision(_value/10.0, 1) +
+                                                ", valuePreviousNumber: " + to_stringWithPrecision(_valuePreviousNumber/10.0, 1) +
                                                 ", resultPreviousNumber: " + std::to_string(_resultPreviousNumber));
-    
+
     return result;
 }
 
@@ -314,10 +314,10 @@ int ClassFlowCNNGeneral::EvalAnalogToDigitTransition(int _value, int _valuePrevi
     int resultIntergerPart = _value / 10;
     int resultDecimalPlace = _value % 10;
 
-    // Value within the digital inequalities 
+    // Value within the digital inequalities
     if (resultDecimalPlace >= (10 - Digital_Uncertainty)    // Band around the zero crossing -> Round, as number reaches inaccuracy zone
         || (_resultPreviousNumber <= 4 && resultDecimalPlace >= 6)) // or number runs after (previous result <= 4, actucal decimal place >= 6)
-    {   
+    {
         if (resultDecimalPlace >= 5) { // "Round up"
             result = resultIntergerPart + 1;
 
@@ -330,9 +330,9 @@ int ClassFlowCNNGeneral::EvalAnalogToDigitTransition(int _value, int _valuePrevi
                 result = result - 1;
                 if (result < 0)
                     result = 9;
-                
+
                 LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "EvalAnalogToDigitTransition (Digital uncertainty, no zero crossing): Result: " + std::to_string(result) +
-                                                        ", Value: " + to_stringWithPrecision(_value/10.0, 1) + 
+                                                        ", Value: " + to_stringWithPrecision(_value/10.0, 1) +
                                                         ", valuePreviousNumber: " + to_stringWithPrecision(_valuePreviousNumber/10.0, 1) +
                                                         ", resultPreviousNumber: " + std::to_string(_resultPreviousNumber));
             }
@@ -342,10 +342,10 @@ int ClassFlowCNNGeneral::EvalAnalogToDigitTransition(int _value, int _valuePrevi
         }
 
         LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "EvalAnalogToDigitTransition (Digital uncertainty): Result: " + std::to_string(result) +
-                                ", Value: " + to_stringWithPrecision(_value/10.0, 1) + 
+                                ", Value: " + to_stringWithPrecision(_value/10.0, 1) +
                                 ", valuePreviousNumber: " + to_stringWithPrecision(_valuePreviousNumber/10.0, 1) +
                                 ", resultPreviousNumber: " + std::to_string(_resultPreviousNumber));
-    } 
+    }
     else {
         result = resultIntergerPart;
         LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "EvalAnalogToDigitTransition: Result: " + std::to_string(result) +
@@ -368,7 +368,7 @@ bool ClassFlowCNNGeneral::ReadParameter(FILE* pfile, std::string& aktparamgraph)
             return false;
 
 
-    if ((toUpper(aktparamgraph) != "[ANALOG]") && (toUpper(aktparamgraph) != ";[ANALOG]") 
+    if ((toUpper(aktparamgraph) != "[ANALOG]") && (toUpper(aktparamgraph) != ";[ANALOG]")
         && (toUpper(aktparamgraph) != "[DIGIT]") && (toUpper(aktparamgraph) != ";[DIGIT]")
         && (toUpper(aktparamgraph) != "[DIGITS]") && (toUpper(aktparamgraph) != ";[DIGITS]")
         )       // Paragraph passt nicht
@@ -392,7 +392,7 @@ bool ClassFlowCNNGeneral::ReadParameter(FILE* pfile, std::string& aktparamgraph)
         if ((toUpper(splitted[0]) == "CNNGOODTHRESHOLD") && (splitted.size() > 1)) {
             CNNGoodThreshold = std::stof(splitted[1]);
         }
-        
+
         if ((toUpper(splitted[0]) == "ROIIMAGESLOCATION") && (splitted.size() > 1)) {
             this->imagesLocation = "/sdcard" + splitted[1];
             this->isLogImage = true;
@@ -404,7 +404,7 @@ bool ClassFlowCNNGeneral::ReadParameter(FILE* pfile, std::string& aktparamgraph)
 
         if ((toUpper(splitted[0]) == "LOGIMAGESELECT") && (splitted.size() > 1)) {
             LogImageSelect = splitted[1];
-            isLogImageSelect = true;            
+            isLogImageSelect = true;
         }
 
         if ((toUpper(splitted[0]) == "SAVEALLFILES") && (splitted.size() > 1))
@@ -414,7 +414,7 @@ bool ClassFlowCNNGeneral::ReadParameter(FILE* pfile, std::string& aktparamgraph)
             else
                 SaveAllFiles = false;
         }
-        
+
         if (splitted.size() >= 5) {
             general* _analog = GetGENERAL(splitted[0], true);
             t_ROI* newROI = _analog->ROI[_analog->ROI.size()-1];
@@ -457,7 +457,7 @@ bool ClassFlowCNNGeneral::ReadParameter(FILE* pfile, std::string& aktparamgraph)
 
     for (int _ana = 0; _ana < GENERAL.size(); ++_ana)
         for (int i = 0; i < GENERAL[_ana]->ROI.size(); ++i) {
-            GENERAL[_ana]->ROI[i]->image = new CImageBasis("ROI " + GENERAL[_ana]->ROI[i]->name, 
+            GENERAL[_ana]->ROI[i]->image = new CImageBasis("ROI " + GENERAL[_ana]->ROI[i]->name,
                     modelxsize, modelysize, modelchannel);
             GENERAL[_ana]->ROI[i]->image_org = new CImageBasis("ROI " + GENERAL[_ana]->ROI[i]->name + "_org",
                     GENERAL[_ana]->ROI[i]->deltax, GENERAL[_ana]->ROI[i]->deltay, 3);
@@ -529,10 +529,10 @@ std::string ClassFlowCNNGeneral::getHTMLSingleStep(std::string host)
     {
         zw = to_stringWithPrecision(htmlinfo[i]->val, 1);
         result = result + "<img src=\"" + host + "/img_tmp/" +  htmlinfo[i]->filename + "\"> " + zw;
-        
+
         delete htmlinfo[i];
     }
-    htmlinfo.clear();         
+    htmlinfo.clear();
 
     return result;
 }
@@ -566,8 +566,8 @@ bool ClassFlowCNNGeneral::doFlow(std::string time)
 
     #ifdef HEAP_TRACING_CLASS_FLOW_CNN_GENERAL_DO_ALING_AND_CUT
         ESP_ERROR_CHECK( heap_trace_stop() );
-        heap_trace_dump(); 
-    #endif   
+        heap_trace_dump();
+    #endif
 
     return true;
 }
@@ -576,7 +576,7 @@ bool ClassFlowCNNGeneral::doFlow(std::string time)
 void ClassFlowCNNGeneral::doPostProcessEventHandling()
 {
     // Post cycle process handling can be included here. Function is called after processing cycle is completed
-    
+
 }
 
 
@@ -595,37 +595,37 @@ bool ClassFlowCNNGeneral::doAlignAndCut(std::string time)
     for (int _ana = 0; _ana < GENERAL.size(); ++_ana)
         for (int i = 0; i < GENERAL[_ana]->ROI.size(); ++i) {
             ESP_LOGD(TAG, "General %d - Align&Cut", i);
-            
-            caic->CutAndSave(GENERAL[_ana]->ROI[i]->posx, GENERAL[_ana]->ROI[i]->posy, GENERAL[_ana]->ROI[i]->deltax, 
+
+            caic->CutAndSave(GENERAL[_ana]->ROI[i]->posx, GENERAL[_ana]->ROI[i]->posy, GENERAL[_ana]->ROI[i]->deltax,
                                 GENERAL[_ana]->ROI[i]->deltay, GENERAL[_ana]->ROI[i]->image_org);
             if (SaveAllFiles) {
                 if (GENERAL[_ana]->name == "default")
-                    GENERAL[_ana]->ROI[i]->image_org->SaveToFile(FormatFileName("/sdcard/img_tmp/" + 
+                    GENERAL[_ana]->ROI[i]->image_org->SaveToFile(FormatFileName("/sdcard/img_tmp/" +
                                                         GENERAL[_ana]->ROI[i]->name + "_org.jpg"));
                 else
-                    GENERAL[_ana]->ROI[i]->image_org->SaveToFile(FormatFileName("/sdcard/img_tmp/" + GENERAL[_ana]->name + "_" + 
+                    GENERAL[_ana]->ROI[i]->image_org->SaveToFile(FormatFileName("/sdcard/img_tmp/" + GENERAL[_ana]->name + "_" +
                                                         GENERAL[_ana]->ROI[i]->name + "_org.jpg"));
-            } 
+            }
 
             GENERAL[_ana]->ROI[i]->image_org->Resize(modelxsize, modelysize, GENERAL[_ana]->ROI[i]->image);
             if (SaveAllFiles) {
                 if (GENERAL[_ana]->name == "default")
-                    GENERAL[_ana]->ROI[i]->image->SaveToFile(FormatFileName("/sdcard/img_tmp/" + 
+                    GENERAL[_ana]->ROI[i]->image->SaveToFile(FormatFileName("/sdcard/img_tmp/" +
                                                         GENERAL[_ana]->ROI[i]->name + ".jpg"));
                 else
-                    GENERAL[_ana]->ROI[i]->image->SaveToFile(FormatFileName("/sdcard/img_tmp/" + 
+                    GENERAL[_ana]->ROI[i]->image->SaveToFile(FormatFileName("/sdcard/img_tmp/" +
                                                         GENERAL[_ana]->name + "_" + GENERAL[_ana]->ROI[i]->name + ".jpg"));
-            } 
+            }
         }
 
     return true;
-} 
+}
 
 
 void ClassFlowCNNGeneral::DrawROI(CImageBasis *_zw)
 {
-    if (_zw->ImageOkay()) 
-    { 
+    if (_zw->ImageOkay())
+    {
         if (CNNType == Analogue || CNNType == Analogue100) {
             int r = 0;
             int g = 255;
@@ -633,30 +633,30 @@ void ClassFlowCNNGeneral::DrawROI(CImageBasis *_zw)
 
             for (int _ana = 0; _ana < GENERAL.size(); ++_ana)
                 for (int i = 0; i < GENERAL[_ana]->ROI.size(); ++i) {
-                    _zw->drawRect(GENERAL[_ana]->ROI[i]->posx, GENERAL[_ana]->ROI[i]->posy, GENERAL[_ana]->ROI[i]->deltax, 
+                    _zw->drawRect(GENERAL[_ana]->ROI[i]->posx, GENERAL[_ana]->ROI[i]->posy, GENERAL[_ana]->ROI[i]->deltax,
                                     GENERAL[_ana]->ROI[i]->deltay, r, g, b, 1);
-                    
-                    _zw->drawEllipse((int) (GENERAL[_ana]->ROI[i]->posx + GENERAL[_ana]->ROI[i]->deltax/2), 
-                                        (int)  (GENERAL[_ana]->ROI[i]->posy + GENERAL[_ana]->ROI[i]->deltay/2), 
+
+                    _zw->drawEllipse((int) (GENERAL[_ana]->ROI[i]->posx + GENERAL[_ana]->ROI[i]->deltax/2),
+                                        (int)  (GENERAL[_ana]->ROI[i]->posy + GENERAL[_ana]->ROI[i]->deltay/2),
                                         (int) (GENERAL[_ana]->ROI[i]->deltax/2), (int) (GENERAL[_ana]->ROI[i]->deltay/2), r, g, b, 2);
 
-                    _zw->drawLine((int) (GENERAL[_ana]->ROI[i]->posx + GENERAL[_ana]->ROI[i]->deltax/2), 
-                                        (int) GENERAL[_ana]->ROI[i]->posy, (int) (GENERAL[_ana]->ROI[i]->posx + GENERAL[_ana]->ROI[i]->deltax/2), 
+                    _zw->drawLine((int) (GENERAL[_ana]->ROI[i]->posx + GENERAL[_ana]->ROI[i]->deltax/2),
+                                        (int) GENERAL[_ana]->ROI[i]->posy, (int) (GENERAL[_ana]->ROI[i]->posx + GENERAL[_ana]->ROI[i]->deltax/2),
                                         (int) (GENERAL[_ana]->ROI[i]->posy + GENERAL[_ana]->ROI[i]->deltay), r, g, b, 2);
 
-                    _zw->drawLine((int) GENERAL[_ana]->ROI[i]->posx, (int) (GENERAL[_ana]->ROI[i]->posy + GENERAL[_ana]->ROI[i]->deltay/2), 
-                                        (int) GENERAL[_ana]->ROI[i]->posx + GENERAL[_ana]->ROI[i]->deltax, (int) (GENERAL[_ana]->ROI[i]->posy + 
+                    _zw->drawLine((int) GENERAL[_ana]->ROI[i]->posx, (int) (GENERAL[_ana]->ROI[i]->posy + GENERAL[_ana]->ROI[i]->deltay/2),
+                                        (int) GENERAL[_ana]->ROI[i]->posx + GENERAL[_ana]->ROI[i]->deltax, (int) (GENERAL[_ana]->ROI[i]->posy +
                                         GENERAL[_ana]->ROI[i]->deltay/2), r, g, b, 2);
                 }
         }
         else {
             for (int _dig = 0; _dig < GENERAL.size(); ++_dig)
                 for (int i = 0; i < GENERAL[_dig]->ROI.size(); ++i)
-                    _zw->drawRect(GENERAL[_dig]->ROI[i]->posx, GENERAL[_dig]->ROI[i]->posy, GENERAL[_dig]->ROI[i]->deltax, 
+                    _zw->drawRect(GENERAL[_dig]->ROI[i]->posx, GENERAL[_dig]->ROI[i]->posy, GENERAL[_dig]->ROI[i]->deltax,
                                         GENERAL[_dig]->ROI[i]->deltay, 0, 0, (255 - _dig*100), 2);
         }
     }
-} 
+}
 
 
 bool ClassFlowCNNGeneral::getNetworkParameter()
@@ -671,7 +671,7 @@ bool ClassFlowCNNGeneral::getNetworkParameter()
         LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "TFLITE: Failed to load model: " + cnnmodelfile);
         LogFile.WriteHeapInfo("getNetworkParameter-LoadModel");
         return false;
-    } 
+    }
 
     if (!tflite->MakeAllocate()) {
         LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "TFLITE: Allocation of tensors failed");
@@ -725,7 +725,7 @@ bool ClassFlowCNNGeneral::getNetworkParameter()
     LogFile.WriteToFile(ESP_LOG_INFO, TAG, "Network parameter loaded: " + cnnmodelfile);
 
     tflite->CTfLiteClassDeleteInterpreter();
-    
+
     return true;
 }
 
@@ -766,7 +766,7 @@ bool ClassFlowCNNGeneral::doNeuralNetwork(std::string time)
                     }
 
                     float result = fmod(atan2(tflite->GetOutputValue(0), tflite->GetOutputValue(1)) / (M_PI * 2) + 2, 1);
-                            
+
                     if(GENERAL[n]->ROI[roi]->CCW) {
                         if (result == 0.0)
                             GENERAL[n]->ROI[roi]->CNNResult = 0;
@@ -783,9 +783,9 @@ bool ClassFlowCNNGeneral::doNeuralNetwork(std::string time)
                         GENERAL[n]->ROI[roi]->CNNResult = 99;
 
                     GENERAL[n]->ROI[roi]->isRejected = false;
-                                                
+
                     LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "Result: " + to_stringWithPrecision(GENERAL[n]->ROI[roi]->CNNResult / 10.0, 1));
-                    
+
                     if (isLogImage)
                         LogImage(logPath, GENERAL[n]->ROI[roi]->name, Analogue, GENERAL[n]->ROI[roi]->CNNResult, time, GENERAL[n]->ROI[roi]->image_org);
                 } break;
@@ -794,7 +794,7 @@ bool ClassFlowCNNGeneral::doNeuralNetwork(std::string time)
                 {
                     LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "Type: Digital (dig-class11)");
 
-                    GENERAL[n]->ROI[roi]->CNNResult = tflite->GetClassFromImageBasis(GENERAL[n]->ROI[roi]->image); // 0-9 + 10 => NaN             
+                    GENERAL[n]->ROI[roi]->CNNResult = tflite->GetClassFromImageBasis(GENERAL[n]->ROI[roi]->image); // 0-9 + 10 => NaN
                     LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "Result: " + std::to_string(GENERAL[n]->ROI[roi]->CNNResult));
 
                     if (isLogImage) {
@@ -813,7 +813,7 @@ bool ClassFlowCNNGeneral::doNeuralNetwork(std::string time)
                 case DoubleHyprid10: // for models dig-cont*
                 {
                     LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "Type: DoubleHyprid10 (dig-cont)");
-                    
+
                     int LogImageResult;
                     int _num, _numplus, _numminus;
                     float _val, _valplus, _valminus, _fit;
@@ -859,7 +859,7 @@ bool ClassFlowCNNGeneral::doNeuralNetwork(std::string time)
                         GENERAL[n]->ROI[roi]->CNNResult = 99;
 
                     /*
-                    std::string zw = "num (p, m): " + std::to_string(_num) + " (" + std::to_string(_numplus) + " , " + std::to_string(_numminus) + 
+                    std::string zw = "num (p, m): " + std::to_string(_num) + " (" + std::to_string(_numplus) + " , " + std::to_string(_numminus) +
                                      "), val (p, m): " + std::to_string(_val) + " (" + std::to_string(_valplus) + " , " + std::to_string(_valminus) +
                                      "), result: " + to_stringWithPrecision(GENERAL[n]->ROI[roi]->CNNResult/10.0, 1) + ", fit: " + std::to_string(_fit);
                     LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, zw);
@@ -875,7 +875,7 @@ bool ClassFlowCNNGeneral::doNeuralNetwork(std::string time)
                         GENERAL[n]->ROI[roi]->isRejected = false;
                         LogImageResult = GENERAL[n]->ROI[roi]->CNNResult;
                     }
-                    
+
                     LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "Result: " + to_stringWithPrecision(GENERAL[n]->ROI[roi]->CNNResult / 10.0, 1));
 
                     if (isLogImage) {
@@ -890,12 +890,12 @@ bool ClassFlowCNNGeneral::doNeuralNetwork(std::string time)
                         }
                     }
                 } break;
-                
+
                 case Digital100:  // for models dig-class100*
                 case Analogue100: // for models ana-class100*
                 {
                     LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "Type: Analogue100/Digital100 (ana/dig-class100)");
-                   
+
                     if (tflite->LoadInputImageBasis(GENERAL[n]->ROI[roi]->image)) {
                         tflite->Invoke();
                         LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "Invoke done");
@@ -906,16 +906,16 @@ bool ClassFlowCNNGeneral::doNeuralNetwork(std::string time)
                     }
 
                     int _num = tflite->GetOutClassification();
-                    
+
                     if(GENERAL[n]->ROI[roi]->CCW) {
                         if (_num == 0)
                             GENERAL[n]->ROI[roi]->CNNResult = 0;
                         else
                             GENERAL[n]->ROI[roi]->CNNResult = 100 -_num;
 
-                    }                       
+                    }
                     else {
-                        GENERAL[n]->ROI[roi]->CNNResult = _num; 
+                        GENERAL[n]->ROI[roi]->CNNResult = _num;
                     }
 
                     if (GENERAL[n]->ROI[roi]->CNNResult < 0)
@@ -923,7 +923,7 @@ bool ClassFlowCNNGeneral::doNeuralNetwork(std::string time)
                     else if (GENERAL[n]->ROI[roi]->CNNResult >= 100)
                         GENERAL[n]->ROI[roi]->CNNResult = 99;
 
-                    GENERAL[n]->ROI[roi]->isRejected = false;   
+                    GENERAL[n]->ROI[roi]->isRejected = false;
 
                     LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "Result: " + to_stringWithPrecision(GENERAL[n]->ROI[roi]->CNNResult / 10.0, 1));
 
@@ -939,7 +939,7 @@ bool ClassFlowCNNGeneral::doNeuralNetwork(std::string time)
                         }
                     }
                 } break;
-                        
+
                 default:
                 break;
             }
@@ -947,7 +947,7 @@ bool ClassFlowCNNGeneral::doNeuralNetwork(std::string time)
     }
 
     tflite->CTfLiteClassDeleteInterpreter();
-    
+
     return true;
 }
 
@@ -978,7 +978,7 @@ std::vector<HTMLInfo*> ClassFlowCNNGeneral::GetHTMLInfo()
             }
 
             HTMLInfo *zw = new HTMLInfo;
-            
+
             zw->name = GENERAL[_ana]->name;
             zw->position = i;
 
@@ -995,7 +995,7 @@ std::vector<HTMLInfo*> ClassFlowCNNGeneral::GetHTMLInfo()
                 zw->val = GENERAL[_ana]->ROI[i]->CNNResult;
             else
                 zw->val = GENERAL[_ana]->ROI[i]->CNNResult / 10.0;
-            
+
             zw->image = GENERAL[_ana]->ROI[i]->image;
             zw->image_org = GENERAL[_ana]->ROI[i]->image_org;
 
@@ -1046,13 +1046,13 @@ void ClassFlowCNNGeneral::UpdateNameNumbers(std::vector<std::string> *_name_numb
 }
 
 
-std::string ClassFlowCNNGeneral::getReadoutRawString(int _seqNo) 
+std::string ClassFlowCNNGeneral::getReadoutRawString(int _seqNo)
 {
     std::string rt = "";
 
     if (_seqNo >= GENERAL.size() || GENERAL[_seqNo]==NULL || GENERAL[_seqNo]->ROI.size() == 0)
         return rt;
- 
+
     for (int i = 0; i < GENERAL[_seqNo]->ROI.size(); ++i) {
         if (CNNType == Analogue || CNNType == Analogue100 || CNNType == DoubleHyprid10 || CNNType == Digital100) {
             rt = rt + "," + to_stringWithPrecision(GENERAL[_seqNo]->ROI[i]->CNNResult / 10.0, 1);
@@ -1073,7 +1073,7 @@ ClassFlowCNNGeneral::~ClassFlowCNNGeneral()
 {
     delete tflite;
     tflite = NULL;
-    
+
     for (int _ana = 0; _ana < GENERAL.size(); ++_ana)
         for (int i = 0; i < GENERAL[_ana]->ROI.size(); ++i) {
             delete GENERAL[_ana]->ROI[i]->image;

--- a/code/components/jomjol_flowcontroll/ClassFlowCNNGeneral.h
+++ b/code/components/jomjol_flowcontroll/ClassFlowCNNGeneral.h
@@ -22,14 +22,14 @@ class ClassFlowCNNGeneral : public ClassFlowImage
         int modelxsize, modelysize, modelchannel;
         std::string LogImageSelect;
         bool isLogImageSelect;
-        bool SaveAllFiles;   
+        bool SaveAllFiles;
 
         int EvalAnalogNumber(int _value, int _resultPreviousNumber);
-        int EvalDigitNumber(int _value, int _valuePreviousNumber, int _resultPreviousNumber, 
+        int EvalDigitNumber(int _value, int _valuePreviousNumber, int _resultPreviousNumber,
                                 bool isPreviousAnalog = false, int analogDigitalTransitionStart=92);
         int EvalAnalogToDigitTransition(int _value, int _valuePreviousNumber,  int _resultPreviousNumber, int analogDigitalTransitionStart);
 
-        bool doNeuralNetwork(std::string time); 
+        bool doNeuralNetwork(std::string time);
         bool doAlignAndCut(std::string time);
 
         bool getNetworkParameter();
@@ -43,27 +43,27 @@ class ClassFlowCNNGeneral : public ClassFlowImage
         void doPostProcessEventHandling();
 
         std::string getHTMLSingleStep(std::string host);
-        std::string getReadout(int _seqNo = 0, bool _extendedResolution = false, int _valuePreviousNumber = -1, 
+        std::string getReadout(int _seqNo = 0, bool _extendedResolution = false, int _valuePreviousNumber = -1,
                                     int _resultPreviousNumber = -1, int analogDigitalTransitionStart = 92);
 
-        std::string getReadoutRawString(int _seqNo);  
+        std::string getReadoutRawString(int _seqNo);
 
-        void DrawROI(CImageBasis *_zw); 
+        void DrawROI(CImageBasis *_zw);
 
-        std::vector<HTMLInfo*> GetHTMLInfo();   
+        std::vector<HTMLInfo*> GetHTMLInfo();
 
         int getNumberGENERAL();
         general* GetGENERAL(int _seqNo);
         general* GetGENERAL(std::string _name, bool _create);
-        general* FindGENERAL(std::string _numbername);    
-        std::string getNameGENERAL(int _seqNo);    
+        general* FindGENERAL(std::string _numbername);
+        std::string getNameGENERAL(int _seqNo);
 
         void UpdateNameNumbers(std::vector<std::string> *_name_numbers);
 
         t_CNNType getCNNType() {return CNNType;};
         bool CNNTypeWithExtendedResolution();
 
-        std::string name() {return "ClassFlowCNNGeneral - " +  cnnname;}; 
+        std::string name() {return "ClassFlowCNNGeneral - " +  cnnname;};
 };
 
 #endif

--- a/code/components/jomjol_flowcontroll/ClassFlowControll.cpp
+++ b/code/components/jomjol_flowcontroll/ClassFlowControll.cpp
@@ -53,7 +53,7 @@ void ClassFlowControll::SetInitialParameter(void)
 	flowInfluxDB = NULL;
 	flowInfluxDBv2 = NULL;
     #endif //ENABLE_INFLUXDB
-    
+
     AutoStart = false;
     AutoInterval = 5; // in Minutes
     SetupModeActive = false;
@@ -157,7 +157,7 @@ bool ClassFlowControll::ReadParameter(FILE* pfile, std::string& aktparamgraph)
             {
                 LogFile.setLogLevel(ESP_LOG_DEBUG);
             }
-            else 
+            else
             {
                 LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "Invalid log level set. Use default log level ERROR");
                 LogFile.setLogLevel(ESP_LOG_ERROR);
@@ -167,7 +167,7 @@ bool ClassFlowControll::ReadParameter(FILE* pfile, std::string& aktparamgraph)
             if (!getIsPlannedReboot() && (esp_reset_reason() == ESP_RST_PANIC))
                 LogFile.setLogLevel(ESP_LOG_DEBUG);
         }
-        
+
         if ((toUpper(splitted[0]) == "LOGFILESRETENTION") && (splitted.size() > 1))
         {
             LogFile.SetLogFileRetention(std::stoi(splitted[1]));
@@ -219,7 +219,7 @@ bool ClassFlowControll::ReadParameter(FILE* pfile, std::string& aktparamgraph)
                 LogFile.WriteToFile(ESP_LOG_WARN, TAG, "Please reboot to activate new hostname");
             }
         }
-   
+
         #if (defined WLAN_USE_ROAMING_BY_SCANNING || (defined WLAN_USE_MESH_ROAMING && defined WLAN_USE_MESH_ROAMING_ACTIVATE_CLIENT_TRIGGERED_QUERIES))
         if ((toUpper(splitted[0]) == "RSSITHRESHOLD") || (toUpper(splitted[0]) == ";RSSITHRESHOLD"))
         {
@@ -386,7 +386,7 @@ ClassFlow* ClassFlowControll::CreateClassFlow(std::string _type)
     }
 
     #ifdef ENABLE_MQTT
-    else if (toUpper(_type).compare("[MQTT]") == 0) 
+    else if (toUpper(_type).compare("[MQTT]") == 0)
     {
         cfc = new ClassFlowMQTT(flowpostprocessing);
         if(cfc) {
@@ -397,7 +397,7 @@ ClassFlow* ClassFlowControll::CreateClassFlow(std::string _type)
     #endif //ENABLE_MQTT
 
     #ifdef ENABLE_INFLUXDB
-    else if (toUpper(_type).compare("[INFLUXDB]") == 0) 
+    else if (toUpper(_type).compare("[INFLUXDB]") == 0)
     {
         cfc = new ClassFlowInfluxDB(&FlowControll);
         if(cfc) {
@@ -405,7 +405,7 @@ ClassFlow* ClassFlowControll::CreateClassFlow(std::string _type)
             FlowControlPublish.push_back(cfc);
         }
     }
-    else if (toUpper(_type).compare("[INFLUXDBV2]") == 0) 
+    else if (toUpper(_type).compare("[INFLUXDBV2]") == 0)
     {
         cfc = new ClassFlowInfluxDBv2(&FlowControll);
         if (cfc) {
@@ -428,7 +428,7 @@ ClassFlow* ClassFlowControll::CreateClassFlow(std::string _type)
     }
 
     else if (toUpper(_type).compare("[SYSTEM]") == 0) {
-        cfc = this;      
+        cfc = this;
     }
 
     return cfc;
@@ -436,7 +436,7 @@ ClassFlow* ClassFlowControll::CreateClassFlow(std::string _type)
 
 
 bool ClassFlowControll::InitFlow(std::string config)
-{   
+{
     LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "Init flow");
 
     bool bRetVal = true;
@@ -453,7 +453,7 @@ bool ClassFlowControll::InitFlow(std::string config)
     setvbuf(pFile, NULL, _IOFBF, 512);
 
     if (pFile == NULL) {
-        LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "InitFlow: Unable to open config file"); 
+        LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "InitFlow: Unable to open config file");
         return false;
     }
 
@@ -518,13 +518,13 @@ void ClassFlowControll::DeinitFlow(void)
 
     gpio_handler_deinit();
     //LogFile.WriteHeapInfo("After GPIO");
-    
+
     #ifdef ENABLE_MQTT
 	delete flowMQTT;
     flowMQTT = NULL;
     //LogFile.WriteHeapInfo("After MQTT");
     #endif //ENABLE_MQTT
-    
+
     #ifdef ENABLE_INFLUXDB
     delete flowInfluxDB;
     flowInfluxDB = NULL;
@@ -554,13 +554,13 @@ void ClassFlowControll::DeinitFlow(void)
     delete flowtakeimage;
     flowtakeimage = NULL;
     //LogFile.WriteHeapInfo("After TAKEIMG");
-    
+
     FlowControll.clear();               // Clear vector to release allocated memory
     FlowControlPublish.clear();         // Clear vector to release allocated memory
     FlowStateEvaluationEvent.clear();  // Clear vector to release allocated memory
     FlowStatePublishEvent.clear();     // Clear vector to release allocated memory
-    
-    LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "Deinit flow completed"); 
+
+    LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "Deinit flow completed");
     LogFile.WriteHeapInfo("DeinitFlow completed");
 }
 
@@ -572,10 +572,10 @@ bool ClassFlowControll::doFlowImageEvaluation(std::string time)
 
     for (int i = 0; i < FlowControll.size(); ++i)
     {
-        #ifdef DEBUG_DETAIL_ON  
+        #ifdef DEBUG_DETAIL_ON
             LogFile.WriteHeapInfo("ClassFlowControll::doFlow: " + FlowControll[i]->name());
         #endif
-        
+
         setActStatus(TranslateAktstatus(FlowControll[i]->name()));
         LogFile.WriteToFile(ESP_LOG_INFO, TAG, "Process state: " + getActStatus());
         #ifdef ENABLE_MQTT
@@ -584,7 +584,7 @@ bool ClassFlowControll::doFlowImageEvaluation(std::string time)
 
         if (!FlowControll[i]->doFlow(time)) {
             FlowStateEvaluationEvent.push_back(FlowControll[i]->getFlowState());
-            
+
             for (int j = 0; j < FlowControll[i]->getFlowState()->EventCode.size(); j++) {
                 if (FlowControll[i]->getFlowState()->EventCode[j] < 0) {
                     LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "Error occured during processing of state \"" + getActStatus() + "\"");
@@ -615,10 +615,10 @@ bool ClassFlowControll::doFlowPublishData(std::string time)
 
     for (int i = 0; i < FlowControlPublish.size(); ++i)
     {
-        #ifdef DEBUG_DETAIL_ON  
+        #ifdef DEBUG_DETAIL_ON
             LogFile.WriteHeapInfo("ClassFlowControll::doFlow: " + FlowControlPublish[i]->name());
         #endif
-        
+
         setActStatus(TranslateAktstatus(FlowControlPublish[i]->name()));
         LogFile.WriteToFile(ESP_LOG_INFO, TAG, "Process state: " + getActStatus());
         #ifdef ENABLE_MQTT
@@ -655,7 +655,7 @@ bool ClassFlowControll::doFlowTakeImageOnly(std::string time)
 {
     bool result = true;
     FlowStateEvaluationEvent.clear();
-    
+
     for (int i = 0; i < FlowControll.size(); ++i)
     {
         if (FlowControll[i]->name() == "ClassFlowTakeImage") {
@@ -706,7 +706,7 @@ void ClassFlowControll::PostProcessEventHandler()
     for (int i = 0; i < FlowStateEvaluationEvent.size(); ++i) {
         for (int j = 0; j < FlowControll.size(); ++j) {
             if (FlowStateEvaluationEvent[i]->ClassName.compare(FlowControll[j]->name()) == 0) {
-                LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, FlowStateEvaluationEvent[i]->ClassName + "-> doPostProcessEventHandling"); 
+                LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, FlowStateEvaluationEvent[i]->ClassName + "-> doPostProcessEventHandling");
                 FlowControll[j]->doPostProcessEventHandling();
                 FlowControll[j]->presetFlowStateHandler(true); // Reinit after processing
             }
@@ -718,7 +718,7 @@ void ClassFlowControll::PostProcessEventHandler()
     for (int i = 0; i < FlowStatePublishEvent.size(); ++i) {
         for (int j = 0; j < FlowControlPublish.size(); ++j) {
             if (FlowStatePublishEvent[i]->ClassName.compare(FlowControlPublish[j]->name()) == 0) {
-                LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, FlowStatePublishEvent[i]->ClassName + "-> doPostProcessEventHandling"); 
+                LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, FlowStatePublishEvent[i]->ClassName + "-> doPostProcessEventHandling");
                 FlowControlPublish[j]->doPostProcessEventHandling();
                 FlowControlPublish[j]->presetFlowStateHandler(true); // Reinit after processing
             }
@@ -796,7 +796,7 @@ int ClassFlowControll::getFlowStateErrorOrDeviation()
 }
 
 
-std::vector<HTMLInfo*> ClassFlowControll::GetAllDigital() 
+std::vector<HTMLInfo*> ClassFlowControll::GetAllDigital()
 {
     if (flowdigit)
     {
@@ -852,11 +852,11 @@ void ClassFlowControll::AnalogDrawROI(CImageBasis *_zw)
 
 
 #ifdef ENABLE_MQTT
-bool ClassFlowControll::StartMQTTService() 
+bool ClassFlowControll::StartMQTTService()
 {
     if (flowMQTT == NULL) // Service disabled
         return true;
-    
+
     return flowMQTT->Start(AutoInterval);
 }
 #endif //ENABLE_MQTT
@@ -866,10 +866,10 @@ bool ClassFlowControll::StartMQTTService()
 std::string ClassFlowControll::getNumbersName()
 {
     if (flowpostprocessing == NULL) {
-        LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "getNumbersName: Request rejected. Postprocessing class not yet created"); 
+        LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "getNumbersName: Request rejected. Postprocessing class not yet created");
         return "";
     }
-    
+
     return flowpostprocessing->getNumbersName();
 }
 
@@ -878,10 +878,10 @@ std::string ClassFlowControll::getNumbersName()
 std::string ClassFlowControll::getNumbersName(int _number)
 {
     if (flowpostprocessing == NULL) {
-        LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "getNumbersName: Request rejected. Postprocessing class not yet created"); 
+        LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "getNumbersName: Request rejected. Postprocessing class not yet created");
         return "";
     }
-    
+
     return (*flowpostprocessing->GetNumbers())[_number]->name;
 }
 
@@ -890,10 +890,10 @@ std::string ClassFlowControll::getNumbersName(int _number)
 int ClassFlowControll::getNumbersSize()
 {
     if (flowpostprocessing == NULL) {
-        LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "getNumbersSize: Request rejected. Postprocessing class not yet created"); 
+        LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "getNumbersSize: Request rejected. Postprocessing class not yet created");
         return -1;
     }
-    
+
     return flowpostprocessing->GetNumbers()->size();
 }
 
@@ -902,17 +902,17 @@ int ClassFlowControll::getNumbersSize()
 int ClassFlowControll::getNumbersROISize(int _seqNo = 0, int _filter = 0)
 {
     if (flowpostprocessing == NULL) {
-        LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "Request rejected. Flowpostprocessing not available"); 
+        LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "Request rejected. Flowpostprocessing not available");
         return -1;
     }
-    
+
     if (_filter == 0)
         return (*flowpostprocessing->GetNumbers())[_seqNo]->digitCount + (*flowpostprocessing->GetNumbers())[_seqNo]->analogCount;
     else if (_filter == 1)
         return (*flowpostprocessing->GetNumbers())[_seqNo]->digitCount;
     else if (_filter == 2)
         return (*flowpostprocessing->GetNumbers())[_seqNo]->analogCount;
-    else 
+    else
         return -1;
 }
 
@@ -921,10 +921,10 @@ int ClassFlowControll::getNumbersROISize(int _seqNo = 0, int _filter = 0)
 int ClassFlowControll::getNumbersNamePosition(std::string _name)
 {
     if (flowpostprocessing == NULL) {
-        LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "getNumbersNamePosition: Request rejected. Postprocessing class not yet created"); 
+        LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "getNumbersNamePosition: Request rejected. Postprocessing class not yet created");
         return -1;
     }
-    
+
     for (int i = 0; i < getNumbersSize(); ++i) {
         if ((*flowpostprocessing->GetNumbers())[i]->name == _name)
             return i;
@@ -938,22 +938,22 @@ int ClassFlowControll::getNumbersNamePosition(std::string _name)
 std::string ClassFlowControll::getNumbersValue(int _position, int _type)
 {
     if (flowpostprocessing == NULL) {
-        LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "getNumbersValue: Request rejected. Postprocessing class not yet created"); 
+        LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "getNumbersValue: Request rejected. Postprocessing class not yet created");
         return "";
     }
 
     if (_position < 0 || _position > getNumbersSize()) {
-        LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "getNumbersValue: Array position out of range"); 
+        LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "getNumbersValue: Array position out of range");
         return "";
     }
 
     switch (_type) {
         case READOUT_TYPE_TIMESTAMP_PROCESSED:
             return (*flowpostprocessing->GetNumbers())[_position]->sTimeProcessed;
-        
+
         case READOUT_TYPE_TIMESTAMP_FALLBACKVALUE:
             return (*flowpostprocessing->GetNumbers())[_position]->sTimeFallbackValue;
-        
+
         case READOUT_TYPE_VALUE:
             return (*flowpostprocessing->GetNumbers())[_position]->sActualValue;
 
@@ -965,13 +965,13 @@ std::string ClassFlowControll::getNumbersValue(int _position, int _type)
 
         case READOUT_TYPE_VALUE_STATUS:
             return (*flowpostprocessing->GetNumbers())[_position]->sValueStatus;
-        
+
         case READOUT_TYPE_RATE_PER_MIN:
             return (*flowpostprocessing->GetNumbers())[_position]->sRatePerMin;
-        
+
         case READOUT_TYPE_RATE_PER_INTERVAL:
             return (*flowpostprocessing->GetNumbers())[_position]->sRatePerInterval;
-        
+
         default:
             return "";
     }
@@ -984,7 +984,7 @@ std::string ClassFlowControll::getNumbersValue(int _position, int _type)
 std::string ClassFlowControll::getNumbersValue(std::string _name, int _type)
 {
     if (flowpostprocessing == NULL) {
-        LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "Request rejected. Flowpostprocessing not available"); 
+        LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "Request rejected. Flowpostprocessing not available");
         return "";
     }
 
@@ -1024,7 +1024,7 @@ std::string ClassFlowControll::getReadoutAll(int _type)
                         if ((*numbers)[i]->isFallbackValueValid)
                             out = out + (*numbers)[i]->sFallbackValue;
                         else
-                            out = out + "Outdated or age indeterminable";                
+                            out = out + "Outdated or age indeterminable";
                     }
                     else
                         out = out + "Deactivated";
@@ -1049,7 +1049,7 @@ std::string ClassFlowControll::getReadoutAll(int _type)
     }
 
     return out;
-}	
+}
 
 
 /* Return values for numbers names (number sequences) of a given array positon and a given return type */
@@ -1077,14 +1077,14 @@ std::string ClassFlowControll::getReadout(bool _rawvalue = false, bool _noerror 
 }
 
 
-std::string ClassFlowControll::GetFallbackValue(std::string _number)	
+std::string ClassFlowControll::GetFallbackValue(std::string _number)
 {
     if (flowpostprocessing)
     {
-        return flowpostprocessing->GetFallbackValue(_number);   
+        return flowpostprocessing->GetFallbackValue(_number);
     }
 
-    return std::string("");    
+    return std::string("");
 }
 
 
@@ -1106,7 +1106,7 @@ bool ClassFlowControll::UpdateFallbackValue(std::string _newvalue, std::string _
             return false;
         }
     }
-    
+
     if (flowpostprocessing) {
         if (flowpostprocessing->SetFallbackValue(newvalueAsDouble, _numbers))
             return true;
@@ -1122,7 +1122,7 @@ bool ClassFlowControll::UpdateFallbackValue(std::string _newvalue, std::string _
 
 int ClassFlowControll::CleanTempFolder() {
     const char* folderPath = "/sdcard/img_tmp";
-    
+
     ESP_LOGD(TAG, "Clean up temporary folder to avoid damage of sdcard sectors: %s", folderPath);
     DIR *dir = opendir(folderPath);
     if (!dir) {
@@ -1146,7 +1146,7 @@ int ClassFlowControll::CleanTempFolder() {
     }
     closedir(dir);
     ESP_LOGD(TAG, "%d files deleted", deleted);
-    
+
     return 0;
 }
 
@@ -1173,7 +1173,7 @@ esp_err_t ClassFlowControll::GetJPGStream(std::string _fn, httpd_req_t *req)
 {
     ESP_LOGD(TAG, "ClassFlowControll::GetJPGStream %s", _fn.c_str());
 
-    #ifdef DEBUG_DETAIL_ON 
+    #ifdef DEBUG_DETAIL_ON
         LogFile.WriteHeapInfo("ClassFlowControll::GetJPGStream - Start");
     #endif
 
@@ -1192,7 +1192,7 @@ esp_err_t ClassFlowControll::GetJPGStream(std::string _fn, httpd_req_t *req)
     }
     else if (_fn == "alg_roi.jpg") {
         if (getActStatus().compare(std::string(FLOW_INIT_DELAYED)) == 0) {
-            FILE* file = fopen("/sdcard/html/Flowstate_initialization_delayed.jpg", "rb"); 
+            FILE* file = fopen("/sdcard/html/Flowstate_initialization_delayed.jpg", "rb");
 
             if (!file) {
                 LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "File /sdcard/html/Flowstate_initialization_delayed.jpg not found");
@@ -1211,7 +1211,7 @@ esp_err_t ClassFlowControll::GetJPGStream(std::string _fn, httpd_req_t *req)
 
             if (!fileBuffer) {
                 LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "ClassFlowControll::GetJPGStream: Not enough memory to create fileBuffer: " + std::to_string(fileSize));
-                fclose(file);  
+                fclose(file);
                 return ESP_FAIL;
             }
 
@@ -1219,12 +1219,12 @@ esp_err_t ClassFlowControll::GetJPGStream(std::string _fn, httpd_req_t *req)
             fclose(file);
 
             httpd_resp_set_type(req, "image/jpeg");
-            result = httpd_resp_send(req, (const char *)fileBuffer, fileSize); 
+            result = httpd_resp_send(req, (const char *)fileBuffer, fileSize);
             free(fileBuffer);
         }
         else if (getActStatus().compare(std::string(FLOW_INIT)) == 0 ||
                     getActStatus().compare(std::string(FLOW_INIT_FAILED)) == 0) {
-            FILE* file = fopen("/sdcard/html/Flowstate_initialization.jpg", "rb"); 
+            FILE* file = fopen("/sdcard/html/Flowstate_initialization.jpg", "rb");
 
             if (!file) {
                 LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "File /sdcard/html/Flowstate_initialization.jpg not found");
@@ -1243,7 +1243,7 @@ esp_err_t ClassFlowControll::GetJPGStream(std::string _fn, httpd_req_t *req)
 
             if (!fileBuffer) {
                 LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "ClassFlowControll::GetJPGStream: Not enough memory to create fileBuffer: " + std::to_string(fileSize));
-                fclose(file);  
+                fclose(file);
                 return ESP_FAIL;
             }
 
@@ -1251,11 +1251,11 @@ esp_err_t ClassFlowControll::GetJPGStream(std::string _fn, httpd_req_t *req)
             fclose(file);
 
             httpd_resp_set_type(req, "image/jpeg");
-            result = httpd_resp_send(req, (const char *)fileBuffer, fileSize); 
+            result = httpd_resp_send(req, (const char *)fileBuffer, fileSize);
             free(fileBuffer);
         }
         else if (getActStatus().compare(std::string(FLOW_SETUP_MODE)) == 0) {
-            FILE* file = fopen("/sdcard/html/Flowstate_setup_mode.jpg", "rb"); 
+            FILE* file = fopen("/sdcard/html/Flowstate_setup_mode.jpg", "rb");
 
             if (!file) {
                 LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "File /sdcard/html/Flowstate_setup_mode.jpg not found");
@@ -1274,7 +1274,7 @@ esp_err_t ClassFlowControll::GetJPGStream(std::string _fn, httpd_req_t *req)
 
             if (!fileBuffer) {
                 LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "ClassFlowControll::GetJPGStream: Not enough memory to create fileBuffer: " + std::to_string(fileSize));
-                fclose(file);  
+                fclose(file);
                 return ESP_FAIL;
             }
 
@@ -1282,12 +1282,12 @@ esp_err_t ClassFlowControll::GetJPGStream(std::string _fn, httpd_req_t *req)
             fclose(file);
 
             httpd_resp_set_type(req, "image/jpeg");
-            result = httpd_resp_send(req, (const char *)fileBuffer, fileSize); 
+            result = httpd_resp_send(req, (const char *)fileBuffer, fileSize);
             free(fileBuffer);
         }
         else if (((flowtakeimage != NULL) && !flowtakeimage->getFlowState()->getExecuted && getActStatus().compare(std::string(FLOW_IDLE_NO_AUTOSTART)) == 0) ||
                     (!isAutoStart() && FlowStateEventOccured() && getActStatus().compare(std::string(FLOW_TAKE_IMAGE)) == 0)) {   // Show only before first cycle started or error occured, otherwise result will be shown till next start
-            FILE* file = fopen("/sdcard/html/Flowstate_idle_no_autostart.jpg", "rb"); 
+            FILE* file = fopen("/sdcard/html/Flowstate_idle_no_autostart.jpg", "rb");
 
             if (!file) {
                 LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "File /sdcard/html/Flowstate_idle_no_autostart.jpg not found");
@@ -1306,7 +1306,7 @@ esp_err_t ClassFlowControll::GetJPGStream(std::string _fn, httpd_req_t *req)
 
             if (!fileBuffer) {
                 LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "ClassFlowControll::GetJPGStream: Not enough memory to create fileBuffer: " + std::to_string(fileSize));
-                fclose(file);  
+                fclose(file);
                 return ESP_FAIL;
             }
 
@@ -1314,12 +1314,12 @@ esp_err_t ClassFlowControll::GetJPGStream(std::string _fn, httpd_req_t *req)
             fclose(file);
 
             httpd_resp_set_type(req, "image/jpeg");
-            result = httpd_resp_send(req, (const char *)fileBuffer, fileSize); 
+            result = httpd_resp_send(req, (const char *)fileBuffer, fileSize);
             free(fileBuffer);
         }
         else if (getActStatus().compare(std::string(FLOW_TAKE_IMAGE)) == 0) {
             if (flowalignment && flowalignment->AlgROI) {
-                FILE* file = fopen("/sdcard/html/Flowstate_take_image.jpg", "rb");    
+                FILE* file = fopen("/sdcard/html/Flowstate_take_image.jpg", "rb");
 
                 if (!file) {
                     LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "File /sdcard/html/Flowstate_take_image.jpg not found");
@@ -1333,7 +1333,7 @@ esp_err_t ClassFlowControll::GetJPGStream(std::string _fn, httpd_req_t *req)
                 fseek(file, 0, SEEK_END);
                 flowalignment->AlgROI->size = ftell(file); /* how long is the file ? */
                 fseek(file, 0, SEEK_SET); /* reset */
-                
+
                 if (flowalignment->AlgROI->size > MAX_JPG_SIZE) {
                     LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "File /sdcard/html/Flowstate_take_image.jpg (" + std::to_string(flowalignment->AlgROI->size) +
                                                             ") > allocated buffer (" + std::to_string(MAX_JPG_SIZE) + ")");
@@ -1359,7 +1359,7 @@ esp_err_t ClassFlowControll::GetJPGStream(std::string _fn, httpd_req_t *req)
             }
         }
         else if (isAutoStart() && FlowStateEventOccured() && (getActStatus().compare(std::string(FLOW_TAKE_IMAGE)) == 0)) {
-            FILE* file = fopen("/sdcard/html/Flowstate_idle_autostart.jpg", "rb"); 
+            FILE* file = fopen("/sdcard/html/Flowstate_idle_autostart.jpg", "rb");
 
             if (!file) {
                 LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "File /sdcard/html/Flowstate_idle_autostart.jpg not found");
@@ -1378,7 +1378,7 @@ esp_err_t ClassFlowControll::GetJPGStream(std::string _fn, httpd_req_t *req)
 
             if (!fileBuffer) {
                 LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "ClassFlowControll::GetJPGStream: Not enough memory to create fileBuffer: " + std::to_string(fileSize));
-                fclose(file);  
+                fclose(file);
                 return ESP_FAIL;
             }
 
@@ -1386,7 +1386,7 @@ esp_err_t ClassFlowControll::GetJPGStream(std::string _fn, httpd_req_t *req)
             fclose(file);
 
             httpd_resp_set_type(req, "image/jpeg");
-            result = httpd_resp_send(req, (const char *)fileBuffer, fileSize); 
+            result = httpd_resp_send(req, (const char *)fileBuffer, fileSize);
             free(fileBuffer);
         }
         else {
@@ -1408,7 +1408,7 @@ esp_err_t ClassFlowControll::GetJPGStream(std::string _fn, httpd_req_t *req)
     }
     else {
         std::vector<HTMLInfo*> htmlinfo;
-    
+
         htmlinfo = GetAllDigital();
         ESP_LOGD(TAG, "After getClassFlowControll::GetAllDigital");
 
@@ -1433,7 +1433,7 @@ esp_err_t ClassFlowControll::GetJPGStream(std::string _fn, httpd_req_t *req)
         {
 	        htmlinfo = GetAllAnalog();
 	        ESP_LOGD(TAG, "After getClassFlowControll::GetAllAnalog");
-	        
+
 	        for (int i = 0; i < htmlinfo.size(); ++i)
 	        {
 	            if (_fn == htmlinfo[i]->filename)
@@ -1453,7 +1453,7 @@ esp_err_t ClassFlowControll::GetJPGStream(std::string _fn, httpd_req_t *req)
     	}
     }
 
-    #ifdef DEBUG_DETAIL_ON 
+    #ifdef DEBUG_DETAIL_ON
         LogFile.WriteHeapInfo("ClassFlowControll::GetJPGStream - before send");
     #endif
 
@@ -1468,11 +1468,11 @@ esp_err_t ClassFlowControll::GetJPGStream(std::string _fn, httpd_req_t *req)
 
         if (_sendDelete)
             delete _send;
-            
-        _send = NULL;  
+
+        _send = NULL;
     }
 
-    #ifdef DEBUG_DETAIL_ON 
+    #ifdef DEBUG_DETAIL_ON
         LogFile.WriteHeapInfo("ClassFlowControll::GetJPGStream - done");
     #endif
 

--- a/code/components/jomjol_flowcontroll/ClassFlowControll.h
+++ b/code/components/jomjol_flowcontroll/ClassFlowControll.h
@@ -38,7 +38,7 @@ class ClassFlowControll : public ClassFlow
 		std::vector<strFlowState*> FlowStatePublishEvent;
 
 		ClassFlowTakeImage* flowtakeimage;
-		ClassFlowAlignment* flowalignment;	
+		ClassFlowAlignment* flowalignment;
 		ClassFlowCNNGeneral* flowanalog;
 		ClassFlowCNNGeneral* flowdigit;
 		ClassFlowPostProcessing* flowpostprocessing;
@@ -49,15 +49,15 @@ class ClassFlowControll : public ClassFlow
 		ClassFlowInfluxDB* flowInfluxDB;
 		ClassFlowInfluxDBv2* flowInfluxDBv2;
 		#endif //ENABLE_INFLUXDB
-		
+
 		ClassFlow* CreateClassFlow(std::string _type);
-		void SetInitialParameter(void);	
+		void SetInitialParameter(void);
 
 		float AutoInterval;
 		bool AutoStart;
 		bool SetupModeActive;
 		bool readParameterDone;
-		
+
 		std::string aktstatus;
 		std::string aktstatusWithTime;
 		int flowStateErrorInRow;
@@ -70,11 +70,11 @@ public:
 	void DeinitFlow(void);
 	ClassFlow* getFlowClass(std::string _classname);
 
-	bool ReadParameter(FILE* pfile, std::string& aktparamgraph);	
+	bool ReadParameter(FILE* pfile, std::string& aktparamgraph);
 	bool doFlowImageEvaluation(std::string time);
 	bool doFlowPublishData(std::string time);
 	bool doFlowTakeImageOnly(std::string time);
-	
+
 	std::string TranslateAktstatus(std::string _input);
 	bool getStatusSetupModus() {return SetupModeActive;};
 
@@ -89,7 +89,7 @@ public:
 	std::string getReadout(bool _rawvalue, bool _noerror, int _number);
 
 	bool UpdateFallbackValue(std::string _newvalue, std::string _numbers);
-	std::string GetFallbackValue(std::string _number = "");	
+	std::string GetFallbackValue(std::string _number = "");
 
 	#ifdef ENABLE_MQTT
 	bool StartMQTTService();
@@ -117,7 +117,7 @@ public:
 	void PostProcessEventHandler();
 
 	std::vector<HTMLInfo*> GetAllDigital();
-	std::vector<HTMLInfo*> GetAllAnalog();	
+	std::vector<HTMLInfo*> GetAllAnalog();
 
 	t_CNNType GetTypeDigital();
 	t_CNNType GetTypeAnalog();

--- a/code/components/jomjol_flowcontroll/ClassFlowDefineTypes.h
+++ b/code/components/jomjol_flowcontroll/ClassFlowDefineTypes.h
@@ -19,7 +19,7 @@ enum t_CNNType {
 
 
 struct t_ROI {
-    int posx, posy, deltax, deltay; 
+    int posx, posy, deltax, deltay;
     int CNNResult = -10;     // normalized to 0-99 (exception for class11: 0-10: 0-9+NaN), default: negative number equal to "-1.0"
     bool isRejected, CCW;
     std::string name;
@@ -62,7 +62,7 @@ struct NumberPost {
     t_RateType rateType;            // Parameter: Select Rate Checking Procedure
     float maxRateValue;             // Parameter: Max allowed rate
     double ratePerMin;              // Rate per minute (e.g. m3/min)
-    double ratePerInterval;         // Rate per interval, value delta between actual and fallback value, 
+    double ratePerInterval;         // Rate per interval, value delta between actual and fallback value,
                                     // e.g. dV/dT (actual value-fallbackvalue)/(actual processing timestamp-fallbackvalue processing timestamp)
 
     double fallbackValue;           // Fallback value, equal the last successful processed value (legacy name: prevalue)
@@ -72,15 +72,15 @@ struct NumberPost {
     std::string sTimeFallbackValue; // FallbackValue timestamp -> Time of last valid value
     std::string sRatePerMin;        // Rate per minute, based on time between last valid and actual reading
     std::string sRatePerInterval;   // Rate per interval, value delta between actual value and last valid value (fallback value)
-    std::string sRawValue;          // Raw value (possibly incl. N & leading 0)    
+    std::string sRawValue;          // Raw value (possibly incl. N & leading 0)
     std::string sActualValue;       // Value of actual valid reading, incl. post-processing corrections
     std::string sFallbackValue;     // Fallback value, equal to last valid reading (legacy name: prevalue)
     std::string sValueStatus;       // Value status
 
-    std::string FieldV1;            // Fieldname in InfluxDBv1  
+    std::string FieldV1;            // Fieldname in InfluxDBv1
     std::string MeasurementV1;      // Measurement in InfluxDBv1
 
-    std::string FieldV2;            // Fieldname in InfluxDBv2  
+    std::string FieldV2;            // Fieldname in InfluxDBv2
     std::string MeasurementV2;      // Measurement in InfluxDBv2
 
     general *digit_roi;             // Pointer to digit ROI struct

--- a/code/components/jomjol_flowcontroll/ClassFlowImage.cpp
+++ b/code/components/jomjol_flowcontroll/ClassFlowImage.cpp
@@ -52,7 +52,7 @@ ClassFlowImage::ClassFlowImage(std::vector<ClassFlow*> * lfc, ClassFlow *_prev, 
 }
 
 
-std::string ClassFlowImage::CreateLogFolder(std::string time) 
+std::string ClassFlowImage::CreateLogFolder(std::string time)
 {
 	if (!isLogImage)
 		return "";
@@ -68,7 +68,7 @@ std::string ClassFlowImage::CreateLogFolder(std::string time)
 }
 
 
-void ClassFlowImage::LogImage(std::string _logPath, std::string _numbername, t_CNNType _type, int _value, std::string _time, CImageBasis *_img) 
+void ClassFlowImage::LogImage(std::string _logPath, std::string _numbername, t_CNNType _type, int _value, std::string _time, CImageBasis *_img)
 {
 	if (!isLogImage)
 		return;
@@ -77,7 +77,7 @@ void ClassFlowImage::LogImage(std::string _logPath, std::string _numbername, t_C
         LogFile.WriteToFile(ESP_LOG_ERROR, logTag, "LogImage: logPath empty");
         return;
     }
-	
+
 	char buf[10];
 
     if (_type == None) { // log with no label -> raw image
@@ -107,7 +107,7 @@ void ClassFlowImage::RemoveOldLogs()
 {
 	if (!isLogImage)
 		return;
-	
+
     if (imagesRetention == 0) {
         LogFile.WriteToFile(ESP_LOG_DEBUG, logTag, "RemoveOldLogs: Retention deactivated");
         return;
@@ -121,7 +121,7 @@ void ClassFlowImage::RemoveOldLogs()
         return;
     }
 
-    time_t rawtime;  
+    time_t rawtime;
     time(&rawtime);
     rawtime = addDays(rawtime, -imagesRetention + 1);
     //ESP_LOGI(TAG, "imagesRetention: %d", imagesRetention);
@@ -134,18 +134,18 @@ void ClassFlowImage::RemoveOldLogs()
 
     while ((entry = readdir(dir)) != NULL) {
 		if (entry->d_type == DT_DIR) {
-			//ESP_LOGD(TAG, "Compare folder %s to %s", entry->d_name, cmpfolderame.c_str());	
+			//ESP_LOGD(TAG, "Compare folder %s to %s", entry->d_name, cmpfolderame.c_str());
 			if ((strlen(entry->d_name) == cmpfolderame.length()) && (strcmp(entry->d_name, cmpfolderame.c_str()) < 0)) {
                 std::string folderpath = imagesLocation + "/" + entry->d_name;
                 //ESP_LOGI(TAG, "Delete folder %s", folderpath.c_str());
                 if (removeFolder(folderpath.c_str(), TAG) > 0) {
                     deleted++;
-                } 
+                }
                 else {
                     LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "Failed to delete folder " + folderpath);
                     notDeleted ++;
                 }
-			} 
+			}
             else {
                 notDeleted ++;
             }

--- a/code/components/jomjol_flowcontroll/ClassFlowImage.h
+++ b/code/components/jomjol_flowcontroll/ClassFlowImage.h
@@ -22,7 +22,7 @@ class ClassFlowImage : public ClassFlow
 		ClassFlowImage(std::vector<ClassFlow*> * lfc, const char* logTag);
 		ClassFlowImage(std::vector<ClassFlow*> * lfc, ClassFlow *_prev, const char* logTag);
 		virtual ~ClassFlowImage();
-		
+
 		void RemoveOldLogs();
 };
 

--- a/code/components/jomjol_flowcontroll/ClassFlowInfluxDB.cpp
+++ b/code/components/jomjol_flowcontroll/ClassFlowInfluxDB.cpp
@@ -20,7 +20,7 @@ static const char* TAG = "INFLUXDB";
 void ClassFlowInfluxDB::SetInitialParameter(void)
 {
     presetFlowStateHandler(true);
-    flowpostprocessing = NULL;  
+    flowpostprocessing = NULL;
     previousElement = NULL;
     ListFlowControll = NULL;
 
@@ -36,7 +36,7 @@ void ClassFlowInfluxDB::SetInitialParameter(void)
 
     disabled = false;
     InfluxDBenable = false;
-}       
+}
 
 
 ClassFlowInfluxDB::ClassFlowInfluxDB()
@@ -88,7 +88,7 @@ bool ClassFlowInfluxDB::ReadParameter(FILE* pfile, std::string& aktparamgraph)
         if (!this->GetNextParagraph(pfile, aktparamgraph))
             return false;
 
-    if (toUpper(aktparamgraph).compare("[INFLUXDB]") != 0) 
+    if (toUpper(aktparamgraph).compare("[INFLUXDB]") != 0)
         return false;
 
     while (this->getNextLine(pfile, &aktparamgraph) && !this->isNewParagraph(aktparamgraph))
@@ -110,7 +110,7 @@ bool ClassFlowInfluxDB::ReadParameter(FILE* pfile, std::string& aktparamgraph)
         if ((toUpper(_param) == "USER") && (splitted.size() > 1))
         {
             this->user = splitted[1];
-        } 
+        }
 
         if ((toUpper(_param) == "PASSWORD") && (splitted.size() > 1))
         {
@@ -120,7 +120,7 @@ bool ClassFlowInfluxDB::ReadParameter(FILE* pfile, std::string& aktparamgraph)
         if ((toUpper(splitted[0]) == "TLSENCRYPTION") && (splitted.size() > 1))
         {
             if (toUpper(splitted[1]) == "TRUE")
-                TLSEncryption = true;  
+                TLSEncryption = true;
             else
                 TLSEncryption = false;
         }
@@ -129,7 +129,7 @@ bool ClassFlowInfluxDB::ReadParameter(FILE* pfile, std::string& aktparamgraph)
         {
             TLSCACertFilename = "/sdcard" + splitted[1];
         }
-        
+
         if ((toUpper(splitted[0]) == "TLSCLIENTCERT") && (splitted.size() > 1))
         {
             TLSClientCertFilename = "/sdcard" + splitted[1];
@@ -144,25 +144,25 @@ bool ClassFlowInfluxDB::ReadParameter(FILE* pfile, std::string& aktparamgraph)
         {
             handleMeasurement(splitted[0], splitted[1]);
         }
-        
+
         if (((toUpper(_param) == "FIELD")) && (splitted.size() > 1))
         {
             handleFieldname(splitted[0], splitted[1]);
         }
     }
 
-    LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "Init: URI: " + uri + ", Database: " + database + ", User: " + user + 
+    LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "Init: URI: " + uri + ", Database: " + database + ", User: " + user +
                         ", Password: *****, TLS Encryption: " + std::to_string(TLSEncryption));
 
-    if ((uri.length() > 0) && (uri != "undefined") && (database.length() > 0) && (database != "undefined")) { 
-        InfluxDBenable = InfluxDBInit(uri, database, user, password, TLSEncryption, TLSCACertFilename, 
+    if ((uri.length() > 0) && (uri != "undefined") && (database.length() > 0) && (database != "undefined")) {
+        InfluxDBenable = InfluxDBInit(uri, database, user, password, TLSEncryption, TLSCACertFilename,
                                         TLSClientCertFilename, TLSClientKeyFilename);
-    } 
+    }
     else {
         LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "Init failed, missing or wrong parameter");
         InfluxDBenable = false;
     }
-   
+
     return InfluxDBenable;
 }
 
@@ -199,7 +199,7 @@ bool ClassFlowInfluxDB::doFlow(std::string zwtime)
         LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "Failed to read post-processing data");
         return false;
     }
-      
+
     return true;
 }
 
@@ -207,7 +207,7 @@ bool ClassFlowInfluxDB::doFlow(std::string zwtime)
 void ClassFlowInfluxDB::doPostProcessEventHandling()
 {
     // Post cycle process handling can be included here. Function is called after processing cycle is completed
-    
+
 }
 
 
@@ -220,7 +220,7 @@ void ClassFlowInfluxDB::handleMeasurement(std::string _decsep, std::string _valu
         _digit = _decsep.substr(0, _pospunkt);
     else
         _digit = "default";
-    
+
     for (int j = 0; j < flowpostprocessing->GetNumbers()->size(); ++j) {
         if (_digit == "default" || (*flowpostprocessing->GetNumbers())[j]->name == _digit)
             (*flowpostprocessing->GetNumbers())[j]->MeasurementV1 = _value;
@@ -239,11 +239,11 @@ void ClassFlowInfluxDB::handleFieldname(std::string _decsep, std::string _value)
         _digit = _decsep.substr(0, _pospunkt);
     else
         _digit = "default";
-    
+
     for (int j = 0; j < flowpostprocessing->GetNumbers()->size(); ++j) {
         if (_digit == "default" || (*flowpostprocessing->GetNumbers())[j]->name == _digit)
             (*flowpostprocessing->GetNumbers())[j]->FieldV1 = _value;
-        
+
         //ESP_LOGI(TAG, "handleFieldname: Name: %s, Pospunkt: %d, value: %s", _digit.c_str(), _pospunkt, _value);
     }
 }

--- a/code/components/jomjol_flowcontroll/ClassFlowInfluxDB.h
+++ b/code/components/jomjol_flowcontroll/ClassFlowInfluxDB.h
@@ -20,10 +20,10 @@ class ClassFlowInfluxDB : public ClassFlow
         std::string TLSCACertFilename, TLSClientCertFilename, TLSClientKeyFilename;
         bool InfluxDBenable;
 
-        void SetInitialParameter(void);    
-        
-        void handleFieldname(std::string _decsep, std::string _value);   
-        void handleMeasurement(std::string _decsep, std::string _value);   
+        void SetInitialParameter(void);
+
+        void handleFieldname(std::string _decsep, std::string _value);
+        void handleMeasurement(std::string _decsep, std::string _value);
 
     public:
         ClassFlowInfluxDB();

--- a/code/components/jomjol_flowcontroll/ClassFlowInfluxDBv2.cpp
+++ b/code/components/jomjol_flowcontroll/ClassFlowInfluxDBv2.cpp
@@ -20,14 +20,14 @@ static const char* TAG = "INFLUXDBV2";
 void ClassFlowInfluxDBv2::SetInitialParameter(void)
 {
     presetFlowStateHandler(true);
-    flowpostprocessing = NULL;  
+    flowpostprocessing = NULL;
     previousElement = NULL;
     ListFlowControll = NULL;
 
     uri = "";
     bucket = "";
-    dborg = "";  
-    dbtoken = "";  
+    dborg = "";
+    dbtoken = "";
     TLSEncryption = false;
     TLSCACertFilename = "";
     TLSClientCertFilename = "";
@@ -35,7 +35,7 @@ void ClassFlowInfluxDBv2::SetInitialParameter(void)
 
     disabled = false;
     InfluxDBenable = false;
-}       
+}
 
 
 ClassFlowInfluxDBv2::ClassFlowInfluxDBv2()
@@ -87,7 +87,7 @@ bool ClassFlowInfluxDBv2::ReadParameter(FILE* pfile, std::string& aktparamgraph)
         if (!this->GetNextParagraph(pfile, aktparamgraph))
             return false;
 
-    if (toUpper(aktparamgraph).compare("[INFLUXDBV2]") != 0) 
+    if (toUpper(aktparamgraph).compare("[INFLUXDBV2]") != 0)
         return false;
 
     while (this->getNextLine(pfile, &aktparamgraph) && !this->isNewParagraph(aktparamgraph))
@@ -119,7 +119,7 @@ bool ClassFlowInfluxDBv2::ReadParameter(FILE* pfile, std::string& aktparamgraph)
         if ((toUpper(splitted[0]) == "TLSENCRYPTION") && (splitted.size() > 1))
         {
             if (toUpper(splitted[1]) == "TRUE")
-                TLSEncryption = true;  
+                TLSEncryption = true;
             else
                 TLSEncryption = false;
         }
@@ -128,7 +128,7 @@ bool ClassFlowInfluxDBv2::ReadParameter(FILE* pfile, std::string& aktparamgraph)
         {
             TLSCACertFilename = "/sdcard" + splitted[1];
         }
-        
+
         if ((toUpper(splitted[0]) == "TLSCLIENTCERT") && (splitted.size() > 1))
         {
             TLSClientCertFilename = "/sdcard" + splitted[1];
@@ -142,7 +142,7 @@ bool ClassFlowInfluxDBv2::ReadParameter(FILE* pfile, std::string& aktparamgraph)
         if (((toUpper(_param) == "MEASUREMENT")) && (splitted.size() > 1))
         {
             handleMeasurement(splitted[0], splitted[1]);
-        }              
+        }
 
         if (((toUpper(_param) == "FIELD")) && (splitted.size() > 1))
         {
@@ -150,20 +150,20 @@ bool ClassFlowInfluxDBv2::ReadParameter(FILE* pfile, std::string& aktparamgraph)
         }
     }
 
-    LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "Init: URI: " + uri + ", Bucket: " + bucket + ", Org: " + dborg + 
+    LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "Init: URI: " + uri + ", Bucket: " + bucket + ", Org: " + dborg +
                         ", Token: *****, TLS Encryption: " + std::to_string(TLSEncryption));
 
-    if ((uri.length() > 0 && (uri != "undefined")) && (bucket.length() > 0) && (bucket != "undefined") && 
-        (dborg.length() > 0) && (dborg != "undefined") && (dbtoken.length() > 0) && (dbtoken != "undefined")) 
-    { 
-        InfluxDBenable = InfluxDBv2Init(uri, bucket, dborg, dbtoken, TLSEncryption, TLSCACertFilename, 
+    if ((uri.length() > 0 && (uri != "undefined")) && (bucket.length() > 0) && (bucket != "undefined") &&
+        (dborg.length() > 0) && (dborg != "undefined") && (dbtoken.length() > 0) && (dbtoken != "undefined"))
+    {
+        InfluxDBenable = InfluxDBv2Init(uri, bucket, dborg, dbtoken, TLSEncryption, TLSCACertFilename,
                                             TLSClientCertFilename, TLSClientKeyFilename);
     }
     else {
         LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "Init failed, missing or wrong parameter");
         InfluxDBenable = false;
     }
-   
+
     return InfluxDBenable;
 }
 
@@ -200,7 +200,7 @@ bool ClassFlowInfluxDBv2::doFlow(std::string zwtime)
         LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "Failed to read post-processing data");
         return false;
     }
-    
+
     return true;
 }
 
@@ -208,7 +208,7 @@ bool ClassFlowInfluxDBv2::doFlow(std::string zwtime)
 void ClassFlowInfluxDBv2::doPostProcessEventHandling()
 {
     // Post cycle process handling can be included here. Function is called after processing cycle is completed
-    
+
 }
 
 
@@ -221,7 +221,7 @@ void ClassFlowInfluxDBv2::handleMeasurement(std::string _decsep, std::string _va
         _digit = _decsep.substr(0, _pospunkt);
     else
         _digit = "default";
-    
+
     for (int j = 0; j < flowpostprocessing->GetNumbers()->size(); ++j) {
         if (_digit == "default" || (*flowpostprocessing->GetNumbers())[j]->name == _digit)
             (*flowpostprocessing->GetNumbers())[j]->MeasurementV2 = _value;
@@ -240,7 +240,7 @@ void ClassFlowInfluxDBv2::handleFieldname(std::string _decsep, std::string _valu
         _digit = _decsep.substr(0, _pospunkt);
     else
         _digit = "default";
-    
+
     for (int j = 0; j < flowpostprocessing->GetNumbers()->size(); ++j) {
         if (_digit == "default" || (*flowpostprocessing->GetNumbers())[j]->name == _digit)
             (*flowpostprocessing->GetNumbers())[j]->FieldV2 = _value;

--- a/code/components/jomjol_flowcontroll/ClassFlowInfluxDBv2.h
+++ b/code/components/jomjol_flowcontroll/ClassFlowInfluxDBv2.h
@@ -20,9 +20,9 @@ class ClassFlowInfluxDBv2 : public ClassFlow
         std::string TLSCACertFilename, TLSClientCertFilename, TLSClientKeyFilename;
         bool InfluxDBenable;
 
-        void SetInitialParameter(void);     
+        void SetInitialParameter(void);
 
-        void handleFieldname(std::string _decsep, std::string _value);   
+        void handleFieldname(std::string _decsep, std::string _value);
         void handleMeasurement(std::string _decsep, std::string _value);
 
 

--- a/code/components/jomjol_flowcontroll/ClassFlowMQTT.cpp
+++ b/code/components/jomjol_flowcontroll/ClassFlowMQTT.cpp
@@ -25,14 +25,14 @@ void ClassFlowMQTT::SetInitialParameter(void)
 {
     presetFlowStateHandler(true);
     previousElement = NULL;
-    ListFlowControll = NULL; 
+    ListFlowControll = NULL;
     disabled = false;
 
     mqttConfig = {};
     HADiscoveryConfig = {};
 
     processDataNotation = JSON;
-}       
+}
 
 
 ClassFlowMQTT::ClassFlowMQTT(ClassFlowPostProcessing* _flowpostprocessing)
@@ -77,11 +77,11 @@ bool ClassFlowMQTT::ReadParameter(FILE* pfile, std::string& aktparamgraph)
 
         if ((toUpper(splitted[0]) == "PASSWORD") && (splitted.size() > 1)) {
             mqttConfig.password = splitted[1];
-        }   
+        }
 
         if ((toUpper(splitted[0]) == "TLSENCRYPTION") && (splitted.size() > 1)) {
             if (toUpper(splitted[1]) == "TRUE")
-                mqttConfig.TLSEncryption = true;  
+                mqttConfig.TLSEncryption = true;
             else
                 mqttConfig.TLSEncryption = false;
         }
@@ -89,18 +89,18 @@ bool ClassFlowMQTT::ReadParameter(FILE* pfile, std::string& aktparamgraph)
         if ((toUpper(splitted[0]) == "TLSCACERT") && (splitted.size() > 1)) {
             mqttConfig.TLSCACertFilename = "/sdcard" + splitted[1];
         }
-        
+
         if ((toUpper(splitted[0]) == "TLSCLIENTCERT") && (splitted.size() > 1)) {
             mqttConfig.TLSClientCertFilename = "/sdcard" + splitted[1];
         }
 
         if ((toUpper(splitted[0]) == "TLSCLIENTKEY") && (splitted.size() > 1)) {
             mqttConfig.TLSClientKeyFilename = "/sdcard" + splitted[1];
-        }      
+        }
 
         if ((toUpper(splitted[0]) == "RETAINPROCESSDATA") && (splitted.size() > 1)) {
             if (toUpper(splitted[1]) == "TRUE")
-                mqttConfig.retainProcessData = true;  
+                mqttConfig.retainProcessData = true;
             else
                 mqttConfig.retainProcessData = false;
         }
@@ -123,7 +123,7 @@ bool ClassFlowMQTT::ReadParameter(FILE* pfile, std::string& aktparamgraph)
                 HADiscoveryConfig.HADiscoveryPrefix.pop_back();
         }
 
-        
+
         if ((toUpper(splitted[0]) == "HASTATUSTOPIC") && (splitted.size() > 1)) {
             HADiscoveryConfig.HAStatusTopic = splitted[1];
             // Remove traling slash or backslash if existing
@@ -137,9 +137,9 @@ bool ClassFlowMQTT::ReadParameter(FILE* pfile, std::string& aktparamgraph)
             else
                 HADiscoveryConfig.HARetainDiscoveryTopics = false;
         }
-        
+
         if ((toUpper(splitted[0]) == "HAMETERTYPE") && (splitted.size() > 1)) {
-        /* Use meter type for the device class 
+        /* Use meter type for the device class
            Make sure it is a listed one on https://developers.home-assistant.io/docs/core/entity/sensor/#available-device-classes */
             if (toUpper(splitted[1]) == "WATER_M3") {
                 mqttServer_setMeterType("water", "m³", "h", "m³/h");
@@ -186,7 +186,7 @@ bool ClassFlowMQTT::ReadParameter(FILE* pfile, std::string& aktparamgraph)
 }
 
 
-bool ClassFlowMQTT::Start(float _processingInterval) 
+bool ClassFlowMQTT::Start(float _processingInterval)
 {
     std::stringstream stream;
 
@@ -201,7 +201,7 @@ bool ClassFlowMQTT::Start(float _processingInterval)
     stream << std::fixed << std::setprecision(1) << "Process interval: " << _processingInterval <<
             "min -> MQTT keepAlive: " << ((float)mqttConfig.keepAlive/60) << "min";
     LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, stream.str());
-    
+
     if (MQTT_Configure()) {
         MQTT_Init();
         return true;
@@ -228,17 +228,17 @@ bool ClassFlowMQTT::doFlow(std::string zwtime)
 
     // Publish process status
     LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "Publish process status");
-    retValStatus &= MQTTPublish(mqttConfig.mainTopic + "/process/status/process_status", 
+    retValStatus &= MQTTPublish(mqttConfig.mainTopic + "/process/status/process_status",
                                 getProcessStatus().c_str(), MQTT_QOS, false);
-    retValStatus &= MQTTPublish(mqttConfig.mainTopic + "/process/status/process_interval", 
+    retValStatus &= MQTTPublish(mqttConfig.mainTopic + "/process/status/process_interval",
                                 to_stringWithPrecision(flowctrl.getProcessInterval(), 1).c_str(), MQTT_QOS, false);
-    retValStatus &= MQTTPublish(mqttConfig.mainTopic + "/process/status/process_time", 
+    retValStatus &= MQTTPublish(mqttConfig.mainTopic + "/process/status/process_time",
                                 std::to_string(getFlowProcessingTime()).c_str(), MQTT_QOS, false);
-    retValStatus &= MQTTPublish(mqttConfig.mainTopic + "/process/status/process_state", 
+    retValStatus &= MQTTPublish(mqttConfig.mainTopic + "/process/status/process_state",
                                 flowctrl.getActStatus().c_str(), MQTT_QOS, false);
-    retValStatus &= MQTTPublish(mqttConfig.mainTopic + "/process/status/process_error", 
+    retValStatus &= MQTTPublish(mqttConfig.mainTopic + "/process/status/process_error",
                                 std::to_string(flowctrl.getFlowStateErrorOrDeviation()).c_str(), MQTT_QOS, false);
-    retValStatus &= MQTTPublish(mqttConfig.mainTopic + "/process/status/cycle_counter", 
+    retValStatus &= MQTTPublish(mqttConfig.mainTopic + "/process/status/cycle_counter",
                                 std::to_string(getFlowCycleCounter()).c_str(), MQTT_QOS, false);
 
     if (!retValStatus)
@@ -254,10 +254,10 @@ bool ClassFlowMQTT::doFlow(std::string zwtime)
 
     std::vector<NumberPost*> *numberSequences = flowpostprocessing->GetNumbers();
 
-    retValData &= MQTTPublish(mqttConfig.mainTopic + "/process/data/number_sequences", 
+    retValData &= MQTTPublish(mqttConfig.mainTopic + "/process/data/number_sequences",
                               std::to_string((*numberSequences).size()), MQTT_QOS, mqttConfig.retainProcessData);
-    
-    for (int i = 0; i < (*numberSequences).size(); ++i) {        
+
+    for (int i = 0; i < (*numberSequences).size(); ++i) {
         if (processDataNotation == JSON || processDataNotation == JSON_AND_TOPICS || HADiscoveryConfig.HADiscoveryEnabled) {
             cJSON *cJSONObject = cJSON_CreateObject();
             if (cJSONObject == NULL) {
@@ -279,48 +279,48 @@ bool ClassFlowMQTT::doFlow(std::string zwtime)
             if (cJSON_AddStringToObject(cJSONObject, "rate_per_interval", (*numberSequences)[i]->sRatePerInterval.c_str()) == NULL)
                 retValData = false;
             if (HADiscoveryConfig.HADiscoveryEnabled) { // Only used for Home Assistant integration
-                if (cJSON_AddStringToObject(cJSONObject, "rate_per_time_unit", (mqttServer_getTimeUnit() == "h") ? 
-                            to_stringWithPrecision((*numberSequences)[i]->ratePerMin * 60, (*numberSequences)[i]->decimalPlaceCount).c_str() : 
-                                                (*numberSequences)[i]->sRatePerMin.c_str()) == NULL) 
+                if (cJSON_AddStringToObject(cJSONObject, "rate_per_time_unit", (mqttServer_getTimeUnit() == "h") ?
+                            to_stringWithPrecision((*numberSequences)[i]->ratePerMin * 60, (*numberSequences)[i]->decimalPlaceCount).c_str() :
+                                                (*numberSequences)[i]->sRatePerMin.c_str()) == NULL)
                     retValData = false;
             }
             if (cJSON_AddStringToObject(cJSONObject, "timestamp_processed", (*numberSequences)[i]->sTimeProcessed.c_str()) == NULL)
                 retValData = false;
             if (cJSON_AddStringToObject(cJSONObject, "timestamp_fallbackvalue", (*numberSequences)[i]->sTimeFallbackValue.c_str()) == NULL)
                 retValData = false;
-                
+
             char *jsonString = cJSON_PrintBuffered(cJSONObject, 512, 1); // Print to predefined buffer, avoid dynamic allocations
             std::string jsonData = std::string(jsonString);
-            cJSON_free(jsonString);  
+            cJSON_free(jsonString);
             cJSON_Delete(cJSONObject);
-            retValData &= MQTTPublish(mqttConfig.mainTopic + "/process/data/" + std::to_string(i+1) + "/json", 
+            retValData &= MQTTPublish(mqttConfig.mainTopic + "/process/data/" + std::to_string(i+1) + "/json",
                                       jsonData, MQTT_QOS, mqttConfig.retainProcessData);
         }
 
         if (processDataNotation == TOPICS || processDataNotation == JSON_AND_TOPICS) {
-            retValData &= MQTTPublish(mqttConfig.mainTopic + "/process/data/" + std::to_string(i+1) + "/sequence_name", 
+            retValData &= MQTTPublish(mqttConfig.mainTopic + "/process/data/" + std::to_string(i+1) + "/sequence_name",
                                         (*numberSequences)[i]->name.c_str(), MQTT_QOS, mqttConfig.retainProcessData);
-            retValData &= MQTTPublish(mqttConfig.mainTopic + "/process/data/" + std::to_string(i+1) + "/actual_value", 
+            retValData &= MQTTPublish(mqttConfig.mainTopic + "/process/data/" + std::to_string(i+1) + "/actual_value",
                                         (*numberSequences)[i]->sActualValue.c_str(), MQTT_QOS, mqttConfig.retainProcessData);
-            retValData &= MQTTPublish(mqttConfig.mainTopic + "/process/data/" + std::to_string(i+1) + "/fallback_value", 
+            retValData &= MQTTPublish(mqttConfig.mainTopic + "/process/data/" + std::to_string(i+1) + "/fallback_value",
                                         (*numberSequences)[i]->sFallbackValue.c_str(), MQTT_QOS, mqttConfig.retainProcessData);
-            retValData &= MQTTPublish(mqttConfig.mainTopic + "/process/data/" + std::to_string(i+1) + "/raw_value", 
+            retValData &= MQTTPublish(mqttConfig.mainTopic + "/process/data/" + std::to_string(i+1) + "/raw_value",
                                         (*numberSequences)[i]->sRawValue.c_str(), MQTT_QOS, mqttConfig.retainProcessData);
-            retValData &= MQTTPublish(mqttConfig.mainTopic + "/process/data/" + std::to_string(i+1) + "/value_status", 
+            retValData &= MQTTPublish(mqttConfig.mainTopic + "/process/data/" + std::to_string(i+1) + "/value_status",
                                         (*numberSequences)[i]->sValueStatus.c_str(), MQTT_QOS, mqttConfig.retainProcessData);
-            retValData &= MQTTPublish(mqttConfig.mainTopic + "/process/data/" + std::to_string(i+1) + "/rate_per_minute", 
+            retValData &= MQTTPublish(mqttConfig.mainTopic + "/process/data/" + std::to_string(i+1) + "/rate_per_minute",
                                         (*numberSequences)[i]->sRatePerMin.c_str(), MQTT_QOS, mqttConfig.retainProcessData);
-            retValData &= MQTTPublish(mqttConfig.mainTopic + "/process/data/" + std::to_string(i+1) + "/rate_per_interval", 
+            retValData &= MQTTPublish(mqttConfig.mainTopic + "/process/data/" + std::to_string(i+1) + "/rate_per_interval",
                                         (*numberSequences)[i]->sRatePerInterval.c_str(), MQTT_QOS, mqttConfig.retainProcessData);
             if (HADiscoveryConfig.HADiscoveryEnabled) { // Only used for Home Assistant integration
-                retValData &= MQTTPublish(mqttConfig.mainTopic + "/process/data/" + std::to_string(i+1) + "/rate_per_time_unit", 
-                            (mqttServer_getTimeUnit() == "h") ? to_stringWithPrecision((*numberSequences)[i]->ratePerMin * 60, 
-                            (*numberSequences)[i]->decimalPlaceCount).c_str() : (*numberSequences)[i]->sRatePerMin.c_str(), 
+                retValData &= MQTTPublish(mqttConfig.mainTopic + "/process/data/" + std::to_string(i+1) + "/rate_per_time_unit",
+                            (mqttServer_getTimeUnit() == "h") ? to_stringWithPrecision((*numberSequences)[i]->ratePerMin * 60,
+                            (*numberSequences)[i]->decimalPlaceCount).c_str() : (*numberSequences)[i]->sRatePerMin.c_str(),
                             MQTT_QOS, mqttConfig.retainProcessData);
             }
-            retValData &= MQTTPublish(mqttConfig.mainTopic + "/process/data/" + std::to_string(i+1) + "/timestamp_processed", 
+            retValData &= MQTTPublish(mqttConfig.mainTopic + "/process/data/" + std::to_string(i+1) + "/timestamp_processed",
                                         (*numberSequences)[i]->sTimeProcessed.c_str(), MQTT_QOS, mqttConfig.retainProcessData);
-            retValData &= MQTTPublish(mqttConfig.mainTopic + "/process/data/" + std::to_string(i+1) + "/timestamp_fallbackvalue", 
+            retValData &= MQTTPublish(mqttConfig.mainTopic + "/process/data/" + std::to_string(i+1) + "/timestamp_fallbackvalue",
                                         (*numberSequences)[i]->sTimeFallbackValue.c_str(), MQTT_QOS, mqttConfig.retainProcessData);
         }
     }
@@ -330,7 +330,7 @@ bool ClassFlowMQTT::doFlow(std::string zwtime)
 
     if (!retValCommon || !retValStatus || !retValData) // If publishing of one of the clusters failed
         return false;
-    
+
     return true;
 }
 
@@ -338,7 +338,7 @@ bool ClassFlowMQTT::doFlow(std::string zwtime)
 void ClassFlowMQTT::doPostProcessEventHandling()
 {
     // Post cycle process handling can be included here. Function is called after processing cycle is completed
-    
+
 }
 
 

--- a/code/components/jomjol_flowcontroll/ClassFlowPostProcessing.cpp
+++ b/code/components/jomjol_flowcontroll/ClassFlowPostProcessing.cpp
@@ -18,7 +18,7 @@
 static const char* TAG = "POSTPROC";
 
 
-//#define DEBUG_DETAIL_ON 
+//#define DEBUG_DETAIL_ON
 
 
 ClassFlowPostProcessing::ClassFlowPostProcessing(std::vector<ClassFlow*>* lfc, ClassFlowCNNGeneral *_analog, ClassFlowCNNGeneral *_digit)
@@ -62,7 +62,7 @@ void ClassFlowPostProcessing::handleDecimalExtendedResolution(std::string _decse
             else
                 NUMBERS[j]->isExtendedResolution = false;
 
-            #ifdef DEBUG_DETAIL_ON 
+            #ifdef DEBUG_DETAIL_ON
                 ESP_LOGI(TAG, "handleDecimalExtendedResolution: Name: %s, Pospunkt: %d, value: %d", _digit.c_str(), _pospunkt, NUMBERS[j]->isExtendedResolution);
             #endif
         }
@@ -84,8 +84,8 @@ void ClassFlowPostProcessing::handleDecimalShift(std::string _decsep, std::strin
         if (_digit == "default" || NUMBERS[j]->name == _digit) {
             NUMBERS[j]->decimalShift = stoi(_value);
 
-            #ifdef DEBUG_DETAIL_ON 
-                ESP_LOGI(TAG, "handleDecimalShift: Name: %s, Pospunkt: %d, value: %d", _digit.c_str(), 
+            #ifdef DEBUG_DETAIL_ON
+                ESP_LOGI(TAG, "handleDecimalShift: Name: %s, Pospunkt: %d, value: %d", _digit.c_str(),
                             _pospunkt, NUMBERS[j]->decimalShift);
             #endif
         }
@@ -103,12 +103,12 @@ void ClassFlowPostProcessing::handleAnalogDigitalTransitionStart(std::string _de
     else
         _digit = "default";
 
-    for (int j = 0; j < NUMBERS.size(); ++j) {    
-        if (_digit == "default" || NUMBERS[j]->name == _digit) { 
+    for (int j = 0; j < NUMBERS.size(); ++j) {
+        if (_digit == "default" || NUMBERS[j]->name == _digit) {
             NUMBERS[j]->analogDigitalTransitionStart = (int) (stof(_value) * 10);
 
-            #ifdef DEBUG_DETAIL_ON 
-                ESP_LOGI(TAG, "handleAnalogDigitalTransitionStart: Name: %s, Pospunkt: %d, value: %f", _digit.c_str(), 
+            #ifdef DEBUG_DETAIL_ON
+                ESP_LOGI(TAG, "handleAnalogDigitalTransitionStart: Name: %s, Pospunkt: %d, value: %f", _digit.c_str(),
                             _pospunkt, NUMBERS[j]->analogDigitalTransitionStart/10.0);
             #endif
         }
@@ -133,13 +133,13 @@ void ClassFlowPostProcessing::handleAllowNegativeRate(std::string _decsep, std::
             }
             else {
                 NUMBERS[j]->allowNegativeRates = false;
-                
+
                 if (!UseFallbackValue) // Fallback Value is mandatory to evaluate negative rates
-                    LogFile.WriteToFile(ESP_LOG_WARN, TAG, "Activate parameter \'Use Fallback Value\' to use negative rate evaluation"); 
+                    LogFile.WriteToFile(ESP_LOG_WARN, TAG, "Activate parameter \'Use Fallback Value\' to use negative rate evaluation");
             }
 
-            #ifdef DEBUG_DETAIL_ON 
-                ESP_LOGI(TAG, "handleAllowNegativeRate: Name: %s, Pospunkt: %d, value: %d", _digit.c_str(), 
+            #ifdef DEBUG_DETAIL_ON
+                ESP_LOGI(TAG, "handleAllowNegativeRate: Name: %s, Pospunkt: %d, value: %d", _digit.c_str(),
                             _pospunkt, NUMBERS[j]->allowNegativeRates);
             #endif
         }
@@ -173,10 +173,10 @@ void ClassFlowPostProcessing::handleMaxRateType(std::string _decsep, std::string
             }
 
             if (NUMBERS[j]->useMaxRateValue && !UseFallbackValue) // Fallback Value is mandatory to evaluate rate limits
-                LogFile.WriteToFile(ESP_LOG_WARN, TAG, "Activate parameter \'Use Fallback Value\' to use rate limit evaluation"); 
+                LogFile.WriteToFile(ESP_LOG_WARN, TAG, "Activate parameter \'Use Fallback Value\' to use rate limit evaluation");
 
-            #ifdef DEBUG_DETAIL_ON 
-                ESP_LOGI(TAG, "handleMaxRateType: Name: %s, Pospunkt: %d, rateType: %d", _digit.c_str(), 
+            #ifdef DEBUG_DETAIL_ON
+                ESP_LOGI(TAG, "handleMaxRateType: Name: %s, Pospunkt: %d, rateType: %d", _digit.c_str(),
                             _pospunkt, NUMBERS[j]->rateType);
             #endif
         }
@@ -193,13 +193,13 @@ void ClassFlowPostProcessing::handleMaxRateValue(std::string _decsep, std::strin
         _digit = _decsep.substr(0, _pospunkt);
     else
         _digit = "default";
-    
+
     for (int j = 0; j < NUMBERS.size(); ++j) {
         if (_digit == "default" || NUMBERS[j]->name == _digit) {
             NUMBERS[j]->maxRateValue = stof(_value);
 
-            #ifdef DEBUG_DETAIL_ON 
-                ESP_LOGI(TAG, "handleMaxRateValue: Name: %s, Pospunkt: %d, value: %f", _digit.c_str(), 
+            #ifdef DEBUG_DETAIL_ON
+                ESP_LOGI(TAG, "handleMaxRateValue: Name: %s, Pospunkt: %d, value: %f", _digit.c_str(),
                         _pospunkt, NUMBERS[j]->maxRateValue);
             #endif
         }
@@ -253,8 +253,8 @@ bool ClassFlowPostProcessing::ReadParameter(FILE* pfile, std::string& aktparamgr
                     NUMBERS[j]->checkDigitIncreaseConsistency = false;
                 }
             }
-        } 
-        
+        }
+
         if ((toUpper(_param) == "ALLOWNEGATIVERATES") && (splitted.size() > 1)) {
             handleAllowNegativeRate(splitted[0], splitted[1]);
         }
@@ -334,7 +334,7 @@ void ClassFlowPostProcessing::InitNUMBERS()
         flowAnalog->UpdateNameNumbers(&name_numbers);
     }
 
-    #ifdef DEBUG_DETAIL_ON 
+    #ifdef DEBUG_DETAIL_ON
         ESP_LOGI(TAG, "Anzahl NUMBERS: %d - DIGITS: %d, ANALOG: %d", name_numbers.size(), anzDIGIT, anzANALOG);
     #endif
 
@@ -343,11 +343,11 @@ void ClassFlowPostProcessing::InitNUMBERS()
         NumberPost *_number = new NumberPost;
 
         _number->name = name_numbers[_num];
-        
+
         _number->digit_roi = NULL;
         if (flowDigit)
             _number->digit_roi = flowDigit->FindGENERAL(name_numbers[_num]);
-        
+
         if (_number->digit_roi)
             _number->digitCount = _number->digit_roi->ROI.size();
         else
@@ -379,14 +379,14 @@ void ClassFlowPostProcessing::InitNUMBERS()
         _number->isFallbackValueValid = false;
 
         _number->ratePerMin = 0;
-        _number->ratePerInterval = 0; 
+        _number->ratePerInterval = 0;
         _number->fallbackValue = 0;
         _number->actualValue = 0;
 
         _number->sRatePerMin = "";
         _number->sRatePerInterval = "";
         _number->sRawValue = "";
-        _number->sFallbackValue = "";   
+        _number->sFallbackValue = "";
         _number->sActualValue = "";
         _number->sValueStatus = "";
 
@@ -394,8 +394,8 @@ void ClassFlowPostProcessing::InitNUMBERS()
     }
 
     for (int i = 0; i < NUMBERS.size(); ++i) {
-        LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "Number sequence: " + NUMBERS[i]->name + 
-                                                ", Digits: " + std::to_string(NUMBERS[i]->digitCount) + 
+        LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "Number sequence: " + NUMBERS[i]->name +
+                                                ", Digits: " + std::to_string(NUMBERS[i]->digitCount) +
                                                 ", Analogs: " + std::to_string(NUMBERS[i]->analogCount));
     }
 }
@@ -416,10 +416,10 @@ void ClassFlowPostProcessing::setDecimalShift()
         else if (!NUMBERS[j]->digit_roi && NUMBERS[j]->analog_roi) {
             if (NUMBERS[j]->isExtendedResolution && flowAnalog->CNNTypeWithExtendedResolution())
                 NUMBERS[j]->decimalShift -= 1;
-            
+
             NUMBERS[j]->decimalPlaceCount = -1*(NUMBERS[j]->decimalShift);
         }
-        // Digit numbers & analog pointer available 
+        // Digit numbers & analog pointer available
         else if (NUMBERS[j]->digit_roi && NUMBERS[j]->analog_roi) {
             NUMBERS[j]->decimalPlaceCount = NUMBERS[j]->analogCount - NUMBERS[j]->decimalShift;
 
@@ -427,7 +427,7 @@ void ClassFlowPostProcessing::setDecimalShift()
                 NUMBERS[j]->decimalPlaceCount += 1;
         }
 
-        #ifdef DEBUG_DETAIL_ON 
+        #ifdef DEBUG_DETAIL_ON
             ESP_LOGI(TAG, "setDecimalShift: Sequence %i, decimalPlace %i, DecShift %i", j, NUMBERS[j]->decimalPlaceCount, NUMBERS[j]->decimalShift);
         #endif
     }
@@ -449,7 +449,7 @@ std::string ClassFlowPostProcessing::ShiftDecimal(std::string _value, int _decSh
     else {
         _value = _value.erase(_pos_dec_org, 1);
     }
-    
+
     _pos_dec_new = _pos_dec_org + _decShift;
 
     if (_pos_dec_new <= 0) {        // comma is before the first digit
@@ -463,8 +463,8 @@ std::string ClassFlowPostProcessing::ShiftDecimal(std::string _value, int _decSh
     if (_pos_dec_new > _value.length()){    // Comma should be after string (123 --> 1230)
         for (int i = _value.length(); i < _pos_dec_new; ++i){
             _value = _value.insert(_value.length(), "0");
-        }  
-        return _value;      
+        }
+        return _value;
     }
 
     std::string zw;
@@ -485,7 +485,7 @@ bool ClassFlowPostProcessing::doFlow(std::string zwtime)
     if (_timeProcessed == 0)
         time(&_timeProcessed);
 
-    #ifdef DEBUG_DETAIL_ON 
+    #ifdef DEBUG_DETAIL_ON
         ESP_LOGI(TAG, "Quantity of number sequences: %d", NUMBERS.size());
     #endif
 
@@ -497,7 +497,7 @@ bool ClassFlowPostProcessing::doFlow(std::string zwtime)
         NUMBERS[j]->isActualValueConfirmed = true;
 
         /* Process analog numbers of sequence */
-        if (NUMBERS[j]->analog_roi) {      
+        if (NUMBERS[j]->analog_roi) {
             LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "doFlow: Get analog numbers");
             NUMBERS[j]->sRawValue = flowAnalog->getReadout(j, NUMBERS[j]->isExtendedResolution);
 
@@ -507,7 +507,7 @@ bool ClassFlowPostProcessing::doFlow(std::string zwtime)
             }
         }
 
-        #ifdef DEBUG_DETAIL_ON 
+        #ifdef DEBUG_DETAIL_ON
             ESP_LOGI(TAG, "After analog->getReadout: RawValue %s", NUMBERS[j]->sRawValue.c_str());
         #endif
 
@@ -519,29 +519,29 @@ bool ClassFlowPostProcessing::doFlow(std::string zwtime)
         if (NUMBERS[j]->digit_roi) {
             LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "doFlow: Get digit numbers");
             if (NUMBERS[j]->analog_roi) // If analog numbers available
-                NUMBERS[j]->sRawValue = flowDigit->getReadout(j, false, NUMBERS[j]->analog_roi->ROI[0]->CNNResult, resultPreviousNumberAnalog, 
+                NUMBERS[j]->sRawValue = flowDigit->getReadout(j, false, NUMBERS[j]->analog_roi->ROI[0]->CNNResult, resultPreviousNumberAnalog,
                                                                     NUMBERS[j]->analogDigitalTransitionStart) + NUMBERS[j]->sRawValue;
             else
                 NUMBERS[j]->sRawValue = flowDigit->getReadout(j, NUMBERS[j]->isExtendedResolution); // Extended resolution for digits only if no analog previous number
         }
 
-        #ifdef DEBUG_DETAIL_ON 
+        #ifdef DEBUG_DETAIL_ON
             ESP_LOGI(TAG, "After digital->getReadout: RawValue %s", NUMBERS[j]->sRawValue.c_str());
         #endif
 
         /* Apply parametrized decimal shift */
         NUMBERS[j]->sRawValue = ShiftDecimal(NUMBERS[j]->sRawValue, NUMBERS[j]->decimalShift);
 
-        #ifdef DEBUG_DETAIL_ON 
+        #ifdef DEBUG_DETAIL_ON
             ESP_LOGI(TAG, "After ShiftDecimal: RawValue %s", NUMBERS[j]->sRawValue.c_str());
         #endif
 
         /* Remove leading N */
-        if (IgnoreLeadingNaN)               
+        if (IgnoreLeadingNaN)
             while ((NUMBERS[j]->sRawValue.length() > 1) && (NUMBERS[j]->sRawValue[0] == 'N'))
                 NUMBERS[j]->sRawValue.erase(0, 1);
 
-        #ifdef DEBUG_DETAIL_ON 
+        #ifdef DEBUG_DETAIL_ON
             ESP_LOGI(TAG, "After IgnoreLeadingNaN: RawValue %s", NUMBERS[j]->sRawValue.c_str());
         #endif
 
@@ -552,7 +552,7 @@ bool ClassFlowPostProcessing::doFlow(std::string zwtime)
         if (findDelimiterPos(NUMBERS[j]->sActualValue, "N") != std::string::npos) {
             LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "Substitude N positions for number sequence: " + NUMBERS[j]->name);
             if (UseFallbackValue && NUMBERS[j]->isFallbackValueValid) { // fallbackValue can be used to replace the N
-                NUMBERS[j]->sActualValue = SubstitudeN(NUMBERS[j]->sActualValue, NUMBERS[j]->fallbackValue); 
+                NUMBERS[j]->sActualValue = SubstitudeN(NUMBERS[j]->sActualValue, NUMBERS[j]->fallbackValue);
             }
             else { // fallbackValue not valid to replace any N
                 if (!UseFallbackValue)
@@ -567,7 +567,7 @@ bool ClassFlowPostProcessing::doFlow(std::string zwtime)
                 NUMBERS[j]->sActualValue = "";
                 NUMBERS[j]->isActualValueANumber = false;
                 NUMBERS[j]->isActualValueConfirmed = false;
-      
+
                 LogFile.WriteToFile(ESP_LOG_WARN, TAG, "Sequence: " + NUMBERS[j]->name + ": Status: " + NUMBERS[j]->sValueStatus);
 
                 WriteDataLog(j);
@@ -575,22 +575,22 @@ bool ClassFlowPostProcessing::doFlow(std::string zwtime)
             }
         }
 
-        #ifdef DEBUG_DETAIL_ON 
+        #ifdef DEBUG_DETAIL_ON
             ESP_LOGI(TAG, "After SubstitudeN: ActualValue %s", NUMBERS[j]->sActualValue.c_str());
         #endif
 
         /* Delete leading zeros (unless there is only one 0 left) */
         while ((NUMBERS[j]->sActualValue.length() > 1) && (NUMBERS[j]->sActualValue[0] == '0'))
             NUMBERS[j]->sActualValue.erase(0, 1);
-        
-        #ifdef DEBUG_DETAIL_ON 
+
+        #ifdef DEBUG_DETAIL_ON
             ESP_LOGI(TAG, "After removeLeadingZeros: ActualValue %s", NUMBERS[j]->sActualValue.c_str());
         #endif
 
         /* Convert actual value to double interpretation */
         NUMBERS[j]->actualValue = std::stod(NUMBERS[j]->sActualValue);
 
-        #ifdef DEBUG_DETAIL_ON 
+        #ifdef DEBUG_DETAIL_ON
             ESP_LOGI(TAG, "After converting to double: sActualValue: %s, actualValue: %f", NUMBERS[j]->sActualValue.c_str(), NUMBERS[j]->actualValue);
         #endif
 
@@ -609,19 +609,19 @@ bool ClassFlowPostProcessing::doFlow(std::string zwtime)
                 if (NUMBERS[j]->checkDigitIncreaseConsistency) {
                     if (flowDigit) {
                         if (flowDigit->getCNNType() != Digital)
-                            LogFile.WriteToFile(ESP_LOG_WARN, TAG, "Skip \'Digit Increase Consistency\' check, only applicable for dig-class11 models"); 
+                            LogFile.WriteToFile(ESP_LOG_WARN, TAG, "Skip \'Digit Increase Consistency\' check, only applicable for dig-class11 models");
                         else {
                             LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "Check digit increase consistency for number sequence: " + NUMBERS[j]->name);
-                            NUMBERS[j]->actualValue = checkDigitConsistency(NUMBERS[j]->actualValue, NUMBERS[j]->decimalShift, 
+                            NUMBERS[j]->actualValue = checkDigitConsistency(NUMBERS[j]->actualValue, NUMBERS[j]->decimalShift,
                                                                             NUMBERS[j]->analog_roi != NULL, NUMBERS[j]->fallbackValue);
                         }
                     }
                     else {
-                        LogFile.WriteToFile(ESP_LOG_WARN, TAG, "Skip \'Digit Increase Consistency\' check, no digit numbers configured"); 
+                        LogFile.WriteToFile(ESP_LOG_WARN, TAG, "Skip \'Digit Increase Consistency\' check, no digit numbers configured");
                     }
                 }
 
-                #ifdef DEBUG_DETAIL_ON 
+                #ifdef DEBUG_DETAIL_ON
                     ESP_LOGI(TAG, "After checkDigitIncreaseConsistency: actualValue %f", NUMBERS[j]->actualValue);
                 #endif
 
@@ -636,10 +636,10 @@ bool ClassFlowPostProcessing::doFlow(std::string zwtime)
                     NUMBERS[j]->ratePerMin = 0;
                     LogFile.WriteToFile(ESP_LOG_WARN, TAG, "Rate calculation skipped, time delta between now and fallback value timestamp is zero");
                 }
-                
+
                 NUMBERS[j]->ratePerInterval = NUMBERS[j]->actualValue - NUMBERS[j]->fallbackValue;
 
-                double RatePerSelection;  
+                double RatePerSelection;
                     if (NUMBERS[j]->rateType == rtRatePerMin)
                         RatePerSelection = NUMBERS[j]->ratePerMin;
                     else
@@ -651,7 +651,7 @@ bool ClassFlowPostProcessing::doFlow(std::string zwtime)
                     if (abs(RatePerSelection) > abs((double)NUMBERS[j]->maxRateValue)) {
                         if (RatePerSelection < 0) {
                             NUMBERS[j]->sValueStatus  = std::string(VALUE_STATUS_003_RATE_TOO_HIGH_NEG);
-                            
+
                             /* Update timestamp of fallback value to be prepared to identify next negative movement larger than max. rate threshold (diagnostic purpose) */
                             NUMBERS[j]->timeFallbackValue = NUMBERS[j]->timeProcessed;
                             NUMBERS[j]->sTimeFallbackValue = ConvertTimeToString(NUMBERS[j]->timeFallbackValue, TIME_FORMAT_OUTPUT);
@@ -660,17 +660,17 @@ bool ClassFlowPostProcessing::doFlow(std::string zwtime)
                             NUMBERS[j]->sValueStatus  = std::string(VALUE_STATUS_004_RATE_TOO_HIGH_POS);
                         }
 
-                        NUMBERS[j]->sValueStatus += " | Value: " + to_stringWithPrecision(NUMBERS[j]->actualValue, NUMBERS[j]->decimalPlaceCount) + 
-                                                    ", Fallback: " + NUMBERS[j]->sFallbackValue + 
+                        NUMBERS[j]->sValueStatus += " | Value: " + to_stringWithPrecision(NUMBERS[j]->actualValue, NUMBERS[j]->decimalPlaceCount) +
+                                                    ", Fallback: " + NUMBERS[j]->sFallbackValue +
                                                     ", Rate: " + to_stringWithPrecision(RatePerSelection, NUMBERS[j]->decimalPlaceCount);
-                         
-                        LogFile.WriteToFile(ESP_LOG_WARN, TAG, "Sequence: " + NUMBERS[j]->name + ", Status: " + NUMBERS[j]->sValueStatus);           
+
+                        LogFile.WriteToFile(ESP_LOG_WARN, TAG, "Sequence: " + NUMBERS[j]->name + ", Status: " + NUMBERS[j]->sValueStatus);
                         NUMBERS[j]->isActualValueConfirmed = false;
                         setFlowStateHandlerEvent(1); // Set warning event code for post cycle error handler 'doPostProcessEventHandling' (only warning level)
                     }
                 }
 
-                #ifdef DEBUG_DETAIL_ON 
+                #ifdef DEBUG_DETAIL_ON
                     ESP_LOGI(TAG, "After MaxRateCheck: actualValue %f", NUMBERS[j]->actualValue);
                 #endif
 
@@ -678,9 +678,9 @@ bool ClassFlowPostProcessing::doFlow(std::string zwtime)
                 if (!NUMBERS[j]->allowNegativeRates && NUMBERS[j]->isActualValueConfirmed) {
                     LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "Negative rate check for number sequence: " + NUMBERS[j]->name);
                     if (NUMBERS[j]->actualValue < NUMBERS[j]->fallbackValue) {
-                        NUMBERS[j]->sValueStatus  = std::string(VALUE_STATUS_002_RATE_NEGATIVE);  
+                        NUMBERS[j]->sValueStatus  = std::string(VALUE_STATUS_002_RATE_NEGATIVE);
 
-                        LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "Sequence: " + NUMBERS[j]->name + ", Status: " + NUMBERS[j]->sValueStatus + 
+                        LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "Sequence: " + NUMBERS[j]->name + ", Status: " + NUMBERS[j]->sValueStatus +
                                                                 " | Value: " + std::to_string(NUMBERS[j]->actualValue) +
                                                                 ", Fallback: " + std::to_string(NUMBERS[j]->fallbackValue) +
                                                                 ", Rate: " + to_stringWithPrecision(RatePerSelection, NUMBERS[j]->decimalPlaceCount));
@@ -692,7 +692,7 @@ bool ClassFlowPostProcessing::doFlow(std::string zwtime)
                     }
                 }
 
-                #ifdef DEBUG_DETAIL_ON 
+                #ifdef DEBUG_DETAIL_ON
                     ESP_LOGI(TAG, "After allowNegativeRates: actualValue %f", NUMBERS[j]->actualValue);
                 #endif
             }
@@ -706,13 +706,13 @@ bool ClassFlowPostProcessing::doFlow(std::string zwtime)
             if (NUMBERS[j]->isActualValueANumber && NUMBERS[j]->isActualValueConfirmed) { // Value of actual reading is valid
                 // Save value as fallback value
                 NUMBERS[j]->fallbackValue = NUMBERS[j]->actualValue;
-                NUMBERS[j]->sFallbackValue = to_stringWithPrecision(NUMBERS[j]->fallbackValue, NUMBERS[j]->decimalPlaceCount);     
+                NUMBERS[j]->sFallbackValue = to_stringWithPrecision(NUMBERS[j]->fallbackValue, NUMBERS[j]->decimalPlaceCount);
                 NUMBERS[j]->timeFallbackValue = NUMBERS[j]->timeProcessed;
                 NUMBERS[j]->sTimeFallbackValue = ConvertTimeToString(NUMBERS[j]->timeFallbackValue, TIME_FORMAT_OUTPUT);
                 NUMBERS[j]->isFallbackValueValid = true;
                 UpdateFallbackValue = true;
 
-                NUMBERS[j]->sValueStatus = std::string(VALUE_STATUS_000_VALID); 
+                NUMBERS[j]->sValueStatus = std::string(VALUE_STATUS_000_VALID);
             }
             else { // Value of actual reading is invalid, use fallback value and froce rates to zero
                 NUMBERS[j]->ratePerMin = 0;
@@ -725,7 +725,7 @@ bool ClassFlowPostProcessing::doFlow(std::string zwtime)
             NUMBERS[j]->ratePerInterval = 0;
             NUMBERS[j]->fallbackValue = 0;
             NUMBERS[j]->sFallbackValue = "";
-            NUMBERS[j]->sValueStatus = std::string(VALUE_STATUS_000_VALID); 
+            NUMBERS[j]->sValueStatus = std::string(VALUE_STATUS_000_VALID);
         }
 
         /* Write output values */
@@ -734,8 +734,8 @@ bool ClassFlowPostProcessing::doFlow(std::string zwtime)
         NUMBERS[j]->sActualValue = to_stringWithPrecision(NUMBERS[j]->actualValue, NUMBERS[j]->decimalPlaceCount);
 
         /* Write log file entry */
-        LogFile.WriteToFile(ESP_LOG_INFO, TAG, NUMBERS[j]->name + ": Value: " + NUMBERS[j]->sActualValue + 
-                                                                  ", Rate per min: " + NUMBERS[j]->sRatePerMin + 
+        LogFile.WriteToFile(ESP_LOG_INFO, TAG, NUMBERS[j]->name + ": Value: " + NUMBERS[j]->sActualValue +
+                                                                  ", Rate per min: " + NUMBERS[j]->sRatePerMin +
                                                                   ", Status: " + NUMBERS[j]->sValueStatus);
 
         WriteDataLog(j);
@@ -745,7 +745,7 @@ bool ClassFlowPostProcessing::doFlow(std::string zwtime)
 
     if (!FlowState.isSuccessful) // Return false if any error detected
         return false;
-    
+
     return true;
 }
 
@@ -760,13 +760,13 @@ void ClassFlowPostProcessing::doPostProcessEventHandling()
             time(&actualtime);
 
             // Define path, e.g. /sdcard/log/debug/20230814/20230814-125528/ClassFlowPostProcessing
-            std::string destination = std::string(LOG_DEBUG_ROOT_FOLDER) + "/" + getFlowState()->ExecutionTime.DEFAULT_TIME_FORMAT_DATE_EXTR + "/" + 
+            std::string destination = std::string(LOG_DEBUG_ROOT_FOLDER) + "/" + getFlowState()->ExecutionTime.DEFAULT_TIME_FORMAT_DATE_EXTR + "/" +
                                         getFlowState()->ExecutionTime + "/" + getFlowState()->ClassName;
 
             if (!MakeDir(destination))
                 return;
 
-            for (int j = 0; j < NUMBERS.size(); ++j) {       
+            for (int j = 0; j < NUMBERS.size(); ++j) {
                 std::string resultFileName = "/" + NUMBERS[j]->name + "_rate_too_high.txt";
 
                 // Save result in file
@@ -778,17 +778,17 @@ void ClassFlowPostProcessing::doPostProcessEventHandling()
                 if (NUMBERS[j]->digit_roi)
                     for (int i = 0; i < NUMBERS[j]->digit_roi->ROI.size(); ++i)
                         NUMBERS[j]->digit_roi->ROI[i]->image_org->SaveToFile(destination + "/" +
-                                    to_stringWithPrecision(NUMBERS[j]->digit_roi->ROI[i]->CNNResult/10.0, 1) + 
+                                    to_stringWithPrecision(NUMBERS[j]->digit_roi->ROI[i]->CNNResult/10.0, 1) +
                                     "_" + NUMBERS[j]->name + "_dig" + std::to_string(i+1) + ".jpg");
 
                 // Save analog ROIs
                 if (NUMBERS[j]->analog_roi)
                     for (int i = 0; i < NUMBERS[j]->analog_roi->ROI.size(); ++i)
                         NUMBERS[j]->analog_roi->ROI[i]->image_org->SaveToFile(destination + "/" +
-                                        to_stringWithPrecision(NUMBERS[j]->analog_roi->ROI[i]->CNNResult/10.0, 1) + 
+                                        to_stringWithPrecision(NUMBERS[j]->analog_roi->ROI[i]->CNNResult/10.0, 1) +
                                         "_" + NUMBERS[j]->name + "_ana" + std::to_string(i+1) + ".jpg");
             }
-            
+
             LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "Rate too high, debug infos saved: " + destination);
         }
     }
@@ -800,24 +800,24 @@ void ClassFlowPostProcessing::WriteDataLog(int _index)
     if (!LogFile.GetDataLogToSD()) {
         return;
     }
-    
+
     std::string analog = "";
     std::string digital = "";
-    
+
     if (flowAnalog)
         analog = flowAnalog->getReadoutRawString(_index);
-    
+
     if (flowDigit)
         digital = flowDigit->getReadoutRawString(_index);
-    
-    LogFile.WriteToData(NUMBERS[_index]->sTimeProcessed, NUMBERS[_index]->name, 
-                        NUMBERS[_index]->sRawValue, NUMBERS[_index]->sActualValue, NUMBERS[_index]->sFallbackValue, 
+
+    LogFile.WriteToData(NUMBERS[_index]->sTimeProcessed, NUMBERS[_index]->name,
+                        NUMBERS[_index]->sRawValue, NUMBERS[_index]->sActualValue, NUMBERS[_index]->sFallbackValue,
                         NUMBERS[_index]->sRatePerMin, NUMBERS[_index]->sRatePerInterval,
-                        NUMBERS[_index]->sValueStatus.substr(0,3), 
+                        NUMBERS[_index]->sValueStatus.substr(0,3),
                         digital, analog);
-    
-    #ifdef DEBUG_DETAIL_ON 
-        ESP_LOGI(TAG, "WriteDataLog: %s, %s, %s, %s, %s", NUMBERS[_index]->sRawValue.c_str(), NUMBERS[_index]->sActualValue.c_str(), 
+
+    #ifdef DEBUG_DETAIL_ON
+        ESP_LOGI(TAG, "WriteDataLog: %s, %s, %s, %s, %s", NUMBERS[_index]->sRawValue.c_str(), NUMBERS[_index]->sActualValue.c_str(),
                             NUMBERS[_index]->sValueStatus.substr(0,3).c_str(), digital.c_str(), analog.c_str());
     #endif
 }
@@ -867,7 +867,7 @@ float ClassFlowPostProcessing::checkDigitConsistency(double input, int _decilams
     {
         pot++;
     }
-    #ifdef DEBUG_DETAIL_ON 
+    #ifdef DEBUG_DETAIL_ON
         ESP_LOGD(TAG, "checkDigitConsistency: pot=%d, decimalShift=%d", pot, _decilamshift);
     #endif
     pot_max = ((int) log10(input)) + 1;
@@ -887,7 +887,7 @@ float ClassFlowPostProcessing::checkDigitConsistency(double input, int _decilams
 
         if (no_nulldurchgang)
         {
-            if (aktdigit != olddigit) 
+            if (aktdigit != olddigit)
             {
                 input = input + ((float) (olddigit - aktdigit)) * pow(10, pot);     // New Digit is replaced by old Digit;
             }
@@ -899,7 +899,7 @@ float ClassFlowPostProcessing::checkDigitConsistency(double input, int _decilams
                 input = input + ((float) (1)) * pow(10, pot);   // add 1 at the point
             }
         }
-        #ifdef DEBUG_DETAIL_ON 
+        #ifdef DEBUG_DETAIL_ON
             ESP_LOGD(TAG, "checkDigitConsistency: input=%f", input);
         #endif
         pot++;
@@ -915,7 +915,7 @@ std::string ClassFlowPostProcessing::GetFallbackValue(std::string _number)
     int index = -1;
 
     if (_number == "")
-        _number = "default"; 
+        _number = "default";
 
     for (int i = 0; i < NUMBERS.size(); ++i)
         if (NUMBERS[i]->name == _number)
@@ -932,7 +932,7 @@ std::string ClassFlowPostProcessing::GetFallbackValue(std::string _number)
 
 bool ClassFlowPostProcessing::SetFallbackValue(double _newvalue, std::string _numbersname)
 {
-    #ifdef DEBUG_DETAIL_ON 
+    #ifdef DEBUG_DETAIL_ON
         ESP_LOGI(TAG, "SetFallbackValue: %f, %s", _newvalue, _numbersname.c_str());
     #endif
 
@@ -965,7 +965,7 @@ bool ClassFlowPostProcessing::SetFallbackValue(double _newvalue, std::string _nu
             return true;
         }
     }
-    
+
     LogFile.WriteToFile(ESP_LOG_WARN, TAG, "SetFallbackValue: Numbersname not found or not valid");
     return false;   // No new value was set (e.g. wrong numbersname, no numbers at all)
 }
@@ -1046,12 +1046,12 @@ bool ClassFlowPostProcessing::LoadFallbackValue(void)
             }
         }
 
-        #ifdef DEBUG_DETAIL_ON 
+        #ifdef DEBUG_DETAIL_ON
             ESP_LOGI(TAG, "LoadFallbackValue: Sequence: %s, Time: %s, Value: %s", cName, cTime, cValue);
         #endif
 
         for (int j = 0; j < NUMBERS.size(); ++j)
-        {           
+        {
             if ((NUMBERS[j]->name).compare(std::string(cName)) == 0)
             {
                 time_t tStart;
@@ -1085,7 +1085,7 @@ bool ClassFlowPostProcessing::LoadFallbackValue(void)
                 }
                 else {
                     NUMBERS[j]->fallbackValue = stod(std::string(cValue));
-                    NUMBERS[j]->sFallbackValue = to_stringWithPrecision(NUMBERS[j]->fallbackValue, NUMBERS[j]->decimalPlaceCount + 1); // To be on the safe side, keep one digit more 
+                    NUMBERS[j]->sFallbackValue = to_stringWithPrecision(NUMBERS[j]->fallbackValue, NUMBERS[j]->decimalPlaceCount + 1); // To be on the safe side, keep one digit more
                     NUMBERS[j]->isFallbackValueValid = true;
                     LogFile.WriteToFile(ESP_LOG_INFO, TAG, NUMBERS[j]->name + ": Fallback value valid | Time: " + std::string(cTime));
                 }
@@ -1093,17 +1093,17 @@ bool ClassFlowPostProcessing::LoadFallbackValue(void)
         }
     }
     nvs_close(fallbackvalue_nvshandle);
-    
+
     return true;
 }
 
 
 bool ClassFlowPostProcessing::SaveFallbackValue()
-{ 
+{
     if (!UpdateFallbackValue)         // fallbackValue unchanged
         return false;
-    
-    esp_err_t err = ESP_OK;    
+
+    esp_err_t err = ESP_OK;
     nvs_handle_t fallbackvalue_nvshandle;
 
     err = nvs_open("fallbackvalue", NVS_READWRITE, &fallbackvalue_nvshandle);
@@ -1119,12 +1119,12 @@ bool ClassFlowPostProcessing::SaveFallbackValue()
     }
 
     for (int j = 0; j < NUMBERS.size(); ++j)
-    {           
-        #ifdef DEBUG_DETAIL_ON 
-            ESP_LOGI(TAG, "SaveFallbackValue: Sequence: %s, Time: %s, Value: %s", (NUMBERS[j]->name).c_str(), (NUMBERS[j]->sTimeFallbackValue).c_str(), 
+    {
+        #ifdef DEBUG_DETAIL_ON
+            ESP_LOGI(TAG, "SaveFallbackValue: Sequence: %s, Time: %s, Value: %s", (NUMBERS[j]->name).c_str(), (NUMBERS[j]->sTimeFallbackValue).c_str(),
                         (to_stringWithPrecision(NUMBERS[j]->fallbackValue, NUMBERS[j]->decimalPlaceCount)).c_str());
         #endif
-        
+
         err = nvs_set_str(fallbackvalue_nvshandle, ("name" + std::to_string(j)).c_str(), (NUMBERS[j]->name).c_str());
         if (err != ESP_OK) {
             LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "SaveFallbackValue: nvs_set_str name - error code: " + std::to_string(err));
@@ -1135,7 +1135,7 @@ bool ClassFlowPostProcessing::SaveFallbackValue()
             LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "SaveFallbackValue: nvs_set_str timestamp - error code: " + std::to_string(err));
             return false;
         }
-        err = nvs_set_str(fallbackvalue_nvshandle, ("value" + std::to_string(j)).c_str(), 
+        err = nvs_set_str(fallbackvalue_nvshandle, ("value" + std::to_string(j)).c_str(),
                             (to_stringWithPrecision(NUMBERS[j]->fallbackValue, NUMBERS[j]->decimalPlaceCount)).c_str());
         if (err != ESP_OK) {
             LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "SaveFallbackValue: nvs_set_str fallbackvalue - error code: " + std::to_string(err));
@@ -1165,10 +1165,10 @@ std::string ClassFlowPostProcessing::getReadoutParam(bool _rawValue, bool _noerr
 {
     if (_rawValue)
         return NUMBERS[_number]->sRawValue;
-    
+
     if (_noerror)
         return NUMBERS[_number]->sActualValue;
-    
+
     return NUMBERS[_number]->sActualValue;
 }
 
@@ -1185,7 +1185,7 @@ std::string ClassFlowPostProcessing::getReadoutTimeStamp(int _number)
 }
 
 
-std::string ClassFlowPostProcessing::getReadoutStatus(int _number) 
+std::string ClassFlowPostProcessing::getReadoutStatus(int _number)
 {
     return NUMBERS[_number]->sValueStatus;
 }
@@ -1215,7 +1215,7 @@ std::string ClassFlowPostProcessing::getNumbersName()
             ret = ret + "\t";
     }
 
-    #ifdef DEBUG_DETAIL_ON 
+    #ifdef DEBUG_DETAIL_ON
         ESP_LOGI(TAG, "Result ClassFlowPostProcessing::getNumbersName: %s", ret.c_str());
     #endif
 

--- a/code/components/jomjol_flowcontroll/ClassFlowPostProcessing.h
+++ b/code/components/jomjol_flowcontroll/ClassFlowPostProcessing.h
@@ -16,12 +16,12 @@ class ClassFlowPostProcessing : public ClassFlow
         bool UseFallbackValue;
         bool fallbackValueLoaded;
         bool UpdateFallbackValue;
-        int FallbackValueAgeStartup; 
+        int FallbackValueAgeStartup;
         bool IgnoreLeadingNaN;
         bool SaveDebugInfo;
 
         ClassFlowCNNGeneral* flowAnalog;
-        ClassFlowCNNGeneral* flowDigit;    
+        ClassFlowCNNGeneral* flowDigit;
         ClassFlowTakeImage *flowTakeImage;
 
         bool LoadFallbackValue(void);
@@ -36,11 +36,11 @@ class ClassFlowPostProcessing : public ClassFlow
 
         void handleDecimalShift(std::string _decsep, std::string _value);
         void handleMaxRateValue(std::string _decsep, std::string _value);
-        void handleDecimalExtendedResolution(std::string _decsep, std::string _value); 
+        void handleDecimalExtendedResolution(std::string _decsep, std::string _value);
         void handleMaxRateType(std::string _decsep, std::string _value);
         void handleAnalogDigitalTransitionStart(std::string _decsep, std::string _value);
         void handleAllowNegativeRate(std::string _decsep, std::string _value);
-        
+
         void WriteDataLog(int _index);
 
     public:

--- a/code/components/jomjol_flowcontroll/ClassFlowTakeImage.cpp
+++ b/code/components/jomjol_flowcontroll/ClassFlowTakeImage.cpp
@@ -11,7 +11,7 @@
 #include "CImageBasis.h"
 #include "MainFlowControl.h"
 
-// #define DEBUG_DETAIL_ON 
+// #define DEBUG_DETAIL_ON
 
 static const char* TAG = "TAKEIMAGE";
 
@@ -26,7 +26,7 @@ void ClassFlowTakeImage::SetInitialParameter(void)
     timeImageTaken = 0;
     namerawimage = "/sdcard/img_tmp/raw.jpg";
     rawImage = NULL;
-}     
+}
 
 
 ClassFlowTakeImage::ClassFlowTakeImage(std::vector<ClassFlow*>* lfc) : ClassFlowImage(lfc, TAG)
@@ -101,7 +101,7 @@ bool ClassFlowTakeImage::ReadParameter(FILE* pfile, std::string& aktparamgraph)
         if ((toUpper(splitted[0]) == "IMAGESIZE") && (splitted.size() > 1)) {
             imageSize = Camera.textToFramesize(splitted[1].c_str());
         }
- 
+
         if ((toUpper(splitted[0]) == "BRIGHTNESS") && (splitted.size() > 1)) {
             brightness = stoi(splitted[1]);
         }
@@ -159,11 +159,11 @@ bool ClassFlowTakeImage::ReadParameter(FILE* pfile, std::string& aktparamgraph)
         if ((toUpper(splitted[0]) == "ZOOMMODE") && (splitted.size() > 1)) {
             zoomMode = std::stoi(splitted[1]);
         }
-        
+
         if ((toUpper(splitted[0]) == "ZOOMOFFSETX") && (splitted.size() > 1)) {
             zoomOffsetX = std::stoi(splitted[1]);
         }
-        
+
         if ((toUpper(splitted[0]) == "ZOOMOFFSETY") && (splitted.size() > 1)) {
             zoomOffsetY = std::stoi(splitted[1]);
         }
@@ -180,7 +180,7 @@ bool ClassFlowTakeImage::ReadParameter(FILE* pfile, std::string& aktparamgraph)
                 SaveAllFiles = true;
             else
                 SaveAllFiles = false;
-        }  
+        }
     }
 
     #ifdef GPIO_FLASHLIGHT_DEFAULT_USE_PWM
@@ -190,9 +190,9 @@ bool ClassFlowTakeImage::ReadParameter(FILE* pfile, std::string& aktparamgraph)
     Camera.setFlashTime(flashTime);
     Camera.setCameraFrequency(cameraFrequency);
     Camera.setSizeQuality(imageQuality, imageSize, zoomMode, zoomOffsetX, zoomOffsetY);
-    Camera.setImageManipulation(brightness, contrast, saturation, sharpness, exposureControlMode, autoExposureLevel, 
+    Camera.setImageManipulation(brightness, contrast, saturation, sharpness, exposureControlMode, autoExposureLevel,
                                 manualExposureValue, gainControlMode, manualGainValue, specialEffect, mirrorImage, flipImage);
-    
+
     image_width = Camera.image_width;
     image_height = Camera.image_height;
     rawImage = new CImageBasis("rawImage");
@@ -215,8 +215,8 @@ bool ClassFlowTakeImage::doFlow(std::string zwtime)
 {
     presetFlowStateHandler(false, zwtime);
     std::string logPath = CreateLogFolder(zwtime);
- 
-    #ifdef DEBUG_DETAIL_ON  
+
+    #ifdef DEBUG_DETAIL_ON
         LogFile.WriteHeapInfo("ClassFlowTakeImage::doFlow - Start");
     #endif
 
@@ -225,7 +225,7 @@ bool ClassFlowTakeImage::doFlow(std::string zwtime)
         return false;
     }
 
-    #ifdef DEBUG_DETAIL_ON  
+    #ifdef DEBUG_DETAIL_ON
         LogFile.WriteHeapInfo("ClassFlowTakeImage::doFlow - After takePictureWithFlash");
     #endif
 
@@ -233,7 +233,7 @@ bool ClassFlowTakeImage::doFlow(std::string zwtime)
 
     RemoveOldLogs();
 
-    #ifdef DEBUG_DETAIL_ON  
+    #ifdef DEBUG_DETAIL_ON
         LogFile.WriteHeapInfo("ClassFlowTakeImage::doFlow - Done");
     #endif
 
@@ -269,7 +269,7 @@ bool ClassFlowTakeImage::takePictureWithFlash()
     }
 
     // in case the image is flipped, it must be reset here //
-    rawImage->width = image_width;          
+    rawImage->width = image_width;
     rawImage->height = image_height;
 
     if (Camera.captureToBasisImage(rawImage) != ESP_OK)
@@ -302,9 +302,9 @@ ImageData* ClassFlowTakeImage::SendRawImage()
 
     time(&timeImageTaken);
 
-    id = zw->writeToMemoryAsJPG();    
+    id = zw->writeToMemoryAsJPG();
     delete zw;
-    return id;  
+    return id;
 }
 
 

--- a/code/components/jomjol_helper/Helper.cpp
+++ b/code/components/jomjol_helper/Helper.cpp
@@ -118,7 +118,7 @@ bool MakeDir(std::string path)
                 //Done!
                 bSuccess = true;
                 break;
-				
+
             default:
 				LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "Failed to create folder: " + path + " (errno: " + std::to_string(errno) + ")");
                 bSuccess = false;
@@ -222,7 +222,7 @@ bool FileExists(std::string filename)
 		return false;
 	}
 	fclose(fpSourceFile);
-	return true;    
+	return true;
 }
 
 
@@ -239,7 +239,7 @@ bool DeleteFile(std::string fn)
 	fclose(fpSourceFile);
 
 	unlink(fn.c_str());
-	return true;    
+	return true;
 }
 
 
@@ -353,7 +353,7 @@ int mkdir_r(const char *dir, const mode_t mode) {
     char *p = NULL;
     struct stat sb;
     size_t len;
-    
+
     /* copy path */
     len = strnlen(dir, FILE_PATH_MAX);
     if (len == 0 || len == FILE_PATH_MAX) {
@@ -373,7 +373,7 @@ int mkdir_r(const char *dir, const mode_t mode) {
             return 0;
         }
     }
-    
+
     /* recursive mkdir */
     for(p = tmp + 1; *p; p++) {
         if(*p == '/') {
@@ -409,7 +409,7 @@ std::string toUpper(std::string in)
 {
 	for (int i = 0; i < in.length(); ++i)
 		in[i] = toupper(in[i]);
-	
+
 	return in;
 }
 
@@ -418,7 +418,7 @@ std::string toLower(std::string in)
 {
 	for (int i = 0; i < in.length(); ++i)
 		in[i] = tolower(in[i]);
-	
+
 	return in;
 }
 
@@ -457,7 +457,7 @@ int removeFolder(const char* folderPath, const char* logTag) {
 		}
     }
     closedir(dir);
-	
+
 	if (rmdir(folderPath) != 0) {
 		LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "Failed to delete folder " + std::string(folderPath));
 	}
@@ -485,7 +485,7 @@ void deleteAllFilesInDirectory(std::string _directory)
                 filename = _directory + "/" + std::string(entry->d_name);
                 LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "Delete file: " + filename);
                 /* Delete file */
-                unlink(filename.c_str());    
+                unlink(filename.c_str());
             }
         }
     }
@@ -509,16 +509,16 @@ std::vector<std::string> HelperZerlegeZeile(std::string input, std::string _deli
 std::vector<std::string> ZerlegeZeile(std::string input, std::string delimiter)
 {
 	std::vector<std::string> Output;
-	/* The input can have multiple formats: 
+	/* The input can have multiple formats:
 	 *  - key = value
      *  - key = value1 value2 value3 ...
      *  - key value1 value2 value3 ...
-	 *  
+	 *
 	 * Examples:
 	 *  - ImageSize = VGA
-	 *  - IO0 = input disabled 10 false false 
+	 *  - IO0 = input disabled 10 false false
 	 *  - main.dig1 28 144 55 100 false
-	 * 
+	 *
 	 * This causes issues eg. if a password key has a whitespace or equal sign in its value.
 	 * As a workaround and to not break any legacy usage, we enforce to only use the
 	 * equal sign, if the key is "password"
@@ -562,10 +562,10 @@ std::string ReplaceString(std::string subject, const std::string& search,
 std::string to_stringWithPrecision(const double _value, int _decPlace = 6)
 {
 	std::ostringstream out;
-	
+
 	if (_decPlace < 0)
 		_decPlace = 0;
-	
+
     out.precision(_decPlace);
     out << std::fixed << _value;
     return out.str();
@@ -590,7 +590,7 @@ std::string getFormatedUptime(bool compact)
     int hours = int(floor((uptime - days * 3600*24) / (3600)));
     int minutes = int(floor((uptime - days * 3600*24 - hours * 3600) / (60)));
     int seconds = uptime - days * 3600*24 - hours * 3600 - minutes * 60;
-    
+
 	if (compact) {
 		snprintf(buf, sizeof(buf), "%dd%02dh%02dm%02ds", days, hours, minutes, seconds);
 	}
@@ -604,7 +604,7 @@ std::string getFormatedUptime(bool compact)
 
 const char* get404(void)
 {
-    return 
+    return
 "<pre>\n\n\n\n"
 "        _\n"
 "    .__(.)< ( oh oh! This page does not exist! )\n"
@@ -681,14 +681,14 @@ bool isInString(std::string& s, std::string const& toFind)
 
 std::vector<std::string> splitString(const std::string& str) {
     std::vector<std::string> tokens;
- 
+
     std::stringstream ss(str);
     std::string token;
 
     while (std::getline(ss, token, '\n')) {
         tokens.push_back(token);
     }
- 
+
     return tokens;
 }
 

--- a/code/components/jomjol_helper/himem_memory_check.cpp
+++ b/code/components/jomjol_helper/himem_memory_check.cpp
@@ -102,7 +102,7 @@ std::string himem_memory_check()
 		espInfoResultStr += "Himem check Done!\n";
 	}
 
-	return espInfoResultStr; 
+	return espInfoResultStr;
 
 }
 

--- a/code/components/jomjol_helper/perfmon.h
+++ b/code/components/jomjol_helper/perfmon.h
@@ -20,4 +20,4 @@ esp_err_t perfmon_start();
 
 #endif /* COMPONENTS_PERFMON_INCLUDE_PERFMON_H_ */
 
-#endif //DEBUG_ENABLE_PERFMON 
+#endif //DEBUG_ENABLE_PERFMON

--- a/code/components/jomjol_helper/psram.cpp
+++ b/code/components/jomjol_helper/psram.cpp
@@ -52,8 +52,8 @@ void *malloc_psram_heap_STBI(std::string name, size_t size, uint32_t caps)
     else {
         ptr = heap_caps_malloc(size, caps);
     }
-    
-          
+
+
     if (ptr != NULL) {
 	    LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, name + ": Allocated: " + std::to_string(size));
 	}

--- a/code/components/jomjol_helper/psram.h
+++ b/code/components/jomjol_helper/psram.h
@@ -55,4 +55,4 @@ void *calloc_psram_heap(std::string name, size_t n, size_t size, uint32_t caps);
 
 void free_psram_heap(std::string name, void *ptr);
 
-#endif //PSRAM_H_ 
+#endif //PSRAM_H_

--- a/code/components/jomjol_helper/sdcard_check.cpp
+++ b/code/components/jomjol_helper/sdcard_check.cpp
@@ -8,7 +8,7 @@
 #include <inttypes.h>
 #include <sys/stat.h>
 
-#include "esp_rom_crc.h" 
+#include "esp_rom_crc.h"
 
 #include "ClassLogFile.h"
 
@@ -20,12 +20,12 @@ int SDCardCheckRW(void)
     LogFile.WriteToFile(ESP_LOG_INFO, TAG, "Basic R/W check started");
     FILE* pFile = NULL;
     int iCRCMessage = 0;
-   
+
     pFile = fopen("/sdcard/sdcheck.txt","w");
     if (pFile == NULL) {
         LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "Basic R/W check: (E1) Not able to open file to write");
         return -1;
-    } 
+    }
     else {
         std::string sMessage = "This message is used for a SD-Card basic check!";
         iCRCMessage = esp_rom_crc16_le(0, (uint8_t*)sMessage.c_str(), sMessage.length());
@@ -35,7 +35,7 @@ int SDCardCheckRW(void)
             unlink("/sdcard/sdcheck.txt");
             return -2;
         }
-        fclose(pFile); 
+        fclose(pFile);
     }
 
     pFile = fopen("/sdcard/sdcheck.txt","r");
@@ -43,7 +43,7 @@ int SDCardCheckRW(void)
         LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "Basic R/W check: (E3) Not able to open file to read back");
         unlink("/sdcard/sdcheck.txt");
         return -3;
-    } 
+    }
     else {
         char cReadBuf[50];
         if (fgets(cReadBuf, sizeof(cReadBuf), pFile) == 0) {
@@ -53,13 +53,13 @@ int SDCardCheckRW(void)
             return -4;
         }
         else {
-            if (esp_rom_crc16_le(0, (uint8_t*)cReadBuf, strlen(cReadBuf)) != iCRCMessage) {                 
+            if (esp_rom_crc16_le(0, (uint8_t*)cReadBuf, strlen(cReadBuf)) != iCRCMessage) {
                 LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "Basic R/W check: (E5) Read back, but wrong CRC");
                 fclose(pFile);
                 unlink("/sdcard/sdcheck.txt");
                 return -5;
             }
-        }      
+        }
         fclose(pFile);
     }
 
@@ -165,6 +165,6 @@ bool SDCardCheckFolderFilePresence()
 
     if (bRetval)
         LogFile.WriteToFile(ESP_LOG_INFO, TAG, "Folder/file presence check successful");
-    
+
     return bRetval;
 }

--- a/code/components/jomjol_helper/statusled.cpp
+++ b/code/components/jomjol_helper/statusled.cpp
@@ -18,7 +18,7 @@ struct StatusLEDData StatusLEDData = {};
 void task_StatusLED(void *pvParameter)
 {
     //ESP_LOGD(TAG, "task_StatusLED - create");
-	while (StatusLEDData.bProcessingRequest) 
+	while (StatusLEDData.bProcessingRequest)
 	{
 		//ESP_LOGD(TAG, "task_StatusLED - start");
 		struct StatusLEDData StatusLEDDataInt = StatusLEDData;
@@ -36,7 +36,7 @@ void task_StatusLED(void *pvParameter)
 			{
 				gpio_set_level(GPIO_STATUS_LED_ONBOARD, 0);
 				vTaskDelay(StatusLEDDataInt.iBlinkTime / portTICK_PERIOD_MS);
-				gpio_set_level(GPIO_STATUS_LED_ONBOARD, 1);      
+				gpio_set_level(GPIO_STATUS_LED_ONBOARD, 1);
 				vTaskDelay(StatusLEDDataInt.iBlinkTime / portTICK_PERIOD_MS);
 			}
 
@@ -44,7 +44,7 @@ void task_StatusLED(void *pvParameter)
 
 			for (int j = 0; j < StatusLEDDataInt.iCodeBlinkCnt; ++j)
 			{
-				gpio_set_level(GPIO_STATUS_LED_ONBOARD, 0);      
+				gpio_set_level(GPIO_STATUS_LED_ONBOARD, 0);
 				vTaskDelay(StatusLEDDataInt.iBlinkTime / portTICK_PERIOD_MS);
 				gpio_set_level(GPIO_STATUS_LED_ONBOARD, 1);
 				vTaskDelay(StatusLEDDataInt.iBlinkTime / portTICK_PERIOD_MS);
@@ -132,7 +132,7 @@ void StatusLED(StatusLedSource _eSource, int _iCode, bool _bInfinite)
 		}
 	}
 	else {
-		ESP_LOGD(TAG, "task_StatusLED still processing, request skipped");	// Requests with high frequency could be skipped, but LED is only helpful for static states 
+		ESP_LOGD(TAG, "task_StatusLED still processing, request skipped");	// Requests with high frequency could be skipped, but LED is only helpful for static states
 	}
 	//ESP_LOGD(TAG, "StatusLED - done");
 }
@@ -144,7 +144,7 @@ void StatusLEDOff(void)
 		vTaskDelete(xHandle_task_StatusLED); // Delete task for StatusLED to force stop of blinking
 		xHandle_task_StatusLED = NULL;
 	}
-	
+
 	esp_rom_gpio_pad_select_gpio(GPIO_STATUS_LED_ONBOARD); // Init the GPIO
 	gpio_set_direction(GPIO_STATUS_LED_ONBOARD, GPIO_MODE_OUTPUT); // Set the GPIO as a push/pull output
 	gpio_set_level(GPIO_STATUS_LED_ONBOARD, 1);// LED off

--- a/code/components/jomjol_helper/system.cpp
+++ b/code/components/jomjol_helper/system.cpp
@@ -52,14 +52,14 @@ int getChipCoreCount(void)
 {
     esp_chip_info_t chipInfo;
     esp_chip_info(&chipInfo);
-	
+
     return (int)chipInfo.cores;
 }
 
 
 std::string getChipRevision(void)
 {
-	return std::to_string(efuse_hal_get_major_chip_version()) + 
+	return std::to_string(efuse_hal_get_major_chip_version()) +
 		    "." + std::to_string(efuse_hal_get_minor_chip_version());
 }
 
@@ -68,10 +68,10 @@ void printDeviceInfo(void)
 {
     esp_chip_info_t chipInfo;
     esp_chip_info(&chipInfo);
-    
-    LogFile.WriteToFile(ESP_LOG_INFO, TAG, "Device info: Board: " + getBoardType() + 
-										   ", SOC: " + getChipModel() + 
-                                           ", Cores: " + std::to_string(chipInfo.cores) + 
+
+    LogFile.WriteToFile(ESP_LOG_INFO, TAG, "Device info: Board: " + getBoardType() +
+										   ", SOC: " + getChipModel() +
+                                           ", Cores: " + std::to_string(chipInfo.cores) +
                                            ", Revision: " + getChipRevision());
 }
 
@@ -101,7 +101,7 @@ void taskSocTemp(void *pvParameter)
 	temperature_sensor_config_t socTempSensorConfig = TEMPERATURE_SENSOR_CONFIG_DEFAULT(20, 100);
     temperature_sensor_install(&socTempSensorConfig, &socTempSensor);
     temperature_sensor_enable(socTempSensor);
-	
+
 	while(1) {
 		if (temperature_sensor_get_celsius(socTempSensor, &socTemperature) != ESP_OK) {
 			socTemperature = -1;
@@ -145,11 +145,11 @@ float getSOCTemperature()
 
 bool setCPUFrequency(void)
 {
-    ConfigFile configFile = ConfigFile(CONFIG_FILE); 
+    ConfigFile configFile = ConfigFile(CONFIG_FILE);
     std::string cpuFrequency = "160";
 
 	#ifdef CONFIG_IDF_TARGET_ESP32
-    	esp_pm_config_esp32_t pm_config; 
+    	esp_pm_config_esp32_t pm_config;
 	#elif defined(CONFIG_IDF_TARGET_ESP32S3)
     	esp_pm_config_esp32s3_t pm_config;
 	#else
@@ -168,7 +168,7 @@ bool setCPUFrequency(void)
 
 
     /* Load config from config file */
-    while ((!configFile.GetNextParagraph(line, disabledLine, eof) || 
+    while ((!configFile.GetNextParagraph(line, disabledLine, eof) ||
             (line.compare("[System]") != 0)) && !eof) {}
     if (eof) {
         return false;
@@ -178,7 +178,7 @@ bool setCPUFrequency(void)
         return false;
     }
 
-    while (configFile.getNextLine(&line, disabledLine, eof) && 
+    while (configFile.getNextLine(&line, disabledLine, eof) &&
             !configFile.isNewParagraph(line)) {
         splitted = ZerlegeZeile(line);
 
@@ -250,7 +250,7 @@ std::string getESPHeapInfo(){
 	espInfoResultStr += std::string(aMsgBuf);
 	sprintf(aMsgBuf," | Int Min Free: %ld", (long) (aMinFreeInternalHeapSize));
 	espInfoResultStr += std::string(aMsgBuf);
-	
+
 	return 	espInfoResultStr;
 }
 
@@ -261,19 +261,19 @@ size_t getESPHeapSizeTotalFree()
 }
 
 
-size_t getESPHeapSizeInternalFree() 
+size_t getESPHeapSizeInternalFree()
 {
 	return heap_caps_get_free_size(MALLOC_CAP_8BIT| MALLOC_CAP_INTERNAL);
 }
 
 
-size_t getESPHeapSizeInternalLargestFree() 
+size_t getESPHeapSizeInternalLargestFree()
 {
 	return heap_caps_get_largest_free_block(MALLOC_CAP_8BIT | MALLOC_CAP_INTERNAL);
 }
 
 
-size_t getESPHeapSizeInternalMinFree() 
+size_t getESPHeapSizeInternalMinFree()
 {
 	return heap_caps_get_minimum_free_size(MALLOC_CAP_8BIT | MALLOC_CAP_INTERNAL);
 }
@@ -285,13 +285,13 @@ size_t getESPHeapSizeSPIRAMFree()
 }
 
 
-size_t getESPHeapSizeSPIRAMLargestFree() 
+size_t getESPHeapSizeSPIRAMLargestFree()
 {
 	return heap_caps_get_largest_free_block(MALLOC_CAP_8BIT | MALLOC_CAP_SPIRAM);
 }
 
 
-size_t getESPHeapSizeSPIRAMMinFree() 
+size_t getESPHeapSizeSPIRAMMinFree()
 {
 	return heap_caps_get_minimum_free_size(MALLOC_CAP_8BIT | MALLOC_CAP_SPIRAM);
 }
@@ -299,17 +299,17 @@ size_t getESPHeapSizeSPIRAMMinFree()
 
 #ifdef USE_HIMEM_IF_AVAILABLE
 size_t getESPHimemTotal()
-{ 
+{
 	return esp_himem_get_phys_size();
 }
 
 size_t getESPHimemFree()
-{ 
+{
 	return esp_himem_get_free_size();
 }
 
 size_t getESPHimemReservedArea()
-{ 
+{
 	return esp_himem_reserved_area_size();
 }
 #endif
@@ -384,7 +384,7 @@ std::string getResetReason(void)
 		case ESP_RST_SDIO: reasonText = "SDIO"; break;       //!< Reset over SDIO
 
 		case ESP_RST_UNKNOWN:   //!< Reset reason can not be determined
-		default: 
+		default:
 			reasonText = "Unknown";
 	}
     return reasonText;
@@ -406,7 +406,7 @@ void CheckIsPlannedReboot()
 }
 
 
-bool getIsPlannedReboot() 
+bool getIsPlannedReboot()
 {
     return isPlannedReboot;
 }
@@ -541,7 +541,7 @@ struct SDCard_Manufacturer_database database[] = {
 
 
 /* Parse SD Card Manufacturer Database */
-std::string SDCardParseManufacturerIDs(int id) 
+std::string SDCardParseManufacturerIDs(int id)
 {
 	unsigned int id_cnt = sizeof(database) / sizeof(struct SDCard_Manufacturer_database);
 	std::string ret_val = "";
@@ -562,7 +562,7 @@ std::string getSDCardManufacturer()
 {
 	std::string SDCardManufacturer = SDCardParseManufacturerIDs(SDCardCid.mfg_id);
 	//ESP_LOGD(TAG, "SD Card Manufacturer: %s", SDCardManufacturer.c_str());
-	
+
 	return (SDCardManufacturer + " (ID: " + std::to_string(SDCardCid.mfg_id) + ")");
 }
 
@@ -570,7 +570,7 @@ std::string getSDCardManufacturer()
 std::string getSDCardName()
 {
 	char *SDCardName = SDCardCid.name;
-	//ESP_LOGD(TAG, "SD Card Name: %s", SDCardName); 
+	//ESP_LOGD(TAG, "SD Card Name: %s", SDCardName);
 
 	return std::string(SDCardName);
 }
@@ -595,7 +595,7 @@ int getSDCardFreePartitionSpace()
 {
 	FATFS *fs;
     uint32_t fre_clust, fre_sect;
-  
+
     /* Get volume information and free clusters of drive 0 */
     f_getfree("0:", (DWORD *)&fre_clust, &fs);
     fre_sect = (fre_clust * fs->csize) / 1024 /(1024/SDCardCsd.sector_size);	//corrected by SD Card sector size (usually 512 bytes) and convert to MB
@@ -610,7 +610,7 @@ int getSDCardPartitionAllocationSize()
 {
 	FATFS *fs;
     uint32_t fre_clust, allocation_size;
-  
+
     /* Get volume information and free clusters of drive 0 */
     f_getfree("0:", (DWORD *)&fre_clust, &fs);
     allocation_size = fs->ssize;
@@ -624,7 +624,7 @@ int getSDCardPartitionAllocationSize()
 int getSDCardCapacity()
 {
 	int SDCardCapacity = SDCardCsd.capacity / (1024/SDCardCsd.sector_size) / 1024;  // total sectors * sector size  --> Byte to MB (1024*1024)
-	//ESP_LOGD(TAG, "SD Card Capacity: %s", std::to_string(SDCardCapacity).c_str()); 
+	//ESP_LOGD(TAG, "SD Card Capacity: %s", std::to_string(SDCardCapacity).c_str());
 
 	return SDCardCapacity;
 }
@@ -633,7 +633,7 @@ int getSDCardCapacity()
 int getSDCardSectorSize()
 {
 	int SDCardSectorSize = SDCardCsd.sector_size;
-	//ESP_LOGD(TAG, "SD Card Sector Size: %s bytes", std::to_string(SDCardSectorSize).c_str()); 
+	//ESP_LOGD(TAG, "SD Card Sector Size: %s bytes", std::to_string(SDCardSectorSize).c_str());
 
 	return SDCardSectorSize;
 }

--- a/code/components/jomjol_image_proc/CAlignAndCutImage.cpp
+++ b/code/components/jomjol_image_proc/CAlignAndCutImage.cpp
@@ -13,7 +13,7 @@
 
 static const char* TAG = "IMG_ALIGNCUT";
 
-//#define DEBUG_DETAIL_ON  
+//#define DEBUG_DETAIL_ON
 
 
 CAlignAndCutImage::CAlignAndCutImage(std::string _name, CImageBasis *_org, CImageBasis *_temp) : CImageBasis(_name)
@@ -24,9 +24,9 @@ CAlignAndCutImage::CAlignAndCutImage(std::string _name, CImageBasis *_org, CImag
     width = _org->width;
     height = _org->height;
     bpp = _org->bpp;
-    externalImage = true;   
+    externalImage = true;
 
-    islocked = false; 
+    islocked = false;
 
     ImageTMP = _temp;
 }
@@ -91,14 +91,14 @@ int IRAM_ATTR CAlignAndCutImage::Align(strRefInfo *_temp1, strRefInfo *_temp2)
         ESP_LOGI(TAG, "Align: dx1 %d, dy1 %d, dx2 %d, dy2 %d, angle dev %f", dx1, dy1, dx2, dy2, angle_deviation);
     #endif
 
-    if (fabs(angle_deviation) > 45 || abs(dx1) >= _temp1->search_x || abs(dy1) >= _temp1->search_y  || 
-                                      abs(dx2) >= _temp2->search_x || abs(dy2) >= _temp2->search_y) 
+    if (fabs(angle_deviation) > 45 || abs(dx1) >= _temp1->search_x || abs(dy1) >= _temp1->search_y  ||
+                                      abs(dx2) >= _temp2->search_x || abs(dy2) >= _temp2->search_y)
     {
-        _temp1->error_details = _temp2->error_details = "Angle dev: " + to_stringWithPrecision(angle_deviation, 1) + 
+        _temp1->error_details = _temp2->error_details = "Angle dev: " + to_stringWithPrecision(angle_deviation, 1) +
                             ", Ref0dx: " + std::to_string(dx1)+ ", Ref0dy: " + std::to_string(dy1) +
                             ", Ref1dx: " + std::to_string(dx2)+ ", Ref1dy: " + std::to_string(dy2);
         LogFile.WriteToFile(ESP_LOG_ERROR, TAG, _temp1->error_details);
-        
+
         return -1; // ALIGNMENT FAILED
     }
 
@@ -122,11 +122,11 @@ int IRAM_ATTR CAlignAndCutImage::Align(strRefInfo *_temp1, strRefInfo *_temp2)
         rt.Rotate(angle_deviation, width/2, height/2);
     }
 
-    LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "Angle dev: " + to_stringWithPrecision(angle_deviation, 1) + 
+    LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "Angle dev: " + to_stringWithPrecision(angle_deviation, 1) +
                                 ", Ref0dx: " + std::to_string(dx1)+ ", Ref0dy: " + std::to_string(dy1) +
                                 ", Ref1dx: " + std::to_string(dx2)+ ", Ref1dy: " + std::to_string(dy2));
 
-    if (isSimilar1 && isSimilar2)   
+    if (isSimilar1 && isSimilar2)
         return 1; // FAST ALGO match
     else {
         return 0; // STANDARD ALGO done
@@ -169,7 +169,7 @@ void IRAM_ATTR CAlignAndCutImage::CutAndSave(std::string _template1, int x1, int
     #else
         stbi_write_bmp(_template1.c_str(), dx, dy, channels, odata);
     #endif
-    
+
 
     RGBImageRelease();
 

--- a/code/components/jomjol_image_proc/CFindTemplate.cpp
+++ b/code/components/jomjol_image_proc/CFindTemplate.cpp
@@ -10,7 +10,7 @@
 
 static const char* TAG = "IMG_FINDTEMPL";
 
-//#define DEBUG_DETAIL_ON  
+//#define DEBUG_DETAIL_ON
 
 
 bool IRAM_ATTR CFindTemplate::FindTemplate(strRefInfo *_ref, bool _noFast)
@@ -69,7 +69,7 @@ bool IRAM_ATTR CFindTemplate::FindTemplate(strRefInfo *_ref, bool _noFast)
             _ref->found_x = _ref->fastalg_x;
             _ref->found_y = _ref->fastalg_y;
 
-            //free_psram_heap(std::string(TAG) + _ref->image_file, rgb_template);  // Keep alignment image refImage in RAM   
+            //free_psram_heap(std::string(TAG) + _ref->image_file, rgb_template);  // Keep alignment image refImage in RAM
             return true;
         }
     }
@@ -121,8 +121,8 @@ bool IRAM_ATTR CFindTemplate::FindTemplate(strRefInfo *_ref, bool _noFast)
     // Print results
     std::string zw = "SADsum:" + std::to_string(SADsum) + ", X:"+ std::to_string(_ref->found_x) + ", Y:" + std::to_string(_ref->found_y);
     LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "STANDARD Algo results: " + zw);
-    
-    //free_psram_heap(std::string(TAG) + _ref->image_file, rgb_template);   // Keep alignment image refImage in RAM  
+
+    //free_psram_heap(std::string(TAG) + _ref->image_file, rgb_template);   // Keep alignment image refImage in RAM
     return false;
 }
 
@@ -142,20 +142,20 @@ bool IRAM_ATTR CFindTemplate::CalculateSimularities(strRefInfo* _ref)
             stbi_uc* p_tpl = rgb_template + (channels * (youter * tpl_width + xouter));
             for (int _ch = 0; _ch < channels; ++_ch)
             {
-                SADsum += labs(p_tpl[_ch] - p_org[_ch]);              
+                SADsum += labs(p_tpl[_ch] - p_org[_ch]);
                 anz++;
             }
         }
     }
-    
+
     // normalize by number of sums
     SADNorm = SADsum/anz;
 
     // Print results
-    std::string zw = "SADThreshold:" + std::to_string(_ref->fastalg_SADThreshold) + ", SADNorm:" + std::to_string(SADNorm) + 
+    std::string zw = "SADThreshold:" + std::to_string(_ref->fastalg_SADThreshold) + ", SADNorm:" + std::to_string(SADNorm) +
                      ", X:" + std::to_string(_ref->fastalg_x) + ", Y:" + std::to_string(_ref->fastalg_y);
     LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "FAST Algo results: " + zw);
-    
+
     // Evaluate results
     if (SADNorm <= _ref->fastalg_SADThreshold) {
         LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "FAST Algo: Match found");

--- a/code/components/jomjol_image_proc/CFindTemplate.h
+++ b/code/components/jomjol_image_proc/CFindTemplate.h
@@ -27,8 +27,8 @@ class CFindTemplate : public CImageBasis
     private:
         uint8_t* rgb_template;
 
-        bool CalculateSimularities(strRefInfo *_ref);  
-    
+        bool CalculateSimularities(strRefInfo *_ref);
+
     public:
         int tpl_width, tpl_height, tpl_bpp;
 

--- a/code/components/jomjol_image_proc/CImageBasis.cpp
+++ b/code/components/jomjol_image_proc/CImageBasis.cpp
@@ -27,14 +27,14 @@ uint8_t * CImageBasis::RGBImageLock(int _waitmaxsec)
 {
     if (islocked)
     {
-        #ifdef DEBUG_DETAIL_ON   
+        #ifdef DEBUG_DETAIL_ON
                 ESP_LOGD(TAG, "Image is locked: sleep for: %ds", _waitmaxsec);
         #endif
         TickType_t xDelay;
         xDelay = 1000 / portTICK_PERIOD_MS;
         for (int i = 0; i <= _waitmaxsec; ++i)
         {
-            vTaskDelay( xDelay ); 
+            vTaskDelay( xDelay );
             if (!islocked)
                 break;
         }
@@ -65,7 +65,7 @@ void writejpghelp(void *context, void *data, int size)
     ImageData* _zw = (ImageData*) context;
     uint8_t *voidstart = _zw->data;
     uint8_t *datastart = (uint8_t*) data;
-    
+
     if ((_zw->size < MAX_JPG_SIZE)) {   // Abort copy to prevent buffer overflow
         voidstart += _zw->size;
 
@@ -99,7 +99,7 @@ ImageData* CImageBasis::writeToMemoryAsJPG(const int quality)
 void CImageBasis::writeToMemoryAsJPG(ImageData* i, const int quality)
 {
     ImageData* ii = new ImageData;
-    
+
     RGBImageLock();
     stbi_write_jpg_to_func(writejpghelp, ii, width, height, channels, rgb_image, quality);
     RGBImageRelease();
@@ -131,11 +131,11 @@ inline void writejpgtohttphelp(void *context, void *data, int size)
             ESP_LOGE(TAG, "File sending failed");
             _send->res = ESP_FAIL;
         }
-        _send->size = 0;      
+        _send->size = 0;
     }
     std::memcpy((void*) (&(_send->buf[0]) + _send->size), data, size);
     _send->size+= size;
-} 
+}
 
 
 esp_err_t CImageBasis::SendJPGtoHTTP(httpd_req_t *_req, const int quality)
@@ -151,14 +151,14 @@ esp_err_t CImageBasis::SendJPGtoHTTP(httpd_req_t *_req, const int quality)
     if (ii.size > 0) {
         if (httpd_resp_send_chunk(_req, (char*) ii.buf, ii.size) != ESP_OK) { // still send the rest
             ESP_LOGE(TAG, "File sending failed");
-            ii.res = ESP_FAIL;  
+            ii.res = ESP_FAIL;
         }
     }
 
     RGBImageRelease();
 
     return ii.res;
-}  
+}
 
 
 bool CImageBasis::CopyFromMemory(uint8_t* _source, int _size)
@@ -302,7 +302,7 @@ void CImageBasis::drawLine(int x1, int y1, int x2, int y2, int r, int g, int b, 
                 if (isInImage(_x, _y))
                     setPixelColor(_x, _y, r, g, b);
         }
-    
+
     RGBImageRelease();
 }
 
@@ -362,7 +362,7 @@ CImageBasis::CImageBasis(std::string _name)
     rgb_image = NULL;
     width = 0;
     height = 0;
-    channels = 0;    
+    channels = 0;
     islocked = false;
 }
 
@@ -376,7 +376,7 @@ bool CImageBasis::CreateEmptyImage(int _width, int _height, int _channels)
 
     RGBImageLock();
 
-    #ifdef DEBUG_DETAIL_ON 
+    #ifdef DEBUG_DETAIL_ON
         LogFile.WriteHeapInfo("CreateEmptyImage");
     #endif
 
@@ -392,7 +392,7 @@ bool CImageBasis::CreateEmptyImage(int _width, int _height, int _channels)
         return false;
     }
 
-    stbi_uc* p_source;    
+    stbi_uc* p_source;
 
     for (int x = 0; x < width; ++x)
         for (int y = 0; y < height; ++y)
@@ -417,7 +417,7 @@ bool CImageBasis::CreateEmptyImage(int _width, int _height, int _channels, int a
 
     RGBImageLock();
 
-    #ifdef DEBUG_DETAIL_ON 
+    #ifdef DEBUG_DETAIL_ON
         LogFile.WriteHeapInfo("CreateEmptyImage");
     #endif
 
@@ -433,7 +433,7 @@ bool CImageBasis::CreateEmptyImage(int _width, int _height, int _channels, int a
         return false;
     }
 
-    stbi_uc* p_source;    
+    stbi_uc* p_source;
 
     for (int x = 0; x < width; ++x)
         for (int y = 0; y < height; ++y)
@@ -451,7 +451,7 @@ bool CImageBasis::CreateEmptyImage(int _width, int _height, int _channels, int a
 
 void CImageBasis::EmptyImage()
 {
-    #ifdef DEBUG_DETAIL_ON 
+    #ifdef DEBUG_DETAIL_ON
         LogFile.WriteHeapInfo("EmptyImage");
     #endif
 
@@ -483,7 +483,7 @@ bool CImageBasis::LoadFromMemory(stbi_uc *_buffer, int len)
     rgb_image = stbi_load_from_memory(_buffer, len, &width, &height, &channels, 3);
     bpp = channels;
     ESP_LOGD(TAG, "Image loaded from memory: %d, %d, %d", width, height, channels);
-    
+
     if (rgb_image == NULL)
     {
         LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "LoadFromMemory: Image loading failed");
@@ -508,7 +508,7 @@ bool CImageBasis::LoadFromMemoryPreallocated(stbi_uc *_buffer, int len)
     rgb_image = stbi_load_from_memory(_buffer, len, &width, &height, &channels, 3);
     bpp = channels;
     ESP_LOGD(TAG, "Image loaded from memory: %d, %d, %d", width, height, channels);
-    
+
     if (rgb_image == NULL)
     {
         LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "LoadFromMemoryPreallocated: Image loading failed");
@@ -540,7 +540,7 @@ bool CImageBasis::LoadFromFilePreallocated(std::string _name, std::string _image
         LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "No preallocation found");
     }
 
-    #ifdef DEBUG_DETAIL_ON 
+    #ifdef DEBUG_DETAIL_ON
         LogFile.WriteHeapInfo("CImageBasis-LoadFromFilePreallocated - Start");
     #endif
 
@@ -552,16 +552,16 @@ bool CImageBasis::LoadFromFilePreallocated(std::string _name, std::string _image
         RGBImageRelease();
         return false;
     }
-    
+
     RGBImageRelease();
 
-    #ifdef DEBUG_DETAIL_ON 
+    #ifdef DEBUG_DETAIL_ON
         std::string zw = "CImageBasis LoadFromFilePreallocated after load " + _image;
         ESP_LOGI(TAG, "%s", zw.c_str());
         ESP_LOGI(TAG, "w %d, h %d, b %d, c %d", width, height, bpp, channels);
     #endif
 
-    #ifdef DEBUG_DETAIL_ON 
+    #ifdef DEBUG_DETAIL_ON
         LogFile.WriteHeapInfo("CImageBasis-LoadFromFilePreallocated - done");
     #endif
 
@@ -569,7 +569,7 @@ bool CImageBasis::LoadFromFilePreallocated(std::string _name, std::string _image
 }
 
 
-CImageBasis::CImageBasis(std::string _name, CImageBasis *_copyfrom) 
+CImageBasis::CImageBasis(std::string _name, CImageBasis *_copyfrom)
 {
     name = _name;
     islocked = false;
@@ -581,7 +581,7 @@ CImageBasis::CImageBasis(std::string _name, CImageBasis *_copyfrom)
 
     RGBImageLock();
 
-    #ifdef DEBUG_DETAIL_ON 
+    #ifdef DEBUG_DETAIL_ON
         LogFile.WriteHeapInfo("CImageBasis_copyfrom - Start");
     #endif
 
@@ -600,13 +600,13 @@ CImageBasis::CImageBasis(std::string _name, CImageBasis *_copyfrom)
     memCopy(_copyfrom->rgb_image, rgb_image, memsize);
     RGBImageRelease();
 
-    #ifdef DEBUG_DETAIL_ON 
+    #ifdef DEBUG_DETAIL_ON
         LogFile.WriteHeapInfo("CImageBasis_copyfrom - done");
     #endif
 }
 
 
-CImageBasis::CImageBasis(std::string _name, CImageBasis *_copyfrom, int add) 
+CImageBasis::CImageBasis(std::string _name, CImageBasis *_copyfrom, int add)
 {
     name = _name;
     islocked = false;
@@ -618,7 +618,7 @@ CImageBasis::CImageBasis(std::string _name, CImageBasis *_copyfrom, int add)
 
     RGBImageLock();
 
-    #ifdef DEBUG_DETAIL_ON 
+    #ifdef DEBUG_DETAIL_ON
         LogFile.WriteHeapInfo("CImageBasis_copyfrom - Start");
     #endif
 
@@ -637,7 +637,7 @@ CImageBasis::CImageBasis(std::string _name, CImageBasis *_copyfrom, int add)
     memCopy(_copyfrom->rgb_image, rgb_image, memsize);
     RGBImageRelease();
 
-    #ifdef DEBUG_DETAIL_ON 
+    #ifdef DEBUG_DETAIL_ON
         LogFile.WriteHeapInfo("CImageBasis_copyfrom - done");
     #endif
 }
@@ -655,7 +655,7 @@ CImageBasis::CImageBasis(std::string _name, int _width, int _height, int _channe
 
     RGBImageLock();
 
-     #ifdef DEBUG_DETAIL_ON 
+     #ifdef DEBUG_DETAIL_ON
         LogFile.WriteHeapInfo("CImageBasis_width,height,ch - Start");
     #endif
 
@@ -673,7 +673,7 @@ CImageBasis::CImageBasis(std::string _name, int _width, int _height, int _channe
 
     RGBImageRelease();
 
-    #ifdef DEBUG_DETAIL_ON 
+    #ifdef DEBUG_DETAIL_ON
         LogFile.WriteHeapInfo("CImageBasis_width,height,ch - done");
     #endif
 }
@@ -694,7 +694,7 @@ CImageBasis::CImageBasis(std::string _name, std::string _image)
 
     RGBImageLock();
 
-    #ifdef DEBUG_DETAIL_ON 
+    #ifdef DEBUG_DETAIL_ON
         LogFile.WriteHeapInfo("CImageBasis_image - Start");
     #endif
 
@@ -706,16 +706,16 @@ CImageBasis::CImageBasis(std::string _name, std::string _image)
         RGBImageRelease();
         return;
     }
-    
+
     RGBImageRelease();
 
-    #ifdef DEBUG_DETAIL_ON 
+    #ifdef DEBUG_DETAIL_ON
         std::string zw = "CImageBasis after load " + _image;
         ESP_LOGD(TAG, "%s", zw.c_str());
         ESP_LOGD(TAG, "w %d, h %d, b %d, c %d", width, height, bpp, channels);
     #endif
 
-    #ifdef DEBUG_DETAIL_ON 
+    #ifdef DEBUG_DETAIL_ON
         LogFile.WriteHeapInfo("CImageBasis_image - done");
     #endif
 }
@@ -736,7 +736,7 @@ CImageBasis::CImageBasis(std::string _name, std::string _image, bool _externalIm
 
     RGBImageLock();
 
-    #ifdef DEBUG_DETAIL_ON 
+    #ifdef DEBUG_DETAIL_ON
         LogFile.WriteHeapInfo("CImageBasis_image - Start");
     #endif
 
@@ -748,16 +748,16 @@ CImageBasis::CImageBasis(std::string _name, std::string _image, bool _externalIm
         RGBImageRelease();
         return;
     }
-    
+
     RGBImageRelease();
 
-    #ifdef DEBUG_DETAIL_ON 
+    #ifdef DEBUG_DETAIL_ON
         std::string zw = "CImageBasis after load " + _image;
         ESP_LOGD(TAG, "%s", zw.c_str());
         ESP_LOGD(TAG, "w %d, h %d, b %d, c %d", width, height, bpp, channels);
     #endif
 
-    #ifdef DEBUG_DETAIL_ON 
+    #ifdef DEBUG_DETAIL_ON
         LogFile.WriteHeapInfo("CImageBasis_image - done");
     #endif
 }
@@ -799,7 +799,7 @@ void CImageBasis::Negative(void)
 void CImageBasis::Contrast(float _contrast)  //input range [-100..100]
 {
     stbi_uc* p_source;
-    
+
     float contrast = (_contrast/100) + 1;  //convert to decimal & shift range: [0..2]
     float intercept = 128 * (1 - contrast);
 
@@ -840,7 +840,7 @@ void CImageBasis::SaveToFile(std::string _imageout)
     if ((typ == "jpg") || (typ == "JPG")) {       // CAUTION PROBLEMATIC IN ESP32
         stbi_write_jpg(_imageout.c_str(), width, height, channels, rgb_image, 0);
     }
- 
+
     #ifndef STBI_ONLY_JPEG
     if ((typ == "bmp") || (typ == "BMP")) {
         stbi_write_bmp(_imageout.c_str(), width, height, channels, rgb_image);

--- a/code/components/jomjol_image_proc/CImageBasis.h
+++ b/code/components/jomjol_image_proc/CImageBasis.h
@@ -36,15 +36,15 @@ class CImageBasis
     public:
         uint8_t* rgb_image = NULL;
         int channels;
-        int width, height, bpp; 
+        int width, height, bpp;
 
         uint8_t * RGBImageLock(int _waitmaxsec = 60);
         void RGBImageRelease();
         uint8_t * RGBImageGet();
 
-        int getWidth() {return this->width;};   
-        int getHeight() {return this->height;};   
-        int getChannels() {return this->channels;};   
+        int getWidth() {return this->width;};
+        int getHeight() {return this->height;};
+        int getChannels() {return this->channels;};
         int getMemsize() {return this->memsize;};
         void drawRect(int x, int y, int dx, int dy, int r = 255, int g = 255, int b = 255, int thickness = 1);
         void drawLine(int x1, int y1, int x2, int y2, int r, int g, int b, int thickness = 1);
@@ -72,8 +72,8 @@ class CImageBasis
         CImageBasis(std::string name, CImageBasis *_copyfrom);
         CImageBasis(std::string _name, CImageBasis *_copyfrom, int add);
 
-        void Resize(int _new_dx, int _new_dy);        
-        void Resize(int _new_dx, int _new_dy, CImageBasis *_target);        
+        void Resize(int _new_dx, int _new_dy);
+        void Resize(int _new_dx, int _new_dy, CImageBasis *_target);
 
         bool LoadFromMemory(stbi_uc *_buffer, int len);
         bool LoadFromMemoryPreallocated(stbi_uc *_buffer, int len);
@@ -82,7 +82,7 @@ class CImageBasis
         ImageData* writeToMemoryAsJPG(const int quality = 90);
         void writeToMemoryAsJPG(ImageData* ii, const int quality = 90);
 
-        esp_err_t SendJPGtoHTTP(httpd_req_t *req, const int quality = 90);   
+        esp_err_t SendJPGtoHTTP(httpd_req_t *req, const int quality = 90);
 
         uint8_t GetPixelColor(int x, int y, int ch);
 

--- a/code/components/jomjol_image_proc/CMakeLists.txt
+++ b/code/components/jomjol_image_proc/CMakeLists.txt
@@ -2,6 +2,6 @@ FILE(GLOB_RECURSE app_sources ${CMAKE_CURRENT_SOURCE_DIR}/*.*)
 
 idf_component_register(SRCS ${app_sources}
                     INCLUDE_DIRS "."
-                    REQUIRES jomjol_helper jomjol_logfile esp_http_server jomjol_fileserver_ota) 
+                    REQUIRES jomjol_helper jomjol_logfile esp_http_server jomjol_fileserver_ota)
 
 

--- a/code/components/jomjol_image_proc/CRotateImage.cpp
+++ b/code/components/jomjol_image_proc/CRotateImage.cpp
@@ -15,9 +15,9 @@ CRotateImage::CRotateImage(std::string _name, CImageBasis *_org, CImageBasis *_t
     width = _org->width;
     height = _org->height;
     bpp = _org->bpp;
-    externalImage = true;   
-    ImageTMP = _temp;   
-    ImageOrg = _org; 
+    externalImage = true;
+    ImageTMP = _temp;
+    ImageOrg = _org;
     islocked = false;
     doflip = _flip;
 }
@@ -119,7 +119,7 @@ void IRAM_ATTR CRotateImage::Rotate(float _angle, int _centerx, int _centery)
     {
         odata = (unsigned char*)malloc_psram_heap(std::string(TAG) + "->odata", memsize, MALLOC_CAP_SPIRAM);
     }
-    
+
 
     int x_source, y_source;
     stbi_uc* p_target;
@@ -219,7 +219,7 @@ void IRAM_ATTR CRotateImage::RotateAntiAliasing(float _angle, int _centerx, int 
     {
         odata = (unsigned char*)malloc_psram_heap(std::string(TAG) + "->odata", memsize, MALLOC_CAP_SPIRAM);
     }
-    
+
 
     int x_source_1, y_source_1, x_source_2, y_source_2;
     float x_source, y_source;

--- a/code/components/jomjol_image_proc/CRotateImage.h
+++ b/code/components/jomjol_image_proc/CRotateImage.h
@@ -15,7 +15,7 @@ class CRotateImage: public CImageBasis
 
         void Rotate(float _angle);
         void RotateAntiAliasing(float _angle);
-       
+
         void Rotate(float _angle, int _centerx, int _centery);
         void RotateAntiAliasing(float _angle, int _centerx, int _centery);
 

--- a/code/components/jomjol_influxdb/interface_influxdb.cpp
+++ b/code/components/jomjol_influxdb/interface_influxdb.cpp
@@ -64,7 +64,7 @@ static esp_err_t http_event_handler(esp_http_client_event_t *evt)
 }
 
 
-bool InfluxDBInit(std::string _uri, std::string _database, std::string _user, std::string _password, 
+bool InfluxDBInit(std::string _uri, std::string _database, std::string _user, std::string _password,
                     bool _TLSEncryption, std::string _TLSCACertFilename, std::string _TLSClientCertFilename,
                     std::string _TLSClientKeyFilename)
 {
@@ -72,7 +72,7 @@ bool InfluxDBInit(std::string _uri, std::string _database, std::string _user, st
     influxDBDatabase = _database;
     influxDBUser = _user;
     influxDBPassword = _password;
- 
+
 
     // TLS Encryption parameter
     influxDBTLSEncryption = _TLSEncryption;
@@ -129,7 +129,7 @@ bool InfluxDBInit(std::string _uri, std::string _database, std::string _user, st
 
 void InfluxDBPublish(std::string _measurement, std::string _key, std::string _content, std::string _timestamp)
 {
-    char* response_buffer = (char*) calloc_psram_heap(std::string(TAG) + "->response_buffer", 1, 
+    char* response_buffer = (char*) calloc_psram_heap(std::string(TAG) + "->response_buffer", 1,
                             sizeof(char) * MAX_HTTP_OUTPUT_BUFFER, MALLOC_CAP_8BIT | MALLOC_CAP_SPIRAM);
     esp_http_client_config_t http_config = {
        .user_agent = "ESP32 Meter reader",
@@ -148,7 +148,7 @@ void InfluxDBPublish(std::string _measurement, std::string _key, std::string _co
     if (influxDBTLSEncryption) {
         if (!influxDBTLSCACert.empty()) {
             http_config.cert_pem = influxDBTLSCACert.c_str();
-            http_config.cert_len = influxDBTLSCACert.length() + 1;  
+            http_config.cert_len = influxDBTLSCACert.length() + 1;
             http_config.skip_cert_common_name_check = true;    // Skip any validation of server certificate CN field
         }
 
@@ -157,7 +157,7 @@ void InfluxDBPublish(std::string _measurement, std::string _key, std::string _co
             http_config.client_cert_len = influxDBTLSClientCert.length() + 1;
         }
 
-        if (!influxDBTLSClientKey.empty()) {       
+        if (!influxDBTLSClientKey.empty()) {
             http_config.client_key_pem = influxDBTLSClientKey.c_str();
             http_config.client_key_len = influxDBTLSClientKey.length() + 1;
         }
@@ -228,7 +228,7 @@ bool getInfluxDBisEncrypted()
 }
 
 
-bool InfluxDBv2Init(std::string _uri, std::string _bucket, std::string _org, std::string _token, 
+bool InfluxDBv2Init(std::string _uri, std::string _bucket, std::string _org, std::string _token,
                         bool _TLSEncryption, std::string _TLSCACertFilename, std::string _TLSClientCertFilename,
                         std::string _TLSClientKeyFilename)
 {
@@ -290,9 +290,9 @@ bool InfluxDBv2Init(std::string _uri, std::string _bucket, std::string _org, std
 }
 
 
-void InfluxDBv2Publish(std::string _measurement, std::string _key, std::string _content, std::string _timestamp) 
+void InfluxDBv2Publish(std::string _measurement, std::string _key, std::string _content, std::string _timestamp)
 {
-    char* response_buffer = (char*) calloc_psram_heap(std::string(TAG) + "->response_buffer", 1, 
+    char* response_buffer = (char*) calloc_psram_heap(std::string(TAG) + "->response_buffer", 1,
                             sizeof(char) * MAX_HTTP_OUTPUT_BUFFER, MALLOC_CAP_8BIT | MALLOC_CAP_SPIRAM);
     esp_http_client_config_t http_config = {
        .user_agent = "ESP32 Meter reader",
@@ -305,7 +305,7 @@ void InfluxDBv2Publish(std::string _measurement, std::string _key, std::string _
     if (influxDBv2TLSEncryption) {
         if (!influxDBv2TLSCACert.empty()) {
             http_config.cert_pem = influxDBv2TLSCACert.c_str();
-            http_config.cert_len = influxDBv2TLSCACert.length() + 1;  
+            http_config.cert_len = influxDBv2TLSCACert.length() + 1;
             http_config.skip_cert_common_name_check = true;    // Skip any validation of server certificate CN field
         }
 
@@ -314,7 +314,7 @@ void InfluxDBv2Publish(std::string _measurement, std::string _key, std::string _
             http_config.client_cert_len = influxDBv2TLSClientCert.length() + 1;
         }
 
-        if (!influxDBv2TLSClientKey.empty()) {       
+        if (!influxDBv2TLSClientKey.empty()) {
             http_config.client_key_pem = influxDBv2TLSClientKey.c_str();
             http_config.client_key_len = influxDBv2TLSClientKey.length() + 1;
         }
@@ -327,7 +327,7 @@ void InfluxDBv2Publish(std::string _measurement, std::string _key, std::string _
 
     if (_timestamp.length() > 0) {
         struct tm tm;
-        
+
         time_t t;
         time(&t);
         localtime_r(&t, &tm); // Extract DST setting from actual time to consider it for timestamp evaluation
@@ -386,7 +386,7 @@ bool getInfluxDBv2isEncrypted()
 }
 
 
-void InfluxDBdestroy() 
+void InfluxDBdestroy()
 {
 
 }

--- a/code/components/jomjol_influxdb/interface_influxdb.h
+++ b/code/components/jomjol_influxdb/interface_influxdb.h
@@ -8,14 +8,14 @@
 
 // Interface to InfluxDB v1.x
 bool InfluxDBInit(std::string _influxDBURI, std::string _database, std::string _user, std::string _password,
-                    bool _TLSEncryption, std::string _TLSCACertFilename, std::string _TLSClientCertFilename, 
+                    bool _TLSEncryption, std::string _TLSCACertFilename, std::string _TLSClientCertFilename,
                     std::string _TLSClientKeyFilename);
 void InfluxDBPublish(std::string _measurement, std::string _key, std::string _content, std::string _timestamp);
 bool getInfluxDBisEncrypted();
 
 // Interface to InfluxDB v2.x
 bool InfluxDBv2Init(std::string _uri, std::string _bucket, std::string _org, std::string _token,
-                        bool _TLSEncryption, std::string _TLSCACertFilename, std::string _TLSClientCertFilename, 
+                        bool _TLSEncryption, std::string _TLSCACertFilename, std::string _TLSClientCertFilename,
                         std::string _TLSClientKeyFilename);
 void InfluxDBv2Publish(std::string _measurement, std::string _key, std::string _content, std::string _timestamp);
 bool getInfluxDBv2isEncrypted();

--- a/code/components/jomjol_logfile/ClassLogFile.cpp
+++ b/code/components/jomjol_logfile/ClassLogFile.cpp
@@ -21,7 +21,7 @@ extern "C" {
 
 static const char *TAG = "LOGFILE";
 
-ClassLogFile LogFile(LOG_LOGS_ROOT_FOLDER, LOG_FILE_TIME_FORMAT, 
+ClassLogFile LogFile(LOG_LOGS_ROOT_FOLDER, LOG_FILE_TIME_FORMAT,
                      LOG_DATA_ROOT_FOLDER, DATA_FILE_TIME_FORMAT,
                      LOG_DEBUG_ROOT_FOLDER, DEBUG_FOLDER_TIME_FORMAT);
 
@@ -53,16 +53,16 @@ void ClassLogFile::WriteHeapInfo(std::string _id)
 }
 
 
-void ClassLogFile::WriteToData(std::string _timestamp, std::string _name, std::string  _sRawValue, std::string _sValue, 
-                               std::string _sFallbackValue, std::string  _sRatePerMin, std::string  _sRatePerInterval, 
+void ClassLogFile::WriteToData(std::string _timestamp, std::string _name, std::string  _sRawValue, std::string _sValue,
+                               std::string _sFallbackValue, std::string  _sRatePerMin, std::string  _sRatePerInterval,
                                std::string _sValueStatus, std::string _digital, std::string _analog)
 {
     //ESP_LOGD(TAG, "Start WriteToData");
     time_t rawtime;
 
     time(&rawtime);
-    std::string logpath = dataFileRootFolder + "/" + ConvertTimeToString(rawtime, datafile.c_str()); 
-    
+    std::string logpath = dataFileRootFolder + "/" + ConvertTimeToString(rawtime, datafile.c_str());
+
     FILE* pFile;
     std::string zwtime;
 
@@ -93,8 +93,8 @@ void ClassLogFile::WriteToData(std::string _timestamp, std::string _name, std::s
         fputs(_analog.c_str(), pFile);
         fputs("\n", pFile);
 
-        fclose(pFile);    
-    } 
+        fclose(pFile);
+    }
     else {
         LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "Failed to open data file: " + logpath);
     }
@@ -107,19 +107,19 @@ void ClassLogFile::setLogLevel(esp_log_level_t _logLevel)
     std::string levelText;
 
     // Print log level to log file
-    switch(_logLevel) {            
+    switch(_logLevel) {
         case ESP_LOG_WARN:
             levelText = "WARNING";
             break;
-            
+
         case ESP_LOG_INFO:
             levelText = "INFO";
             break;
-            
+
         case ESP_LOG_DEBUG:
             levelText = "DEBUG";
             break;
-    
+
         case ESP_LOG_ERROR:
         default:
             levelText = "ERROR";
@@ -200,7 +200,7 @@ void ClassLogFile::WriteToFile(esp_log_level_t level, std::string tag, std::stri
         ntpTime = ConvertTimeToString(rawtime, "%Y-%m-%dT%H:%M:%S");
     }
 
-    std::string loglevelString; 
+    std::string loglevelString;
     switch(level) {
         case  ESP_LOG_ERROR:
             loglevelString = "ERR";
@@ -230,7 +230,7 @@ void ClassLogFile::WriteToFile(esp_log_level_t level, std::string tag, std::stri
         if (fileNameDateNew != fileNameDate) { // Filename changed
             // Make sure each day gets its own logfile
             // Also we need to re-open it in case it needed to get closed for reading
-            std::string logpath = logFileRootFolder + "/" + fileNameDateNew; 
+            std::string logpath = logFileRootFolder + "/" + fileNameDateNew;
 
             ESP_LOGI(TAG, "Opening logfile %s for appending", logpath.c_str());
             logFileAppendHandle = fopen(logpath.c_str(), "a");
@@ -242,7 +242,7 @@ void ClassLogFile::WriteToFile(esp_log_level_t level, std::string tag, std::stri
             fileNameDate = fileNameDateNew;
         }
     #else
-        std::string logpath = logFileRootFolder + "/" + fileNameDateNew; 
+        std::string logpath = logFileRootFolder + "/" + fileNameDateNew;
         logFileAppendHandle = fopen(logpath.c_str(), "a");
         if (logFileAppendHandle == NULL) {
             ESP_LOGE(TAG, "WriteToFile: Failed to open logfile %s", logpath.c_str());
@@ -255,7 +255,7 @@ void ClassLogFile::WriteToFile(esp_log_level_t level, std::string tag, std::stri
     setvbuf(logFileAppendHandle, NULL, _IOFBF, 512);
 
     fputs(fullmessage.c_str(), logFileAppendHandle);
-    
+
     #ifdef KEEP_LOGFILE_OPEN_FOR_APPENDING
         fflush(logFileAppendHandle);
         fsync(fileno(logFileAppendHandle));
@@ -297,7 +297,7 @@ std::string ClassLogFile::GetCurrentFileName()
     time_t rawtime;
 
     time(&rawtime);
-    std::string logpath = logFileRootFolder + "/" + ConvertTimeToString(rawtime, logfile.c_str()); 
+    std::string logpath = logFileRootFolder + "/" + ConvertTimeToString(rawtime, logfile.c_str());
 
     return logpath;
 }
@@ -338,16 +338,16 @@ void ClassLogFile::RemoveOldLogFile()
                     LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "Time was not set at boot, keep log file \'log_1970-01-01.txt\'");
                     notDeleted++;
                 }
-                else {          
+                else {
                     if (unlink(filepath.c_str()) == 0) {
                         deleted++;
-                    } 
+                    }
                     else {
                         LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "Failed to delete file " + filepath);
                         notDeleted++;
                     }
                 }
-            } 
+            }
             else {
                 notDeleted++;
             }
@@ -390,7 +390,7 @@ void ClassLogFile::RemoveOldDataLog()
             //ESP_LOGI(TAG, "Compare data file: %s to %s", entry->d_name, cmpfilename.c_str());
             if ((strlen(entry->d_name) == cmpfilename.length()) && (strcmp(entry->d_name, cmpfilename.c_str()) < 0)) {
                 //ESP_LOGI(TAG, "delete data file: %s", entry->d_name);
-                std::string filepath = dataFileRootFolder + "/" + entry->d_name; 
+                std::string filepath = dataFileRootFolder + "/" + entry->d_name;
                 if (unlink(filepath.c_str()) == 0) {
                     deleted ++;
                 }
@@ -416,7 +416,7 @@ void ClassLogFile::RemoveOldDebugFiles()
     if (debugFilesRetentionInDays == 0) {
         return;
     }
-    
+
     LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "Delete debug folder older than retention setting");
 
     DIR *dir = opendir(debugFileRootFolder.c_str());
@@ -440,11 +440,11 @@ void ClassLogFile::RemoveOldDebugFiles()
         if (entry->d_type == DT_DIR) {
             //ESP_LOGI(TAG, "Compare folder %s to %s", entry->d_name, cmpfolderame.c_str());
             if ((strlen(entry->d_name) == cmpfolderame.length()) && (strcmp(entry->d_name, cmpfolderame.c_str()) < 0)) {
-                std::string folderpath = debugFileRootFolder + "/" + entry->d_name; 
+                std::string folderpath = debugFileRootFolder + "/" + entry->d_name;
                 //ESP_LOGI(TAG, "Delete folder %s", folderpath.c_str());
                 if (removeFolder(folderpath.c_str(), TAG) > 0) {
                     deleted++;
-                } 
+                }
                 else {
                     LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "Failed to delete folder " + folderpath);
                     notDeleted ++;

--- a/code/components/jomjol_logfile/ClassLogFile.h
+++ b/code/components/jomjol_logfile/ClassLogFile.h
@@ -45,8 +45,8 @@ class ClassLogFile
         void RemoveOldDataLog();
         void RemoveOldDebugFiles();
 
-        void WriteToData(std::string _timestamp, std::string _name, std::string  _sRawValue, std::string  _sValue, 
-                        std::string  _sFallbackValue, std::string  _sRatePerMin, std::string  _sRatePerInterval, 
+        void WriteToData(std::string _timestamp, std::string _name, std::string  _sRawValue, std::string  _sValue,
+                        std::string  _sFallbackValue, std::string  _sRatePerMin, std::string  _sRatePerInterval,
                         std::string  _sValueStatus, std::string  _digital, std::string  _analog);
 
 

--- a/code/components/jomjol_mqtt/interface_mqtt.cpp
+++ b/code/components/jomjol_mqtt/interface_mqtt.cpp
@@ -23,7 +23,7 @@ static const char *TAG = "MQTT_IF";
 strMqttConfig mqttConfig = {}; // Global struct for MQTT config
 extern const strHADiscoveryConfig HADiscoveryConfig;
 
-static std::map<std::string, std::function<void()>>* connectFunktionMap = NULL;  
+static std::map<std::string, std::function<void()>>* connectFunktionMap = NULL;
 static std::map<std::string, std::function<bool(std::string, char*, int)>>* subscribeFunktionMap = NULL;
 
 static strMqttState mqttState = {};
@@ -35,9 +35,9 @@ static std::string LWTTopic;
 static std::string TLSCACert, TLSClientCert, TLSClientKey;
 
 
-bool MQTTPublish(std::string _key, std::string _content, int _qos, bool _retainFlag) 
+bool MQTTPublish(std::string _key, std::string _content, int _qos, bool _retainFlag)
 {
-    if (!mqttState.mqttEnabled) { // MQTT sevice not started / configured (MQTT_Init not called before)      
+    if (!mqttState.mqttEnabled) { // MQTT sevice not started / configured (MQTT_Init not called before)
         return false;
     }
 
@@ -48,20 +48,20 @@ bool MQTTPublish(std::string _key, std::string _content, int _qos, bool _retainF
     MQTT_Init(); // Re-Init client if not initialized yet/anymore
 
     if (mqttState.mqttInitialized && mqttState.mqttConnected) {
-        #ifdef DEBUG_DETAIL_ON 
+        #ifdef DEBUG_DETAIL_ON
             long long int starttime = esp_timer_get_time();
         #endif
         int msg_id = esp_mqtt_client_publish(mqttClient, _key.c_str(), _content.c_str(), 0, _qos, _retainFlag);
-        #ifdef DEBUG_DETAIL_ON 
+        #ifdef DEBUG_DETAIL_ON
             ESP_LOGI(TAG, "Publish msg_id %d in %lld ms", msg_id, (esp_timer_get_time() - starttime)/1000);
         #endif
         if (msg_id == -1) {
-            LogFile.WriteToFile(ESP_LOG_WARN, TAG, "Failed to publish topic '" + _key + "', retry");   
-            #ifdef DEBUG_DETAIL_ON 
+            LogFile.WriteToFile(ESP_LOG_WARN, TAG, "Failed to publish topic '" + _key + "', retry");
+            #ifdef DEBUG_DETAIL_ON
                 starttime = esp_timer_get_time();
             #endif
             msg_id = esp_mqtt_client_publish(mqttClient, _key.c_str(), _content.c_str(), 0, _qos, _retainFlag);
-            #ifdef DEBUG_DETAIL_ON 
+            #ifdef DEBUG_DETAIL_ON
                 ESP_LOGI(TAG, "Publish msg_id %d in %lld ms", msg_id, (esp_timer_get_time() - starttime)/1000);
             #endif
             if (msg_id == -1) {
@@ -93,14 +93,14 @@ static esp_err_t mqtt_event_handler_cb(esp_mqtt_event_handle_t event)
         case MQTT_EVENT_BEFORE_CONNECT:
             mqttState.mqttInitialized = true;
             break;
-        
+
         case MQTT_EVENT_CONNECTED:
             mqttState.mqttReconnectCnt = 0;
             mqttState.mqttInitialized = true;
             mqttState.mqttConnected = true;
             MQTTconnected();
             break;
-        
+
         case MQTT_EVENT_DISCONNECTED:
             mqttState.mqttConnected = false;
             mqttState.mqttReconnectCnt++;
@@ -111,22 +111,22 @@ static esp_err_t mqtt_event_handler_cb(esp_mqtt_event_handle_t event)
                 LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "Disconnected, multiple reconnect attempts failed. Retry");
             }
             break;
-        
+
         case MQTT_EVENT_SUBSCRIBED:
             ESP_LOGD(TAG, "MQTT_EVENT_SUBSCRIBED, msg_id=%d", event->msg_id);
             break;
-        
+
         case MQTT_EVENT_UNSUBSCRIBED:
             ESP_LOGD(TAG, "MQTT_EVENT_UNSUBSCRIBED, msg_id=%d", event->msg_id);
             break;
-        
+
         case MQTT_EVENT_PUBLISHED:
             ESP_LOGD(TAG, "MQTT_EVENT_PUBLISHED, msg_id=%d", event->msg_id);
             break;
-        
+
         case MQTT_EVENT_DATA:
             ESP_LOGD(TAG, "MQTT_EVENT_DATA");
-            #ifdef DEBUG_DETAIL_ON   
+            #ifdef DEBUG_DETAIL_ON
                 ESP_LOGI(TAG, "TOPIC=%.*s", event->topic_len, event->topic);
                 ESP_LOGI(TAG, "DATA=%.*s", event->data_len, event->data);
             #endif
@@ -141,14 +141,14 @@ static esp_err_t mqtt_event_handler_cb(esp_mqtt_event_handle_t event)
                 }
             }
             break;
-        
+
         case MQTT_EVENT_ERROR:
-            // http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html#_Toc398718033 --> chapter 3.2.2.3 
+            // http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html#_Toc398718033 --> chapter 3.2.2.3
 
             // The server does not support the level of the MQTT protocol requested by the client
             // NOTE: Only protocol 3.1.1 is supported (refer to setting in sdkconfig)
             if (event->error_handle->connect_return_code == MQTT_CONNECTION_REFUSE_PROTOCOL) {
-                LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "Connection refused, unacceptable protocol version (0x01)");  
+                LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "Connection refused, unacceptable protocol version (0x01)");
             }
             // The client identifier is correct UTF-8 but not allowed by the server
             // e.g. clientID empty (cannot be the case -> default set in firmware)
@@ -167,15 +167,15 @@ static esp_err_t mqtt_event_handler_cb(esp_mqtt_event_handle_t event)
             else if (event->error_handle->connect_return_code == MQTT_CONNECTION_REFUSE_NOT_AUTHORIZED) {
                 LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "Connection refused, not authorized. Check username/password (0x05)");
             }
-            
+
             // Log any ESP-TLS error: https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/error-codes.html
             if (mqttConfig.TLSEncryption && (event->error_handle->esp_tls_last_esp_err != ESP_OK)) {
-                LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "Connection refused, TLS error code: " + 
-                        intToHexString(event->error_handle->esp_tls_last_esp_err) + 
+                LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "Connection refused, TLS error code: " +
+                        intToHexString(event->error_handle->esp_tls_last_esp_err) +
                         " (More infos: https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/error-codes.html");
             }
 
-            #ifdef DEBUG_DETAIL_ON 
+            #ifdef DEBUG_DETAIL_ON
                 ESP_LOGI(TAG, "MQTT_EVENT_ERROR - esp_mqtt_error_codes:");
                 ESP_LOGI(TAG, "error_type:%d", event->error_handle->error_type);
                 ESP_LOGI(TAG, "connect_return_code:%d", event->error_handle->connect_return_code);
@@ -186,7 +186,7 @@ static esp_err_t mqtt_event_handler_cb(esp_mqtt_event_handle_t event)
             #endif
 
             break;
-        
+
         default:
             ESP_LOGD(TAG, "Other event id: %d", event->event_id);
             break;
@@ -211,11 +211,11 @@ bool MQTT_Configure()
 
     LWTTopic = mqttConfig.mainTopic + MQTT_STATUS_TOPIC;
 
-    LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "URI: " + mqttConfig.uri + ", clientID: " + mqttConfig.clientID + 
-                        ", user: " + mqttConfig.user + ", password: *****, mainTopic: " + mqttConfig.mainTopic + 
-                        ", last-will-topic: " + LWTTopic + ", keepAlive: " + std::to_string(mqttConfig.keepAlive) + 
-                        ", RetainProcessData: " + std::to_string(mqttConfig.retainProcessData) + 
-                        ", TLSEncryption: " + std::to_string(mqttConfig.TLSEncryption)); 
+    LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "URI: " + mqttConfig.uri + ", clientID: " + mqttConfig.clientID +
+                        ", user: " + mqttConfig.user + ", password: *****, mainTopic: " + mqttConfig.mainTopic +
+                        ", last-will-topic: " + LWTTopic + ", keepAlive: " + std::to_string(mqttConfig.keepAlive) +
+                        ", RetainProcessData: " + std::to_string(mqttConfig.retainProcessData) +
+                        ", TLSEncryption: " + std::to_string(mqttConfig.TLSEncryption));
 
     if (mqttConfig.TLSEncryption) {
         if (mqttConfig.uri.substr(0,8) != "mqtts://") {
@@ -265,7 +265,7 @@ bool MQTT_Configure()
             LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "URI parameter needs to be configured with \'mqtt://\'");
             return false;
         }
-        
+
         if (mqttConfig.uri.substr(mqttConfig.uri.find_last_of(":")+1, 4) != "1883") {
             LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "URI parameter not using default MQTT port \'1883\'");
         }
@@ -277,12 +277,12 @@ bool MQTT_Configure()
 
 
 int MQTT_Init()
-{ 
+{
     if (mqttState.mqttInitialized) {
         return 0;
     }
 
-    if (mqttState.mqttConfigOK) {                           
+    if (mqttState.mqttConfigOK) {
         mqttState.mqttEnabled = true;
     } else {
         LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "Init called, but client is not yet configured.");
@@ -323,7 +323,7 @@ int MQTT_Init()
     if (mqttConfig.TLSEncryption) {
         if (!TLSCACert.empty()) {
             mqtt_cfg.broker.verification.certificate = TLSCACert.c_str();
-            mqtt_cfg.broker.verification.certificate_len = TLSCACert.length() + 1;  
+            mqtt_cfg.broker.verification.certificate_len = TLSCACert.length() + 1;
             mqtt_cfg.broker.verification.skip_cert_common_name_check = true;    // Skip any validation of server certificate CN field
         }
 
@@ -332,7 +332,7 @@ int MQTT_Init()
             mqtt_cfg.credentials.authentication.certificate_len = TLSClientCert.length() + 1;
         }
 
-        if (!TLSClientKey.empty()) {       
+        if (!TLSClientKey.empty()) {
             mqtt_cfg.credentials.authentication.key = TLSClientKey.c_str();
             mqtt_cfg.credentials.authentication.key_len = TLSClientKey.length() + 1;
         }
@@ -372,7 +372,7 @@ void MQTTdestroy_client(bool _disable = false)
 {
     if (mqttClient) {
         if (mqttState.mqttConnected) {
-            MQTTdestroySubscribeFunction();      
+            MQTTdestroySubscribeFunction();
             esp_mqtt_client_disconnect(mqttClient);
             mqttState.mqttConnected = false;
         }
@@ -406,7 +406,7 @@ bool getMQTTisEncrypted()
 }
 
 
-bool mqtt_handler_flow_start(std::string _topic, char* _data, int _data_len) 
+bool mqtt_handler_flow_start(std::string _topic, char* _data, int _data_len)
 {
     //ESP_LOGD(TAG, "Handler called: topic %s, data %.*s", _topic.c_str(), _data_len, _data);
 
@@ -421,7 +421,7 @@ bool mqtt_handler_flow_start(std::string _topic, char* _data, int _data_len)
 }
 
 
-bool mqtt_handler_set_fallbackvalue(std::string _topic, char* _data, int _data_len) 
+bool mqtt_handler_set_fallbackvalue(std::string _topic, char* _data, int _data_len)
 {
     //ESP_LOGD(TAG, "Handler called: topic %s, data %.*s", _topic.c_str(), _data_len, _data);
     //example: {"sequence": "main", "value": 12345.1234567}
@@ -433,7 +433,7 @@ bool mqtt_handler_set_fallbackvalue(std::string _topic, char* _data, int _data_l
 
         if (cJSON_IsString(sequenceName) && (sequenceName->valuestring != NULL)) {    // Check if sequenceName is valid
             if (cJSON_IsNumber(value)) {   // Check if value is a number
-                LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "handler_set_fallbackvalue called: sequence: " + std::string(sequenceName->valuestring) + 
+                LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "handler_set_fallbackvalue called: sequence: " + std::string(sequenceName->valuestring) +
                                                                                          ", value: " + std::to_string(value->valuedouble));
                 if (flowctrl.UpdateFallbackValue(std::to_string(value->valuedouble), std::string(sequenceName->valuestring))) {
                     cJSON_Delete(jsonData);
@@ -474,21 +474,21 @@ void MQTTconnected()
         // Note: Further subsriptions are handled in GPIO class
         //*****************************************
         // Subcribe to [mainTopic]/process/ctrl/flow_start
-        std::function<bool(std::string topic, char* data, int data_len)> subHandler1 = mqtt_handler_flow_start;     
+        std::function<bool(std::string topic, char* data, int data_len)> subHandler1 = mqtt_handler_flow_start;
         MQTTregisterSubscribeFunction(mqttConfig.mainTopic + "/process/ctrl/cycle_start", subHandler1);
 
         // Subcribe to [mainTopic]/process/ctrl/set_fallbackvalue
-        std::function<bool(std::string topic, char* data, int data_len)> subHandler2 = mqtt_handler_set_fallbackvalue;     
+        std::function<bool(std::string topic, char* data, int data_len)> subHandler2 = mqtt_handler_set_fallbackvalue;
         MQTTregisterSubscribeFunction(mqttConfig.mainTopic + "/process/ctrl/set_fallbackvalue", subHandler2);
-        
+
         // Subcribe to /homeassistant/status
         if (HADiscoveryConfig.HADiscoveryEnabled) {
-            std::function<bool(std::string topic, char* data, int data_len)> subHandler3 = mqttServer_schedulePublishHADiscoveryFromMqtt;     
+            std::function<bool(std::string topic, char* data, int data_len)> subHandler3 = mqttServer_schedulePublishHADiscoveryFromMqtt;
             MQTTregisterSubscribeFunction(HADiscoveryConfig.HAStatusTopic, subHandler3);
         }
 
        if (subscribeFunktionMap != NULL) {
-            for(std::map<std::string, std::function<bool(std::string, char*, int)>>::iterator it = subscribeFunktionMap->begin(); 
+            for(std::map<std::string, std::function<bool(std::string, char*, int)>>::iterator it = subscribeFunktionMap->begin();
                                                                                         it != subscribeFunktionMap->end(); ++it)
             {
                 int retVal = esp_mqtt_client_subscribe(mqttClient, it->first.c_str(), 0);
@@ -551,7 +551,7 @@ void MQTTdestroySubscribeFunction()
 {
     if (subscribeFunktionMap != NULL) {
         if (mqttState.mqttConnected) {
-            for(std::map<std::string, std::function<bool(std::string, char*, int)>>::iterator it = subscribeFunktionMap->begin(); 
+            for(std::map<std::string, std::function<bool(std::string, char*, int)>>::iterator it = subscribeFunktionMap->begin();
                                                                                         it != subscribeFunktionMap->end(); ++it)
             {
                 int retVal = esp_mqtt_client_unsubscribe(mqttClient, it->first.c_str());

--- a/code/components/jomjol_mqtt/server_mqtt.cpp
+++ b/code/components/jomjol_mqtt/server_mqtt.cpp
@@ -44,12 +44,12 @@ bool mqttServer_publishDeviceInfo(int _qos)
 {
     if (!publishDeviceInfoScheduled)
         return true;
-    
+
     if (!getMQTTisConnected()) {
         LogFile.WriteToFile(ESP_LOG_WARN, TAG, "Skip publish device info, not (yet) connected to broker");
         return false;
     }
-    
+
     LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "Publish device info");
 
     const std::string deviceInfoTopic = "/device/info/";
@@ -103,7 +103,7 @@ bool mqttServer_publishDeviceInfo(int _qos)
 
     char *jsonString = cJSON_PrintBuffered(cJSONObject, 384, 1); // Print to predefined buffer, avoid dynamic allocations
     std::string jsonData = std::string(jsonString);
-    cJSON_free(jsonString);  
+    cJSON_free(jsonString);
     cJSON_Delete(cJSONObject);
     retVal &= MQTTPublish(mqttConfig.mainTopic + deviceInfoTopic + "hardware", jsonData, _qos, true);
 
@@ -119,10 +119,10 @@ bool mqttServer_publishDeviceInfo(int _qos)
         retVal = false;
     if (cJSON_AddStringToObject(cJSONObject, "mac_address", getMac().c_str()) == NULL)
         retVal = false;
-  
+
     jsonString = cJSON_PrintBuffered(cJSONObject, 256, 1); // Print to predefined buffer, avoid dynamic allocations
     jsonData = std::string(jsonString);
-    cJSON_free(jsonString);  
+    cJSON_free(jsonString);
     cJSON_Delete(cJSONObject);
     retVal &= MQTTPublish(mqttConfig.mainTopic + deviceInfoTopic + "network", jsonData, _qos, true);
 
@@ -150,7 +150,7 @@ bool mqttServer_publishDeviceStatus(int _qos)
         LogFile.WriteToFile(ESP_LOG_WARN, TAG, "Skip publish device status, not (yet) connected to broker");
         return false;
     }
-    
+
     LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "Publish device status");
 
     const std::string deviceStatusTopic = "/device/status/";
@@ -180,15 +180,15 @@ bool mqttServer_publishDeviceStatus(int _qos)
         retVal = false;
     if (cJSON_AddNumberToObject(cJSONObject, "heap_spiram_min_free", getESPHeapSizeSPIRAMMinFree()) == NULL)
         retVal = false;
-    
+
     char *jsonString = cJSON_PrintBuffered(cJSONObject, 256, 1); // Print to predefined buffer, avoid dynamic allocations
     std::string jsonData = std::string(jsonString);
-    cJSON_free(jsonString);  
+    cJSON_free(jsonString);
     cJSON_Delete(cJSONObject);
 
     retVal &= MQTTPublish(mqttConfig.mainTopic + deviceStatusTopic + "heap", jsonData, _qos, false);
     retVal &= MQTTPublish(mqttConfig.mainTopic + deviceStatusTopic + "sd_partition_free", std::to_string(getSDCardFreePartitionSpace()), _qos, false);
-    retVal &= MQTTPublish(mqttConfig.mainTopic + deviceStatusTopic + "ntp_syncstatus", getNTPSyncStatus().c_str(), _qos, false); 
+    retVal &= MQTTPublish(mqttConfig.mainTopic + deviceStatusTopic + "ntp_syncstatus", getNTPSyncStatus().c_str(), _qos, false);
 
     if (!retVal) {
         LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "Failed to publish device status");
@@ -240,7 +240,7 @@ void mqttServer_schedulePublishHADiscovery()
 
 
 bool mqttServer_schedulePublishHADiscoveryFromMqtt(std::string _topic, char* _data, int _data_len)
-{ 
+{
     if (_data_len > 0) {    // Check if data length > 0
         if (strncmp("online", _data, _data_len) == 0) {
             publishHADiscoveryScheduled = true;
@@ -259,7 +259,7 @@ esp_err_t handler_mqtt(httpd_req_t *req)
     std::string task;
 
     // Default usage message when handler gets called without any parameter
-    const std::string RESTUsageInfo = 
+    const std::string RESTUsageInfo =
         "Handler usage:<br>"
         "1. Schedule publication of Home Assistant discovery MQTT topics:<br>"
         " - '/mqtt?task=publish_ha_discovery'<br>"
@@ -284,16 +284,16 @@ esp_err_t handler_mqtt(httpd_req_t *req)
 
     if (task.compare("api_name") == 0) {
         httpd_resp_sendstr(req, APIName);
-        return ESP_OK;        
+        return ESP_OK;
     }
     else if (task.compare("publish_ha_discovery") == 0) {
         publishHADiscoveryScheduled = true;
-        httpd_resp_sendstr(req, "001: Publication of HA discovery topics scheduled during state 'Publish to MQTT'");  
+        httpd_resp_sendstr(req, "001: Publication of HA discovery topics scheduled during state 'Publish to MQTT'");
         return ESP_OK;
     }
     else if (task.compare("publish_device_info") == 0) {
         publishDeviceInfoScheduled = true;
-        httpd_resp_sendstr(req, "002: Publication of device info topics scheduled during state 'Publish to MQTT'");  
+        httpd_resp_sendstr(req, "002: Publication of device info topics scheduled during state 'Publish to MQTT'");
         return ESP_OK;
     }
     else {
@@ -305,18 +305,18 @@ esp_err_t handler_mqtt(httpd_req_t *req)
 
 // Publish HA discovery topics (no retained)
 bool mqttServer_publishHADiscovery(int _qos)
-{  
+{
     if (!HADiscoveryConfig.HADiscoveryEnabled || !publishHADiscoveryScheduled) // Continue if enabled and scheduled
         return true;
-    
+
     if (!getMQTTisConnected()) {
         LogFile.WriteToFile(ESP_LOG_WARN, TAG, "Skip publish HA discovery, not (yet) connected to broker");
         return false;
     }
 
-    LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "Publish HA discovery | Sensor device class: " + meterType + 
+    LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "Publish HA discovery | Sensor device class: " + meterType +
                                     ", Value unit: " + valueUnit + " , Rate unit: " + rateUnit);
-    
+
     publishHADiscoveryTopicDeviceInfo = true; // Publish full common device info data only once
     bool publishOK = true;
 
@@ -403,7 +403,7 @@ bool mqttServer_publishHADiscovery(int _qos)
         .entityCategory = "diagnostic"
     };
     publishOK &= publishHADiscoveryTopic(&HADiscoveryData, _qos);
-    
+
     HADiscoveryData = {};
     HADiscoveryData = {
         .topic = "/device/status/chip_temp",
@@ -661,7 +661,7 @@ static bool publishHADiscoveryTopic(const strHADiscoveryData *_data, const int _
     // Signal a problem only if multiple process errors (-2) or process deviation (2) in row occured
     else if (_data->deviceClass == "problem" && _data->topicName == "process_error") // Special binary sensor
         payload += "\"val_tpl\":\"{{ 'ON' if '-2' in value or '2' in value else 'OFF'}}\",";
-    
+
     payload += "\"qos\":\"1\",";
 
     if (!_data->unit.empty())
@@ -676,7 +676,7 @@ static bool publishHADiscoveryTopic(const strHADiscoveryData *_data, const int _
     if (!_data->entityCategory.empty())
         payload += "\"ent_cat\":\"" + _data->entityCategory + "\",";
 
-    payload += 
+    payload +=
         "\"avty_t\":\"~" + std::string(MQTT_STATUS_TOPIC) + "\""; // Use default values for available: "online" / not available: "offline"
 
     // Publish complete general device info only once
@@ -697,7 +697,7 @@ static bool publishHADiscoveryTopic(const strHADiscoveryData *_data, const int _
         payload += std::string(", \"dev\": {")  +
             "\"ids\":[\"" + nodeID + "\"]}";
     }
-    
+
     payload += "}";
 
     if (MQTTPublish(configurationTopic, payload, _qos, HADiscoveryConfig.HARetainDiscoveryTopics)) {
@@ -711,13 +711,13 @@ static bool publishHADiscoveryTopic(const strHADiscoveryData *_data, const int _
 void register_server_mqtt_uri(httpd_handle_t server)
 {
     ESP_LOGI(TAG, "Registering URI handlers");
-    
+
     httpd_uri_t uri = { };
     uri.method    = HTTP_GET;
     uri.uri       = "/mqtt";
     uri.handler   = handler_mqtt;
-    uri.user_ctx  = NULL;    
-    httpd_register_uri_handler(server, &uri); 
+    uri.user_ctx  = NULL;
+    httpd_register_uri_handler(server, &uri);
 }
 
 #endif //ENABLE_MQTT

--- a/code/components/jomjol_mqtt/server_mqtt.h
+++ b/code/components/jomjol_mqtt/server_mqtt.h
@@ -35,7 +35,7 @@ bool mqttServer_publishDeviceInfo(int _qos);
 bool mqttServer_publishDeviceStatus(int _qos);
 
 void mqttServer_setParameter(std::vector<NumberPost*>* _NUMBERS, float _processingInterval);
-void mqttServer_setMeterType(std::string _meterType, std::string _valueUnit, 
+void mqttServer_setMeterType(std::string _meterType, std::string _valueUnit,
                              std::string _timeUnit, std::string _rateUnit);
 std::string mqttServer_getMainTopic();
 std::string mqttServer_getTimeUnit();

--- a/code/components/jomjol_tfliteclass/CTfLiteClass.cpp
+++ b/code/components/jomjol_tfliteclass/CTfLiteClass.cpp
@@ -19,7 +19,7 @@ float CTfLiteClass::GetOutputValue(int nr)
         LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "GetOutputValue failed");
         return -1000;
     }
-        
+
     int numeroutput = output2->dims->data[1];
     if ((nr+1) > numeroutput)
         return -1000;
@@ -161,7 +161,7 @@ void CTfLiteClass::Invoke()
 
 bool CTfLiteClass::LoadInputImageBasis(CImageBasis *rs)
 {
-    #ifdef DEBUG_DETAIL_ON 
+    #ifdef DEBUG_DETAIL_ON
         LogFile.WriteHeapInfo("LoadInputImageBasis - Start");
     #endif
 
@@ -197,7 +197,7 @@ bool CTfLiteClass::LoadInputImageBasis(CImageBasis *rs)
                 input_data_ptr++;
             }
 
-    #ifdef DEBUG_DETAIL_ON 
+    #ifdef DEBUG_DETAIL_ON
         LogFile.WriteHeapInfo("LoadInputImageBasis - done");
     #endif
 
@@ -254,7 +254,7 @@ bool CTfLiteClass::MakeAllocate()
 
 void CTfLiteClass::GetInputTensorSize()
 {
-#ifdef DEBUG_DETAIL_ON    
+#ifdef DEBUG_DETAIL_ON
     float *zw = input;
     int test = sizeof(zw);
     ESP_LOGD(TAG, "Input Tensor Dimension: %d", test);
@@ -265,8 +265,8 @@ void CTfLiteClass::GetInputTensorSize()
 bool CTfLiteClass::ReadFileToModel(std::string _fn)
 {
     LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "Read TFLITE model file: " + _fn);
-    
-    #ifdef DEBUG_DETAIL_ON      
+
+    #ifdef DEBUG_DETAIL_ON
             LogFile.WriteHeapInfo("ReadFileToModel: start");
     #endif
 
@@ -277,7 +277,7 @@ bool CTfLiteClass::ReadFileToModel(std::string _fn)
     }
 
     modelfile = (unsigned char*)malloc_psram_heap(std::string(TAG) + "->modelfile", size, MALLOC_CAP_SPIRAM);
-  
+
 	  if(modelfile == NULL) {
         LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "ReadFileToModel: Can't allocate enough memory: " + std::to_string(size));
         LogFile.WriteHeapInfo("ReadFileToModel: Allocation failed");
@@ -296,9 +296,9 @@ bool CTfLiteClass::ReadFileToModel(std::string _fn)
         fclose(f);
         return false;
     }
-    fclose(f);     
+    fclose(f);
 
-    #ifdef DEBUG_DETAIL_ON 
+    #ifdef DEBUG_DETAIL_ON
         LogFile.WriteHeapInfo("ReadFileToModel: done");
     #endif
 
@@ -309,7 +309,7 @@ bool CTfLiteClass::ReadFileToModel(std::string _fn)
 bool CTfLiteClass::LoadModel(std::string _fn)
 {
     LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "Loading TFLITE model");
-    
+
     if (!ReadFileToModel(_fn)) {
       LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "LoadModel: TFLITE model file reading failed");
       return false;
@@ -349,8 +349,8 @@ CTfLiteClass::CTfLiteClass()
 
 void CTfLiteClass::CTfLiteClassDeleteInterpreter()
 {
-    if (tensor_arena != nullptr) {  
-        LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "TFLITE arena - Used bytes: " + std::to_string(interpreter->arena_used_bytes())); 
+    if (tensor_arena != nullptr) {
+        LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "TFLITE arena - Used bytes: " + std::to_string(interpreter->arena_used_bytes()));
         free_psram_heap(std::string(TAG) + "->tensor_arena", tensor_arena);
         tensor_arena = nullptr;
     }
@@ -364,13 +364,13 @@ void CTfLiteClass::CTfLiteClassDeleteInterpreter()
 
 CTfLiteClass::~CTfLiteClass()
 {
-    if (tensor_arena != nullptr) {  
+    if (tensor_arena != nullptr) {
         free_psram_heap(std::string(TAG) + "->tensor_arena", tensor_arena);
     }
 
     if (interpreter != nullptr) {
         delete interpreter;
     }
-    
+
     free_psram_heap(std::string(TAG) + "->modelfile", modelfile);
-}        
+}

--- a/code/components/jomjol_tfliteclass/CTfLiteClass.h
+++ b/code/components/jomjol_tfliteclass/CTfLiteClass.h
@@ -13,7 +13,7 @@ class CTfLiteClass
         tflite::MicroMutableOpResolver<10> microOpResolver;
         const tflite::Model* model;
         tflite::MicroInterpreter* interpreter;
-        TfLiteTensor* output = nullptr;            
+        TfLiteTensor* output = nullptr;
         int kTensorArenaSize;
         uint8_t *tensor_arena;
         unsigned char *modelfile = NULL;
@@ -28,13 +28,13 @@ class CTfLiteClass
     public:
         CTfLiteClass();
         ~CTfLiteClass();
-        void CTfLiteClassDeleteInterpreter();   
+        void CTfLiteClassDeleteInterpreter();
         bool LoadModel(std::string _fn);
         bool MakeAllocate();
         void GetInputTensorSize();
         bool LoadInputImageBasis(CImageBasis *rs);
         void Invoke();
-        int GetAnzOutPut(bool silent = true);        
+        int GetAnzOutPut(bool silent = true);
         int GetOutClassification(int _von = -1, int _bis = -1);
 
         int GetClassFromImageBasis(CImageBasis *rs);

--- a/code/components/jomjol_time_sntp/time_sntp.cpp
+++ b/code/components/jomjol_time_sntp/time_sntp.cpp
@@ -73,7 +73,7 @@ bool waitingForTimeSync(void)
     const int retry_count = 10;
 
     while (sntp_get_sync_status() == SNTP_SYNC_STATUS_RESET && ++retry <= retry_count) {
-        LogFile.WriteToFile(ESP_LOG_INFO, TAG, "Waiting for time sync - " + std::to_string(retry) + 
+        LogFile.WriteToFile(ESP_LOG_INFO, TAG, "Waiting for time sync - " + std::to_string(retry) +
                                                "/" + std::to_string(retry_count));
         vTaskDelay(2000 / portTICK_PERIOD_MS);
     }
@@ -88,7 +88,7 @@ bool waitingForTimeSync(void)
 void setTimeZone(std::string _tzstring)
 {
     setenv("TZ", _tzstring.c_str(), 1);
-    tzset();    
+    tzset();
     _tzstring = "Time zone set to " + _tzstring;
     LogFile.WriteToFile(ESP_LOG_INFO, TAG, _tzstring);
 }
@@ -163,12 +163,12 @@ std::string getServerName(void)
 
 /**
  * Load the Time zone and Time server from the config file and initialize the NTP client
- * The RTC keeps the time after a restart (Except on Power On or Pin Reset) 
+ * The RTC keeps the time after a restart (Except on Power On or Pin Reset)
  * There should only be a minor correction through NTP
  */
 bool setupTime()
 {
-    ConfigFile configFile = ConfigFile(CONFIG_FILE); 
+    ConfigFile configFile = ConfigFile(CONFIG_FILE);
 
     if (!configFile.ConfigFileExists()) {
         LogFile.WriteToFile(ESP_LOG_WARN, TAG, "No config file, exit setupTime()");
@@ -181,7 +181,7 @@ bool setupTime()
     bool eof = false;
 
     /* Load config from config file */
-    while ((!configFile.GetNextParagraph(line, disabledLine, eof) || 
+    while ((!configFile.GetNextParagraph(line, disabledLine, eof) ||
             (line.compare("[System]") != 0)) && !eof) {}
     if (eof) {
         timeServer = "pool.ntp.org";
@@ -195,7 +195,7 @@ bool setupTime()
         return false;
     }
 
-    while (configFile.getNextLine(&line, disabledLine, eof) && 
+    while (configFile.getNextLine(&line, disabledLine, eof) &&
             !configFile.isNewParagraph(line))
     {
         splitted = ZerlegeZeile(line, "=");
@@ -232,9 +232,9 @@ bool setupTime()
 
     // Set time zone in any case, even no time source is selected.
     setTimeZone(timeZone);
-    
+
     if (useNtp) {
-        LogFile.WriteToFile(ESP_LOG_INFO, TAG, "Init NTP service");        
+        LogFile.WriteToFile(ESP_LOG_INFO, TAG, "Init NTP service");
         sntp_setoperatingmode(SNTP_OPMODE_POLL);
         sntp_setservername(0, timeServer.c_str());
         sntp_set_time_sync_notification_cb(timeSyncNotificationCallback);
@@ -273,7 +273,7 @@ void setupTimeZone(std::string _timeZone)
         return;
 
     LogFile.WriteToFile(ESP_LOG_WARN, TAG, "Time zone has been modified");
-    
+
     timeZone = _timeZone;
 
     if (_timeZone == "") {
@@ -307,7 +307,7 @@ void setupTimeServer(std::string _timeServer)
 
     timeServer = _timeServer;
 
-    if (useNtp) {    
+    if (useNtp) {
         sntp_setoperatingmode(SNTP_OPMODE_POLL);
         sntp_setservername(0, timeServer.c_str());
         sntp_set_time_sync_notification_cb(timeSyncNotificationCallback);

--- a/code/components/jomjol_wlan/connect_wlan.cpp
+++ b/code/components/jomjol_wlan/connect_wlan.cpp
@@ -159,7 +159,7 @@ static char * get_btm_neighbor_list(uint8_t *report, size_t report_len)
 
 			pos += s_len;
 		}
-				
+
 		ESP_LOGI(TAG, "Roaming: RMM neighbor report bssid=" MACSTR
 				" info=0x%x op_class=%u chan=%u phy_type=%u%s%s%s%s",
 				MAC2STR(nr), WPA_GET_LE32(nr + ETH_ALEN),
@@ -168,8 +168,8 @@ static char * get_btm_neighbor_list(uint8_t *report, size_t report_len)
 				lci[0] ? " lci=" : "", lci,
 				civic[0] ? " civic=" : "", civic);
 
-		
-		LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "Roaming: RMM neighbor report BSSID: " + BssidToString((char*)nr) + 
+
+		LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "Roaming: RMM neighbor report BSSID: " + BssidToString((char*)nr) +
 		                                        ", Channel: " + std::to_string(nr[ETH_ALEN + 5]));
 
 		/* neighbor start */
@@ -256,11 +256,11 @@ static void esp_bss_rssi_low_handler(void* arg, esp_event_base_t event_base, int
 	int retval = -1;
 	wifi_event_bss_rssi_low_t *event = (wifi_event_bss_rssi_low_t*) event_data;
 
-	LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "Roaming Event: RSSI " + std::to_string(event->rssi) + 
+	LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "Roaming Event: RSSI " + std::to_string(event->rssi) +
 								" < RSSI_Threshold " + std::to_string(wlan_config.rssi_threshold));
 
 	/* If RRM is supported, call RRM and then send BTM query to AP */
-	if (esp_rrm_is_rrm_supported_connection() && esp_wnm_is_btm_supported_connection()) 
+	if (esp_rrm_is_rrm_supported_connection() && esp_wnm_is_btm_supported_connection())
 	{
 		/* Lets check channel conditions */
 		rrm_ctx++;
@@ -274,7 +274,7 @@ static void esp_bss_rssi_low_handler(void* arg, esp_event_base_t event_base, int
 	}
 
 	/* If RRM is not supported or RRM request failed, send directly BTM query to AP */
-	if (retval < 0 && esp_wnm_is_btm_supported_connection()) 
+	if (retval < 0 && esp_wnm_is_btm_supported_connection())
 	{
 		// btm_query_reasons: https://github.com/espressif/esp-idf/blob/release/v4.4/components/wpa_supplicant/esp_supplicant/include/esp_wnm.h
 		retval = esp_wnm_send_bss_transition_mgmt_query(REASON_FRAME_LOSS, NULL, 0);	// query reason 16 -> LOW RSSI --> (btm_query_reason)16
@@ -287,7 +287,7 @@ static void esp_bss_rssi_low_handler(void* arg, esp_event_base_t event_base, int
 }
 
 
-void printRoamingFeatureSupport(void) 
+void printRoamingFeatureSupport(void)
 {
 	if (esp_rrm_is_rrm_supported_connection())
 		LogFile.WriteToFile(ESP_LOG_INFO, TAG, "Roaming: RRM (802.11k) supported by AP");
@@ -302,7 +302,7 @@ void printRoamingFeatureSupport(void)
 
 
 #ifdef WLAN_USE_MESH_ROAMING_ACTIVATE_CLIENT_TRIGGERED_QUERIES
-void wifiRoamingQuery(void) 
+void wifiRoamingQuery(void)
 {
 	/* Query only if WIFI is connected and feature is supported by AP */
 	if (WIFIConnected && (esp_rrm_is_rrm_supported_connection() || esp_wnm_is_btm_supported_connection())) {
@@ -310,7 +310,7 @@ void wifiRoamingQuery(void)
 		/* Note 1: Set RSSI threshold funtion needs to be called to trigger WIFI_EVENT_STA_BSS_RSSI_LOW */
 		/* Note 2: Additional querys will be sent after flow cycle is finshed --> server_tflite.cpp - function "task_autodoFlow" */
 		/* Note 3: RSSI_Threshold = 0 --> Disable client query by application (WebUI parameter) */
-		
+
 		if (wlan_config.rssi_threshold != 0 && get_WIFI_RSSI() != -127 && (get_WIFI_RSSI() < wlan_config.rssi_threshold))
 			esp_wifi_set_rssi_threshold(wlan_config.rssi_threshold);
 	}
@@ -337,7 +337,7 @@ void wifi_scan(void)
     wifi_scan_config.show_hidden = true;            // scan also hidden SSIDs
 	wifi_scan_config.channel = 0;                   // scan all channels
 
-    esp_wifi_scan_start(&wifi_scan_config, true);   // not using event handler SCAN_DONE by purpose to keep SYS_EVENT heap smaller 
+    esp_wifi_scan_start(&wifi_scan_config, true);   // not using event handler SCAN_DONE by purpose to keep SYS_EVENT heap smaller
                                                     // and the calling task task_autodoFlow is after scan is finish in wait state anyway
                                                     // Scan duration: ca. (120ms + 30ms) * Number of channels -> ca. 1,5 - 2s
 
@@ -365,9 +365,9 @@ void wifi_scan(void)
     for (int i = 0; i < max_number_of_ap_found; i++) {
         LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "Roaming: " + std::to_string(i+1) +
                                                 ": SSID=" + std::string((char*)wifi_ap_records[i].ssid) +
-                                                ", BSSID=" + BssidToString((char*)wifi_ap_records[i].bssid) + 
-                                                ", RSSI=" + std::to_string(wifi_ap_records[i].rssi) + 
-                                                ", CH=" + std::to_string(wifi_ap_records[i].primary) + 
+                                                ", BSSID=" + BssidToString((char*)wifi_ap_records[i].bssid) +
+                                                ", RSSI=" + std::to_string(wifi_ap_records[i].rssi) +
+                                                ", CH=" + std::to_string(wifi_ap_records[i].primary) +
                                                 ", AUTH=" + getAuthModeName(wifi_ap_records[i].authmode));
 		if (wifi_ap_records[i].rssi > (currentAP.rssi + 5) && // RSSI is better than actual RSSI + 5 --> Avoid switching to AP with roughly same RSSI
            (strcmp(BssidToString((char*)wifi_ap_records[i].bssid).c_str(), BssidToString((char*)currentAP.bssid).c_str()) != 0))
@@ -389,7 +389,7 @@ void wifiRoamByScanning(void)
 			APWithBetterRSSI = false;
 			LogFile.WriteToFile(ESP_LOG_WARN, TAG, "Roaming: AP with better RSSI in range, disconnect to switch AP");
 			esp_wifi_disconnect();
-		} 
+		}
 		else {
 			LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "Roaming: Scan completed, stay on current AP");
 		}
@@ -404,7 +404,7 @@ std::string getMac()
     char macFormated[6*2 + 5 + 1]; // AA:BB:CC:DD:EE:FF
 
     esp_read_mac(macInt, ESP_MAC_WIFI_STA);
-    sprintf(macFormated, "%02X:%02X:%02X:%02X:%02X:%02X", macInt[0], macInt[1], macInt[2], macInt[3], macInt[4], macInt[5]); 
+    sprintf(macFormated, "%02X:%02X:%02X:%02X:%02X:%02X", macInt[0], macInt[1], macInt[2], macInt[3], macInt[4], macInt[5]);
 
     return macFormated;
 }
@@ -454,14 +454,14 @@ std::string getHostname() {
 int get_WIFI_RSSI()
 {
 	wifi_ap_record_t ap;
-	if (esp_wifi_sta_get_ap_info(&ap) == ESP_OK) 
+	if (esp_wifi_sta_get_ap_info(&ap) == ESP_OK)
 		return ap.rssi;
 	else
 		return -127;	// Return -127 if no info available e.g. not connected
 }
 
 
-bool getWIFIisConnected() 
+bool getWIFIisConnected()
 {
     return WIFIConnected;
 }
@@ -469,12 +469,12 @@ bool getWIFIisConnected()
 
 static void event_handler(void* arg, esp_event_base_t event_base, int32_t event_id, void* event_data)
 {
-    if (event_base == WIFI_EVENT && event_id == WIFI_EVENT_STA_START) 
+    if (event_base == WIFI_EVENT && event_id == WIFI_EVENT_STA_START)
 	{
         WIFIConnected = false;
         esp_wifi_connect();
     }
-	else if (event_base == WIFI_EVENT && event_id == WIFI_EVENT_STA_DISCONNECTED) 
+	else if (event_base == WIFI_EVENT && event_id == WIFI_EVENT_STA_DISCONNECTED)
 	{
 		/* Disconnect reason: https://github.com/espressif/esp-idf/blob/d825753387c1a64463779bbd2369e177e5d59a79/components/esp_wifi/include/esp_wifi_types.h */
 		wifi_event_sta_disconnected_t *disconn = (wifi_event_sta_disconnected_t *)event_data;
@@ -489,9 +489,9 @@ static void event_handler(void* arg, esp_event_base_t event_base, int32_t event_
 				StatusLED(WLAN_CONN, 1, false);
 			}
 			else if (disconn->reason == WIFI_REASON_AUTH_EXPIRE ||
-					 disconn->reason == WIFI_REASON_AUTH_FAIL || 
+					 disconn->reason == WIFI_REASON_AUTH_FAIL ||
 					 disconn->reason == WIFI_REASON_NOT_AUTHED ||
-					 disconn->reason == WIFI_REASON_4WAY_HANDSHAKE_TIMEOUT || 
+					 disconn->reason == WIFI_REASON_4WAY_HANDSHAKE_TIMEOUT ||
 					 disconn->reason == WIFI_REASON_HANDSHAKE_TIMEOUT) {
 				LogFile.WriteToFile(ESP_LOG_WARN, TAG, "Disconnected (" + std::to_string(disconn->reason) + ", Auth fail)");
 				StatusLED(WLAN_CONN, 2, false);
@@ -510,25 +510,25 @@ static void event_handler(void* arg, esp_event_base_t event_base, int32_t event_
 
 		if (WIFIReconnectCnt >= 10) {
 			WIFIReconnectCnt = 0;
-			LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "Disconnected, multiple reconnect attempts failed (" + 
+			LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "Disconnected, multiple reconnect attempts failed (" +
 													 std::to_string(disconn->reason) + "), still retrying");
 		}
-	}	
-	else if (event_base == WIFI_EVENT && event_id == WIFI_EVENT_STA_CONNECTED) 
+	}
+	else if (event_base == WIFI_EVENT && event_id == WIFI_EVENT_STA_CONNECTED)
 	{
-        LogFile.WriteToFile(ESP_LOG_INFO, TAG, "Connected to: " + wlan_config.ssid + ", RSSI: " + 
+        LogFile.WriteToFile(ESP_LOG_INFO, TAG, "Connected to: " + wlan_config.ssid + ", RSSI: " +
 												std::to_string(get_WIFI_RSSI()));
 
-		#ifdef WLAN_USE_MESH_ROAMING	
+		#ifdef WLAN_USE_MESH_ROAMING
 			printRoamingFeatureSupport();
 
 			#ifdef WLAN_USE_MESH_ROAMING_ACTIVATE_CLIENT_TRIGGERED_QUERIES
 			// wifiRoamingQuery();	// Avoid client triggered query during processing flow (reduce risk of heap shortage). Request will be triggered at the end of every cycle anyway
 			#endif //WLAN_USE_MESH_ROAMING_ACTIVATE_CLIENT_TRIGGERED_QUERIES
-			
+
 		#endif //WLAN_USE_MESH_ROAMING
-	}	
-	else if (event_base == IP_EVENT && event_id == IP_EVENT_STA_GOT_IP) 
+	}
+	else if (event_base == IP_EVENT && event_id == IP_EVENT_STA_GOT_IP)
 	{
         WIFIConnected = true;
 		WIFIReconnectCnt = 0;
@@ -546,17 +546,17 @@ static void event_handler(void* arg, esp_event_base_t event_base, int32_t event_
 			wlan_config.dns = std::string(esp_ip4addr_ntoa((const esp_ip4_addr_t*)&dns_info.ip, buf, sizeof(buf)));
 		}
 
-		LogFile.WriteToFile(ESP_LOG_INFO, TAG, "Assigned IP: " + wlan_config.ipaddress + 
-											", Netmask: " + wlan_config.netmask + 
+		LogFile.WriteToFile(ESP_LOG_INFO, TAG, "Assigned IP: " + wlan_config.ipaddress +
+											", Netmask: " + wlan_config.netmask +
 											", Gateway: " + wlan_config.gateway +
-											", DNS: " + wlan_config.dns); 
+											", DNS: " + wlan_config.dns);
 
 		#ifdef ENABLE_MQTT
             if (getMQTTisEnabled()) {
-                vTaskDelay(5000 / portTICK_PERIOD_MS); 
-                MQTT_Init();    // Init when WIFI is getting connected    
+                vTaskDelay(5000 / portTICK_PERIOD_MS);
+                MQTT_Init();    // Init when WIFI is getting connected
             }
-        #endif //ENABLE_MQTT   
+        #endif //ENABLE_MQTT
 	}
 }
 
@@ -574,11 +574,11 @@ esp_err_t wifi_init_sta(void)
 		LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "esp_event_loop_create_default: Error: "  + std::to_string(retval));
 		return retval;
 	}
-	
+
     my_sta = esp_netif_create_default_wifi_sta();
-	
+
 	if (!wlan_config.ipaddress.empty() && !wlan_config.netmask.empty() && !wlan_config.gateway.empty())
-    {	
+    {
 		retval = esp_netif_dhcpc_stop(my_sta);	// Stop DHCP service
 		if (retval != ESP_OK) {
 			LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "esp_netif_dhcpc_stop: Error: "  + std::to_string(retval));
@@ -613,7 +613,7 @@ esp_err_t wifi_init_sta(void)
 		}
 
 		wlan_config.dhcp = false;
-		LogFile.WriteToFile(ESP_LOG_INFO, TAG, "Use static network config"); 
+		LogFile.WriteToFile(ESP_LOG_INFO, TAG, "Use static network config");
     }
 	else {
 		wlan_config.dhcp = true;
@@ -706,8 +706,8 @@ esp_err_t wifi_init_sta(void)
 }
 
 
-void WIFIDestroy() 
-{	
+void WIFIDestroy()
+{
 	esp_event_handler_unregister(IP_EVENT, IP_EVENT_STA_GOT_IP, event_handler);
     esp_event_handler_unregister(WIFI_EVENT, ESP_EVENT_ANY_ID, event_handler);
 	#ifdef WLAN_USE_MESH_ROAMING

--- a/code/components/jomjol_wlan/read_wlanini.cpp
+++ b/code/components/jomjol_wlan/read_wlanini.cpp
@@ -53,7 +53,7 @@ int LoadWlanFromFile(std::string fn)
     fn = FormatFileName(fn);
     FILE* pFile = fopen(fn.c_str(), "r");
     if (pFile == NULL) {
-        LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "Unable to open file (read). Device init aborted"); 
+        LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "Unable to open file (read). Device init aborted");
         return -1;
     }
 
@@ -80,7 +80,7 @@ int LoadWlanFromFile(std::string fn)
 
             splitted = ZerlegeZeileWLAN(line, "=");
             splitted[0] = trim(splitted[0], " ");
-            
+
             if ((splitted.size() > 1) && (toUpper(splitted[0]) == "SSID")) {
                 tmp = trim(splitted[1]);
                 if ((tmp[0] == '"') && (tmp[tmp.length()-1] == '"')) {
@@ -102,7 +102,7 @@ int LoadWlanFromFile(std::string fn)
                 else {
                     LogFile.WriteToFile(ESP_LOG_INFO, TAG, "Password: No password set");
                 }
-            }   
+            }
 
             else if ((splitted.size() > 1) && (toUpper(splitted[0]) == "HOSTNAME")) {
                 tmp = trim(splitted[1]);
@@ -238,7 +238,7 @@ bool ChangeHostName(std::string fn, std::string _newhostname)
         line += "; This parameter can be configured via WebUI configuration\n";
         line += "; Default: \"watermeter\", if nothing is configured\n\n";
         line = "hostname = \"" + _newhostname + "\"\n";
-        updatedContent.push_back(line);        
+        updatedContent.push_back(line);
     }
 
     // Write updated content back to file
@@ -271,7 +271,7 @@ bool ChangeRSSIThreshold(std::string fn, int _newrssithreshold)
     fn = FormatFileName(fn);
     pFile = fopen(fn.c_str(), "r+");
     if (pFile == NULL) {
-        LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "ChangeRSSIThreshold: Unable to open file wlan.ini"); 
+        LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "ChangeRSSIThreshold: Unable to open file wlan.ini");
         return false;
     }
 
@@ -304,7 +304,7 @@ bool ChangeRSSIThreshold(std::string fn, int _newrssithreshold)
                 line = "";
             else
                 line = std::string(zw);
-            
+
             continue;
         }
 
@@ -312,9 +312,9 @@ bool ChangeRSSIThreshold(std::string fn, int _newrssithreshold)
             line = "RSSIThreshold = " + std::to_string(_newrssithreshold) + "\n";
             found = true;
         }
-    
+
         updatedContent.push_back(line);
-    
+
         if (fgets(zw, sizeof(zw), pFile) == NULL)
             line = "";
         else
@@ -332,7 +332,7 @@ bool ChangeRSSIThreshold(std::string fn, int _newrssithreshold)
         line += "; Note: This parameter can be configured via WebUI configuration\n";
         line += "; Default: 0 = Disable client requested roaming query\n\n";
         line += "RSSIThreshold = " + std::to_string(_newrssithreshold) + "\n";
-        updatedContent.push_back(line);        
+        updatedContent.push_back(line);
     }
 
     // Write updated content back to file
@@ -352,7 +352,7 @@ bool ChangeRSSIThreshold(std::string fn, int _newrssithreshold)
         LogFile.WriteToFile(ESP_LOG_INFO, TAG, "ChangeRSSIThreshold: RSSIThreshold set to " + std::to_string(wlan_config.rssi_threshold));
     else
         LogFile.WriteToFile(ESP_LOG_INFO, TAG, "WLAN roaming/channel scan (RSSIThreshold = 0) -> function disabled");
-    
+
     return true;
 }
 #endif

--- a/code/include/defines.h
+++ b/code/include/defines.h
@@ -48,7 +48,7 @@
 
 // Can also be set in platformio.ini with -D OPTION_TO_ACTIVATE
 // ****************************************************
-//#define DEBUG_DETAIL_ON 
+//#define DEBUG_DETAIL_ON
 //#define DEBUG_DISABLE_BROWNOUT_DETECTOR
 //#define DEBUG_ENABLE_PERFMON
 
@@ -60,7 +60,7 @@
 //#define TASK_ANALYSIS_ON
 
 /* Uncomment this to generate task list with stack sizes using the /heap handler
-    PLEASE BE AWARE: The following CONFIG parameters have to to be set in 
+    PLEASE BE AWARE: The following CONFIG parameters have to to be set in
     sdkconfig.defaults before use of this function is possible!!
     CONFIG_FREERTOS_USE_TRACE_FACILITY=1
     CONFIG_FREERTOS_GENERATE_RUN_TIME_STATS=y
@@ -125,15 +125,15 @@
 
 
 //server_file +(ota_page.html + upload_script.html)
-#define MAX_FILE_SIZE   (8000*1024) // 8 MB Max size of an individual file. Make sure this value 
+#define MAX_FILE_SIZE   (8000*1024) // 8 MB Max size of an individual file. Make sure this value
                                     // is same as that set in upload_script.html and ota_page.html!
 #define MAX_FILE_SIZE_STR "8MB"
-        
-#define LOGFILE_LAST_PART_BYTES 80 * 1024 // 80 kBytes  // Size of partial log file to return 
 
-#define SERVER_FILER_SCRATCH_BUFSIZE  4096 
+#define LOGFILE_LAST_PART_BYTES 80 * 1024 // 80 kBytes  // Size of partial log file to return
+
+#define SERVER_FILER_SCRATCH_BUFSIZE  4096
 #define SERVER_HELPER_SCRATCH_BUFSIZE  8192
-#define SERVER_OTA_SCRATCH_BUFSIZE  1024 
+#define SERVER_OTA_SCRATCH_BUFSIZE  1024
 
 
 //server_file + server_help
@@ -201,7 +201,7 @@
 //#define STB_IMAGE_IMPLEMENTATION
 //#define STB_IMAGE_WRITE_IMPLEMENTATION
 //#define STB_IMAGE_RESIZE_IMPLEMENTATION
-#define STBI_ONLY_JPEG // (save 2% of Flash, but breaks the alignment mark generation, see 
+#define STBI_ONLY_JPEG // (save 2% of Flash, but breaks the alignment mark generation, see
                        // https://github.com/jomjol/AI-on-the-edge-device/issues/1721)
 
 
@@ -212,7 +212,7 @@
 // connect_wlan.cpp
 //******************************
 /* WIFI roaming functionalities 802.11k+v (uses ca. 6kB - 8kB internal RAM; if SCAN CACHE activated: + 1kB / beacon)
-PLEASE BE AWARE: The following CONFIG parameters have to to be set in 
+PLEASE BE AWARE: The following CONFIG parameters have to to be set in
 sdkconfig.defaults before use of this function is possible!!
 CONFIG_WPA_11KV_SUPPORT=y
 CONFIG_WPA_SCAN_CACHE=n
@@ -221,7 +221,7 @@ CONFIG_WPA_11R_SUPPORT=n
 */
 //#define WLAN_USE_MESH_ROAMING   // 802.11v (BSS Transition Management) + 802.11k (Radio Resource Management)
                                   // (ca. 6kB - 8kB internal RAM neccessary)
-//#define WLAN_USE_MESH_ROAMING_ACTIVATE_CLIENT_TRIGGERED_QUERIES  // Client can send query to AP requesting 
+//#define WLAN_USE_MESH_ROAMING_ACTIVATE_CLIENT_TRIGGERED_QUERIES  // Client can send query to AP requesting
                                                                    // to roam (if RSSI lower than RSSI threshold)
 
 // WIFI roaming only client triggered by scanning the channels after each
@@ -369,7 +369,7 @@ CONFIG_WPA_11R_SUPPORT=n
 
     #define GPIO_FLASHLIGHT_DEFAULT_USE_PWM                 // Default flashlight LED (.e.g onboard LED) is PWM controlled
     //#define GPIO_FLASHLIGHT_DEFAULT_USE_SMARTLED          // Default flashlight SmartLED (e.g. onboard WS2812X) controlled
-    
+
     #ifdef GPIO_FLASHLIGHT_DEFAULT_USE_SMARTLED
         #define GPIO_FLASHLIGHT_DEFAULT_SMARTLED_TYPE       LED_WS2812 // Flashlight default: SmartLED type
         #define GPIO_FLASHLIGHT_DEFAULT_SMARTLED_QUANTITY   1          // Flashlight default: SmartLED Quantity
@@ -378,7 +378,7 @@ CONFIG_WPA_11R_SUPPORT=n
 
     // Spare GPIO
     //-------------------------------------------------
-    // Options for usage defintion: 
+    // Options for usage defintion:
     // - 'spare': Free to use
     // - 'restricted: usage': Restricted usable (WebUI expert view)
     // - 'flashlight-pwm' or 'flashlight-smartled' or 'flashlight-digital' (ON/OFF) -> Map to 'flashlight-default'
@@ -406,7 +406,7 @@ CONFIG_WPA_11R_SUPPORT=n
         #define GPIO_SPARE_4_USAGE          "spare"
     #else
         #define GPIO_SPARE_3                GPIO_NUM_NC    // Not usable, in use for 'SD-card'
-        #define GPIO_SPARE_3_USAGE          ""      
+        #define GPIO_SPARE_3_USAGE          ""
 
         #define GPIO_SPARE_4                GPIO_NUM_NC    // Not usable, in use for 'SD-card'
         #define GPIO_SPARE_4_USAGE          ""
@@ -440,7 +440,7 @@ CONFIG_WPA_11R_SUPPORT=n
 
     #define GPIO_FLASHLIGHT_DEFAULT_USE_PWM                 // Default flashlight LED is PWM controlled
     //#define GPIO_FLASHLIGHT_DEFAULT_USE_SMARTLED          // Default flashlight SmartLED (e.g. onboard WS2812X) controlled
-    
+
     #ifdef GPIO_FLASHLIGHT_DEFAULT_USE_SMARTLED
         #define GPIO_FLASHLIGHT_DEFAULT_SMARTLED_TYPE       LED_WS2812 // Flashlight default: SmartLED type
         #define GPIO_FLASHLIGHT_DEFAULT_SMARTLED_QUANTITY   1          // Flashlight default: SmartLED Quantity
@@ -449,14 +449,14 @@ CONFIG_WPA_11R_SUPPORT=n
 
     // Spare GPIO
     //-------------------------------------------------
-    // Options for usage defintion: 
+    // Options for usage defintion:
     // - 'spare': Free to use
     // - 'restricted: usage': Restricted usable (WebUI expert view)
     // - 'flashlight-pwm' or 'flashlight-smartled' or 'flashlight-digital' (ON/OFF) -> Map to 'flashlight-default'
     // --> ESP32CAM: flashlight-default -> flashlight-pwm (Onboard LED, PWM controlled)
     //-------------------------------------------------
     #define GPIO_SPARE_PIN_COUNT            6
-   
+
     #define GPIO_SPARE_1                    GPIO_FLASHLIGHT_DEFAULT // Flashlight default
     #if defined(GPIO_FLASHLIGHT_DEFAULT_USE_PWM)
         #define GPIO_SPARE_1_USAGE          FLASHLIGHT_PWM          // Define flashlight-default as ...
@@ -468,13 +468,13 @@ CONFIG_WPA_11R_SUPPORT=n
 
     #define GPIO_SPARE_2                    GPIO_NUM_2
     #define GPIO_SPARE_2_USAGE              "spare"
-    
+
     #define GPIO_SPARE_3                    GPIO_NUM_3
     #define GPIO_SPARE_3_USAGE              "spare"
 
     #define GPIO_SPARE_4                    GPIO_NUM_4
     #define GPIO_SPARE_4_USAGE              "spare"
-    
+
     #define GPIO_SPARE_5                    GPIO_NUM_5
     #define GPIO_SPARE_5_USAGE              "spare"
 

--- a/code/main/main.cpp
+++ b/code/main/main.cpp
@@ -11,8 +11,8 @@
 #include "driver/sdmmc_host.h"
 
 #ifdef DISABLE_BROWNOUT_DETECTOR
-    #include "soc/soc.h" 
-    #include "soc/rtc_cntl_reg.h" 
+    #include "soc/soc.h"
+    #include "soc/rtc_cntl_reg.h"
 #endif
 
 #ifdef USE_HIMEM_IF_AVAILABLE
@@ -81,9 +81,9 @@ extern "C" void app_main(void)
         //register a buffer to record the memory trace
         ESP_ERROR_CHECK( heap_trace_init_standalone(trace_record, NUM_RECORDS) );
     #endif
-        
+
     deviceStartTimestamp = getCurrentTimeString(TIME_FORMAT_OUTPUT);
-        
+
     #ifdef DISABLE_BROWNOUT_DETECTOR
         WRITE_PERI_REG(RTC_CNTL_BROWN_OUT_REG, 0); //disable brownout detector
     #endif
@@ -93,10 +93,10 @@ extern "C" void app_main(void)
     #endif
 
     // ********************************************
-    // Highlight start of app_main 
+    // Highlight start of app_main
     // ********************************************
     ESP_LOGI(TAG, "================ Start app_main =================");
-    
+
     // Init NVS flash
     // ********************************************
     if (ESP_OK != initNVSFlash()) {
@@ -143,7 +143,7 @@ extern "C" void app_main(void)
     // Note: Start AP if no wlan.ini and/or config.ini available, e.g. SD card empty; function does not exit anymore until reboot
     // ********************************************
     #ifdef ENABLE_SOFTAP
-        CheckStartAPMode(); 
+        CheckStartAPMode();
     #endif
 
     // SD card: basic R/W check
@@ -175,19 +175,19 @@ extern "C" void app_main(void)
 
     if (getHTMLcommit().substr(0, 7) == "?")
         LogFile.WriteToFile(ESP_LOG_WARN, TAG, std::string("Failed to read file html/version.txt to parse WebUI version"));
- 
+
     if (getHTMLcommit().substr(0, 7) != std::string(GIT_REV).substr(0, 7)) { // Compare the first 7 characters of both hashes
         LogFile.WriteToFile(ESP_LOG_WARN, TAG, "WebUI version (" + getHTMLcommit() + ") does not match firmware version (" + std::string(GIT_REV) + ")");
-        LogFile.WriteToFile(ESP_LOG_WARN, TAG, "Recommendation: Repeat OTA update using AI-on-the-edge-device__update__*.zip");    
+        LogFile.WriteToFile(ESP_LOG_WARN, TAG, "Recommendation: Repeat OTA update using AI-on-the-edge-device__update__*.zip");
     }
 
     // Check reboot reason
     // ********************************************
     CheckIsPlannedReboot();
-    if (!getIsPlannedReboot() && (esp_reset_reason() == ESP_RST_PANIC)) {  // If system reboot was not triggered by user and reboot was caused by execption 
+    if (!getIsPlannedReboot() && (esp_reset_reason() == ESP_RST_PANIC)) {  // If system reboot was not triggered by user and reboot was caused by execption
         LogFile.WriteToFile(ESP_LOG_WARN, TAG, "Reset reason: " + getResetReason());
         LogFile.WriteToFile(ESP_LOG_WARN, TAG, "Device was rebooted due to a software exception! Log level is set to DEBUG until the next reboot. "
-                                               "Flow init is delayed by 5 minutes to check the logs or do an OTA update"); 
+                                               "Flow init is delayed by 5 minutes to check the logs or do an OTA update");
         LogFile.WriteToFile(ESP_LOG_WARN, TAG, "Keep device running until crash occurs again and check logs after device is up again");
         LogFile.setLogLevel(ESP_LOG_DEBUG);
         setTaskAutoFlowState(FLOW_TASK_STATE_INIT_DELAYED);
@@ -198,9 +198,9 @@ extern "C" void app_main(void)
 
     #ifdef HEAP_TRACING_MAIN_START
         ESP_ERROR_CHECK( heap_trace_stop() );
-        heap_trace_dump(); 
+        heap_trace_dump();
     #endif
-    
+
     #ifdef HEAP_TRACING_MAIN_WIFI
         ESP_ERROR_CHECK( heap_trace_start(HEAP_TRACE_LEAKS) );
     #endif
@@ -246,8 +246,8 @@ extern "C" void app_main(void)
 
     #ifdef HEAP_TRACING_MAIN_WIFI
         ESP_ERROR_CHECK( heap_trace_stop() );
-        heap_trace_dump(); 
-    #endif   
+        heap_trace_dump();
+    #endif
 
     #ifdef USE_HIMEM_IF_AVAILABLE
         #ifdef DEBUG_HIMEM_MEMORY_CHECK
@@ -266,7 +266,7 @@ extern "C" void app_main(void)
     }
     else { // ESP_OK -> PSRAM init OK --> continue to check PSRAM size
         size_t psram_size = esp_psram_get_size();
-        LogFile.WriteToFile(ESP_LOG_INFO, TAG, "PSRAM size: " + std::to_string(psram_size) + " byte (" + std::to_string(psram_size/1024/1024) + 
+        LogFile.WriteToFile(ESP_LOG_INFO, TAG, "PSRAM size: " + std::to_string(psram_size) + " byte (" + std::to_string(psram_size/1024/1024) +
                                                "MB / " + std::to_string(psram_size/1024/1024*8) + "MBit)");
 
         // Check PSRAM size
@@ -288,7 +288,7 @@ extern "C" void app_main(void)
                 StatusLED(PSRAM_INIT, 3, true);
             }
             else { // HEAP size OK --> continue to camera init
-                // Set SPIRAM memory category 
+                // Set SPIRAM memory category
                 size_t SPIRAMFree = getESPHeapSizeSPIRAMFree();
                 if (SPIRAMFree >= 32000000)
                     setSPIRAMCategory(SPIRAMCategory_32MB);
@@ -326,18 +326,18 @@ extern "C" void app_main(void)
     // Print Device info
     // ********************************************
     printDeviceInfo();
-    
+
     // Print SD-Card info
     // ********************************************
-    LogFile.WriteToFile(ESP_LOG_INFO, TAG, "SD card info: Name: " + getSDCardName() + ", Capacity: " + 
+    LogFile.WriteToFile(ESP_LOG_INFO, TAG, "SD card info: Name: " + getSDCardName() + ", Capacity: " +
             std::to_string(getSDCardCapacity()) + "MB, Free: " + std::to_string(getSDCardFreePartitionSpace()) + "MB");
 
 
     // Start webserver + register handler
     // ********************************************
     ESP_LOGD(TAG, "starting servers");
-    server = start_webserver();   
-    register_server_camera_uri(server); 
+    server = start_webserver();
+    register_server_camera_uri(server);
     register_server_main_flow_task_uri(server);
     register_server_file_uri(server, "/sdcard");
     register_server_ota_sdcard_uri(server);
@@ -358,7 +358,7 @@ extern "C" void app_main(void)
     }
     // Critical error(s) occured which do not allow to continue with regular boot sequence.
     // Provding only a reduced web interface for diagnostic purpose. Reduced web interface and interlock: server_main.cpp -> hello_main_handler()
-    else { 
+    else {
         LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "Basic device initialization failed");
     }
 }
@@ -367,18 +367,18 @@ extern "C" void app_main(void)
 esp_err_t initNVSFlash()
 {
     ESP_LOGI(TAG, "Initializing NVS flash");
-    
+
     esp_err_t ret = nvs_flash_init();
     if (ret == ESP_ERR_NVS_NO_FREE_PAGES) {
         ESP_ERROR_CHECK(nvs_flash_erase());
         ret = nvs_flash_init();
     }
-    
+
     if (ret != ESP_OK) {
         if (ret == ESP_ERR_NOT_FOUND) {
             ESP_LOGE(TAG, "NVS flash init failed. No NVS partition found");
             StatusLED(SDCARD_NVS_INIT, 4, true);
-        } 
+        }
         else if (ret == ESP_ERR_NVS_NO_FREE_PAGES) {
             ESP_LOGE(TAG, "NVS flash init failed. No free NVS pages found");
             StatusLED(SDCARD_NVS_INIT, 5, true);
@@ -435,7 +435,7 @@ esp_err_t initSDCard()
     // formatted in case when mounting fails.
     esp_vfs_fat_sdmmc_mount_config_t mount_config = {
         .format_if_mount_failed = false,
-        .max_files = 12,                         // previously -> 2022-09-21: 5, 2023-01-02: 7 
+        .max_files = 12,                         // previously -> 2022-09-21: 5, 2023-01-02: 7
         .allocation_unit_size = 16 * 1024,
         .disk_status_check_enable = 0
     };
@@ -452,7 +452,7 @@ esp_err_t initSDCard()
         if (ret == ESP_FAIL) {
             ESP_LOGE(TAG, "Failed to mount FAT filesystem on SD card. Check SD card filesystem (only FAT supported) or try another card");
             StatusLED(SDCARD_NVS_INIT, 1, true);
-        } 
+        }
         else if (ret == 263) { // Error code: 0x107 --> usually: SD not found
             ESP_LOGE(TAG, "SD card init failed. Check if SD card is properly inserted into SD card slot or try another card");
             StatusLED(SDCARD_NVS_INIT, 2, true);
@@ -473,7 +473,7 @@ void migrateConfiguration(void)
 {
     if (!FileExists(CONFIG_FILE)) {
         LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "Config file seems to be missing");
-        return;	
+        return;
     }
 
     const std::string sectionConfigFile= "[ConfigFile]";
@@ -504,13 +504,13 @@ void migrateConfiguration(void)
     // If no [Config] section is available, add section and set config version to zero
     if (!configSectionFound) {
         configLines.insert(configLines.begin(), ""); // 3rd line
-        configLines.insert(configLines.begin(), "Version = 0"); //2nd line 
+        configLines.insert(configLines.begin(), "Version = 0"); //2nd line
 	    configLines.insert(configLines.begin(), sectionConfigFile); // 1st line
         migrated = true;
     }
-    
+
      // Process every version iteration beginning from actual version
-	for (int configFileVersion = actualConfigFileVersion; configFileVersion < (int)CONFIG_FILE_VERSION; configFileVersion++) {     
+	for (int configFileVersion = actualConfigFileVersion; configFileVersion < (int)CONFIG_FILE_VERSION; configFileVersion++) {
         // Process each line of config
         for (int i = 0; i < configLines.size(); i++) {
             if (configLines[i].find("[") != std::string::npos) { // Detect start of new section
@@ -533,9 +533,9 @@ void migrateConfiguration(void)
                 // Update config version
                 // ---------------------
                 if (section == sectionConfigFile) {
-                    if(replaceString(configLines[i], "Version = " + std::to_string(configFileVersion), 
+                    if(replaceString(configLines[i], "Version = " + std::to_string(configFileVersion),
                                                      "Version = " + std::to_string(configFileVersion+1))) {
-                        LogFile.WriteToFile(ESP_LOG_WARN, TAG, "Config.ini: Migrate v" + std::to_string(configFileVersion) + 
+                        LogFile.WriteToFile(ESP_LOG_WARN, TAG, "Config.ini: Migrate v" + std::to_string(configFileVersion) +
                                                                                 " > v" + std::to_string(configFileVersion+1));
                         migrated = true;
                     }
@@ -543,7 +543,7 @@ void migrateConfiguration(void)
 
                 // Migrate parameter
                 // ---------------------
-                if (section == "[GPIO]") {                   
+                if (section == "[GPIO]") {
                     // Erase complete section content due to major change in parameter usage
                     // Section will be filled again by WebUI after save config initially
                     if (configLines[i].find("[GPIO]") == std::string::npos && !configLines[i].empty()) {
@@ -561,9 +561,9 @@ void migrateConfiguration(void)
                 // Update config version
                 // ---------------------
                 if (section == sectionConfigFile) {
-                    if(replaceString(configLines[i], "Version = " + std::to_string(configFileVersion), 
+                    if(replaceString(configLines[i], "Version = " + std::to_string(configFileVersion),
                                                      "Version = " + std::to_string(configFileVersion+1))) {
-                        LogFile.WriteToFile(ESP_LOG_WARN, TAG, "Config.ini: Migrate v" + std::to_string(configFileVersion) + 
+                        LogFile.WriteToFile(ESP_LOG_WARN, TAG, "Config.ini: Migrate v" + std::to_string(configFileVersion) +
                                                                                 " > v" + std::to_string(configFileVersion+1));
                         migrated = true;
                     }
@@ -614,7 +614,7 @@ void migrateConfiguration(void)
                 if (section == "[Analog]") {
                     migrated = migrated | replaceString(configLines[i], "LogImageLocation", "ROIImagesLocation");
                     migrated = migrated | replaceString(configLines[i], "LogfileRetentionInDays", "ROIImagesRetention");
-                    migrated = migrated | replaceString(configLines[i], "CNNGoodThreshold", ";UNUSED_PARAMETER"); // This parameter is no longer used          
+                    migrated = migrated | replaceString(configLines[i], "CNNGoodThreshold", ";UNUSED_PARAMETER"); // This parameter is no longer used
                     migrated = migrated | replaceString(configLines[i], "ExtendedResolution", ";UNUSED_PARAMETER"); // This parameter is no longer used
                 }
 
@@ -667,7 +667,7 @@ void migrateConfiguration(void)
                         migrated = migrated | replaceString(configLines[i], "true", "false"); // Set it to its default value
                         migrated = migrated | replaceString(configLines[i], ";", ""); // Enable it
                     }
-                
+
                     /* IgnoreLeadingNaN has a <NUMBER> as prefix! */
                     if (isInString(configLines[i], "IgnoreLeadingNaN") && isInString(configLines[i], ";")) { // It is the parameter "IgnoreLeadingNaN" and it is commented out
                         migrated = migrated | replaceString(configLines[i], "true", "false"); // Set it to its default value
@@ -708,7 +708,7 @@ void migrateConfiguration(void)
                         migrated = migrated | replaceString(configLines[i], ";", ""); // Enable it
                         migrated = migrated | replaceString(configLines[i], "HAMeterType = other", "HAMeterType = water_m3"); // Enable it
                     }
-                    
+
                     if (configLines[i].rfind("Topic", 0) != std::string::npos) { // only if string starts with "Topic" (Was the naming in very old version)
                         migrated = migrated | replaceString(configLines[i], "Topic", "MainTopic");
                     }
@@ -751,7 +751,7 @@ void migrateConfiguration(void)
                     if (isInString(configLines[i], "Database")) { // It is the parameter "Database"
                         migrated = migrated | replaceString(configLines[i], "Database", "Bucket"); // Rename it to Bucket
                     }
-                    
+
                     /* Measurement has a <NUMBER> as prefix! */
                     if (isInString(configLines[i], "Measurement") && isInString(configLines[i], ";")) { // It is the parameter "Measurement" and is it disabled
                         migrated = migrated | replaceString(configLines[i], ";", ""); // Enable it
@@ -790,12 +790,12 @@ void migrateConfiguration(void)
                     * For both cases (true/false), we set it to level 2 (WARNING) */
                     migrated = migrated | replaceString(configLines[i], "LogLevel = true", "LogLevel = 2");
                     migrated = migrated | replaceString(configLines[i], "LogLevel = false", "LogLevel = 2");
-                    
+
                     migrated = migrated | replaceString(configLines[i], "LogfileRetentionInDays", "LogfilesRetention");
                 }
 
                 if (section == "[System]") {
-                    if (isInString(configLines[i], "TimeServer = undefined") && isInString(configLines[i], ";")) 
+                    if (isInString(configLines[i], "TimeServer = undefined") && isInString(configLines[i], ";"))
                     { // It is the parameter "TimeServer" and is it disabled
                         migrated = migrated | replaceString(configLines[i], "undefined", "pool.ntp.org");
                         migrated = migrated | replaceString(configLines[i], ";", ""); // Enable it
@@ -809,14 +809,14 @@ void migrateConfiguration(void)
                         migrated = migrated | replaceString(configLines[i], "undefined", "watermeter");
                         migrated = migrated | replaceString(configLines[i], ";", ""); // Enable it
                     }
-                                        
+
                     migrated = migrated | replaceString(configLines[i], "RSSIThreashold", "RSSIThreshold");
 
                     if (isInString(configLines[i], "CPUFrequency") && isInString(configLines[i], ";")) { // It is the parameter "CPUFrequency" and is it disabled
                         migrated = migrated | replaceString(configLines[i], "240", "160");
                         migrated = migrated | replaceString(configLines[i], ";", ""); // Enable it
                     }
-                    
+
                     migrated = migrated | replaceString(configLines[i], "AutoAdjustSummertime", ";UNUSED_PARAMETER"); // This parameter is no longer used
 
                     migrated = migrated | replaceString(configLines[i], ";SetupMode = true", ";SetupMode = false"); // Set it to its default value
@@ -832,7 +832,7 @@ void migrateConfiguration(void)
             return;
         }
 
-        FILE* pfile = fopen(CONFIG_FILE, "w");        
+        FILE* pfile = fopen(CONFIG_FILE, "w");
         for (int i = 0; i < configLines.size(); i++) {
             fwrite(configLines[i].c_str() , configLines[i].length(), 1, pfile);
             fwrite("\n" , 1, 1, pfile);

--- a/code/main/server_main.cpp
+++ b/code/main/server_main.cpp
@@ -28,7 +28,7 @@
 
 static const char *TAG = "MAIN_SERVER";
 
-httpd_handle_t server = NULL;   
+httpd_handle_t server = NULL;
 extern std::string deviceStartTimestamp;
 
 
@@ -36,10 +36,10 @@ esp_err_t handler_get_info(httpd_req_t *req)
 {
     const char* APIName = "info:v3"; // API name and version
     char _query[200];
-    char _valuechar[30];    
+    char _valuechar[30];
     std::string type;
 
-    if (httpd_req_get_url_query_str(req, _query, sizeof(_query)) == ESP_OK) {       
+    if (httpd_req_get_url_query_str(req, _query, sizeof(_query)) == ESP_OK) {
         if (httpd_query_key_value(_query, "type", _valuechar, sizeof(_valuechar)) == ESP_OK) {
             type = std::string(_valuechar);
         }
@@ -48,7 +48,7 @@ esp_err_t handler_get_info(httpd_req_t *req)
         esp_err_t retVal = ESP_OK;
         std::string sReturnMessage;
         cJSON *cJSONObject = cJSON_CreateObject();
-            
+
         if (cJSONObject == NULL) {
             httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "E91: Error, JSON object cannot be created");
             return ESP_FAIL;
@@ -66,9 +66,9 @@ esp_err_t handler_get_info(httpd_req_t *req)
             retVal = ESP_FAIL;
         if (cJSON_AddStringToObject(cJSONObject, "datalogging_sdcard_status", LogFile.GetDataLogToSD() ? "Enabled" : "Disabled") == NULL)
             retVal = ESP_FAIL;
-        
+
         #ifdef ENABLE_MQTT
-        if (cJSON_AddStringToObject(cJSONObject, "mqtt_status", getMQTTisEnabled() ? (getMQTTisConnected() ? (getMQTTisEncrypted() ? 
+        if (cJSON_AddStringToObject(cJSONObject, "mqtt_status", getMQTTisEnabled() ? (getMQTTisConnected() ? (getMQTTisEncrypted() ?
                                         "Connected (Encrypted)" : "Connected") : "Disconnected") : "Disabled") == NULL)
             retVal = ESP_FAIL;
         #else
@@ -78,12 +78,12 @@ esp_err_t handler_get_info(httpd_req_t *req)
 
         #ifdef ENABLE_INFLUXDB
         ClassFlowInfluxDB* influxdb = (ClassFlowInfluxDB*)(flowctrl.getFlowClass("ClassFlowInfluxDB"));
-        if (cJSON_AddStringToObject(cJSONObject, "influxdbv1_status", influxdb ? (getInfluxDBisEncrypted() ? 
+        if (cJSON_AddStringToObject(cJSONObject, "influxdbv1_status", influxdb ? (getInfluxDBisEncrypted() ?
                                         "Enabled (Encrypted)" : "Enabled") : "Disabled") == NULL)
             retVal = ESP_FAIL;
-        
+
         ClassFlowInfluxDBv2* influxdbv2 = (ClassFlowInfluxDBv2*)(flowctrl.getFlowClass("ClassFlowInfluxDBv2"));
-        if (cJSON_AddStringToObject(cJSONObject, "influxdbv2_status", influxdbv2 ? (getInfluxDBv2isEncrypted() ? 
+        if (cJSON_AddStringToObject(cJSONObject, "influxdbv2_status", influxdbv2 ? (getInfluxDBv2isEncrypted() ?
                                         "Enabled (Encrypted)" : "Enabled") : "Disabled") == NULL)
             retVal = ESP_FAIL;
         #else
@@ -184,7 +184,7 @@ esp_err_t handler_get_info(httpd_req_t *req)
 
         char *jsonString = cJSON_PrintBuffered(cJSONObject, 2048, 1); // Print to predefined buffer, avoid dynamic allocations
         sReturnMessage = std::string(jsonString);
-        cJSON_free(jsonString);  
+        cJSON_free(jsonString);
         cJSON_Delete(cJSONObject);
 
         httpd_resp_set_hdr(req, "Access-Control-Allow-Origin", "*");
@@ -207,39 +207,39 @@ esp_err_t handler_get_info(httpd_req_t *req)
 
     if (type.compare("api_name") == 0) {
         httpd_resp_sendstr(req, APIName);
-        return ESP_OK;        
+        return ESP_OK;
     }
     else if (type.compare("process_status") == 0) {
         httpd_resp_sendstr(req, getProcessStatus().c_str());
-        return ESP_OK;        
+        return ESP_OK;
     }
     else if (type.compare("process_interval") == 0) {
         httpd_resp_sendstr(req, to_stringWithPrecision(flowctrl.getProcessInterval(), 1).c_str());
-        return ESP_OK;        
+        return ESP_OK;
     }
     else if (type.compare("process_time") == 0) {
         httpd_resp_sendstr(req, std::to_string(getFlowProcessingTime()).c_str());
-        return ESP_OK;        
+        return ESP_OK;
     }
     else if (type.compare("cycle_counter") == 0) {
         httpd_resp_sendstr(req, std::to_string(getFlowCycleCounter()).c_str());
-        return ESP_OK;        
+        return ESP_OK;
     }
     else if (type.compare("datalogging_sdcard_status") == 0) {
         httpd_resp_sendstr(req, LogFile.GetDataLogToSD() ? "Enabled" : "Disabled");
-        return ESP_OK;        
+        return ESP_OK;
     }
-    
+
     #ifdef ENABLE_MQTT
     else if (type.compare("mqtt_status") == 0) {
-        httpd_resp_sendstr(req, getMQTTisEnabled() ? (getMQTTisConnected() ? (getMQTTisEncrypted() ? 
+        httpd_resp_sendstr(req, getMQTTisEnabled() ? (getMQTTisConnected() ? (getMQTTisEncrypted() ?
                                 "Connected (Encrypted)" : "Connected") : "Disconnected") : "Disabled");
         return ESP_OK;
     }
     #else
     else if (type.compare("mqtt_status") == 0) {
         httpd_resp_send_err(req, HTTPD_405_METHOD_NOT_ALLOWED, "E01: Service not compiled (#define ENABLE_MQTT)");
-        return ESP_FAIL;          
+        return ESP_FAIL;
     }
     #endif
 
@@ -257,153 +257,153 @@ esp_err_t handler_get_info(httpd_req_t *req)
     #else
     else if (type.compare("influxdbv1_status") == 0) {
         httpd_resp_send_err(req, HTTPD_405_METHOD_NOT_ALLOWED, "E02: Service not compiled (#define ENABLE_INFLUXDB)");
-        return ESP_FAIL;          
+        return ESP_FAIL;
     }
     else if (type.compare("influxdbv2_status") == 0) {
         httpd_resp_send_err(req, HTTPD_405_METHOD_NOT_ALLOWED, "E02: Service not compiled (#define ENABLE_INFLUXDB)");
-        return ESP_FAIL;        
+        return ESP_FAIL;
     }
     #endif
 
     else if (type.compare("ntp_syncstatus") == 0) {
         httpd_resp_sendstr(req, getNTPSyncStatus().c_str());
-        return ESP_OK;        
+        return ESP_OK;
     }
     else if (type.compare("device_starttime") == 0) {
         httpd_resp_sendstr(req, deviceStartTimestamp.c_str());
-        return ESP_OK;        
+        return ESP_OK;
     }
     else if (type.compare("device_uptime") == 0) {
         httpd_resp_sendstr(req, std::to_string(getUptime()).c_str());
-        return ESP_OK;        
+        return ESP_OK;
     }
     else if (type.compare("wlan_status") == 0) {
         httpd_resp_sendstr(req, getWIFIisConnected() ? "Connected" : "Disconnected");
-        return ESP_OK;        
+        return ESP_OK;
     }
     else if (type.compare("wlan_ssid") == 0) {
         httpd_resp_sendstr(req, getSSID().c_str());
-        return ESP_OK;        
+        return ESP_OK;
     }
     else if (type.compare("wlan_rssi") == 0) {
         httpd_resp_sendstr(req, std::to_string(get_WIFI_RSSI()).c_str());
-        return ESP_OK;        
+        return ESP_OK;
     }
     else if (type.compare("mac_address") == 0) {
         httpd_resp_sendstr(req, getMac().c_str());
-        return ESP_OK;        
+        return ESP_OK;
     }
     else if (type.compare("network_config") == 0) {
         httpd_resp_sendstr(req, getDHCPUsage() ? "DHCP" : "Static");
-        return ESP_OK;        
+        return ESP_OK;
     }
     else if (type.compare("ipv4_address") == 0) {
         httpd_resp_sendstr(req, getIPAddress().c_str());
-        return ESP_OK;        
+        return ESP_OK;
     }
     else if (type.compare("netmask_address") == 0) {
         httpd_resp_sendstr(req, getNetmaskAddress().c_str());
-        return ESP_OK;        
+        return ESP_OK;
     }
     else if (type.compare("gateway_address") == 0) {
         httpd_resp_sendstr(req, getGatewayAddress().c_str());
-        return ESP_OK;        
+        return ESP_OK;
     }
     else if (type.compare("dns_address") == 0) {
         httpd_resp_sendstr(req, getDNSAddress().c_str());
-        return ESP_OK;        
+        return ESP_OK;
     }
     else if (type.compare("hostname") == 0) {
         httpd_resp_sendstr(req, getHostname().c_str());
-        return ESP_OK;        
+        return ESP_OK;
     }
     else if (type.compare("board_type") == 0) {
         httpd_resp_sendstr(req, getBoardType().c_str());
-        return ESP_OK;        
+        return ESP_OK;
     }
     else if (type.compare("chip_model") == 0) {
         httpd_resp_sendstr(req, getChipModel().c_str());
-        return ESP_OK;        
+        return ESP_OK;
     }
     else if (type.compare("chip_cores") == 0) {
         httpd_resp_sendstr(req, std::to_string(getChipCoreCount()).c_str());
-        return ESP_OK;        
+        return ESP_OK;
     }
     else if (type.compare("chip_revision") == 0) {
         httpd_resp_sendstr(req, getChipRevision().c_str());
-        return ESP_OK;        
+        return ESP_OK;
     }
     else if (type.compare("chip_frequency") == 0) {
         httpd_resp_sendstr(req, std::to_string(esp_clk_cpu_freq()/1000000).c_str());
-        return ESP_OK;        
+        return ESP_OK;
     }
     else if (type.compare("chip_temp") == 0) {
         httpd_resp_sendstr(req, std::to_string((int)getSOCTemperature()).c_str());
-        return ESP_OK;        
+        return ESP_OK;
     }
     else if (type.compare("camera_type") == 0) {
         httpd_resp_sendstr(req, Camera.getCamType().c_str());
-        return ESP_OK;        
+        return ESP_OK;
     }
     else if (type.compare("camera_frequency") == 0) {
         httpd_resp_sendstr(req, std::to_string(Camera.getCamFrequencyMhz()).c_str());
-        return ESP_OK;        
+        return ESP_OK;
     }
     else if (type.compare("sd_name") == 0) {
         httpd_resp_sendstr(req, getSDCardName().c_str());
-        return ESP_OK;        
+        return ESP_OK;
     }
     else if (type.compare("sd_manufacturer") == 0) {
         httpd_resp_sendstr(req, getSDCardManufacturer().c_str());
-        return ESP_OK;        
+        return ESP_OK;
     }
     else if (type.compare("sd_capacity") == 0) {
         httpd_resp_sendstr(req, std::to_string(getSDCardCapacity()).c_str());
-        return ESP_OK;        
+        return ESP_OK;
     }
     else if (type.compare("sd_sector_size") == 0) {
         httpd_resp_sendstr(req, std::to_string(getSDCardSectorSize()).c_str());
-        return ESP_OK;        
+        return ESP_OK;
     }
     else if (type.compare("sd_partition_alloc_size") == 0) {
         httpd_resp_sendstr(req, std::to_string(getSDCardPartitionAllocationSize()).c_str());
-        return ESP_OK;        
+        return ESP_OK;
     }
     else if (type.compare("sd_partition_size") == 0) {
         httpd_resp_sendstr(req, std::to_string(getSDCardPartitionSize()).c_str());
-        return ESP_OK;        
+        return ESP_OK;
     }
     else if (type.compare("sd_partition_free") == 0) {
         httpd_resp_sendstr(req, std::to_string(getSDCardFreePartitionSpace()).c_str());
-        return ESP_OK;        
+        return ESP_OK;
     }
     else if (type.compare("heap_total_free") == 0) {
         httpd_resp_sendstr(req, std::to_string(getESPHeapSizeTotalFree()).c_str());
-        return ESP_OK;        
+        return ESP_OK;
     }
     else if (type.compare("heap_internal_free") == 0) {
         httpd_resp_sendstr(req, std::to_string(getESPHeapSizeInternalFree()).c_str());
-        return ESP_OK;        
+        return ESP_OK;
     }
     else if (type.compare("heap_internal_largest_free") == 0) {
         httpd_resp_sendstr(req, std::to_string(getESPHeapSizeInternalLargestFree()).c_str());
-        return ESP_OK;        
+        return ESP_OK;
     }
     else if (type.compare("heap_internal_min_free") == 0) {
         httpd_resp_sendstr(req, std::to_string(getESPHeapSizeInternalMinFree()).c_str());
-        return ESP_OK;        
+        return ESP_OK;
     }
     else if (type.compare("heap_spiram_free") == 0) {
         httpd_resp_sendstr(req, std::to_string(getESPHeapSizeSPIRAMFree()).c_str());
-        return ESP_OK;        
+        return ESP_OK;
     }
     else if (type.compare("heap_spiram_largest_free") == 0) {
         httpd_resp_sendstr(req, std::to_string(getESPHeapSizeSPIRAMLargestFree()).c_str());
-        return ESP_OK;        
+        return ESP_OK;
     }
     else if (type.compare("heap_spiram_min_free") == 0) {
         httpd_resp_sendstr(req, std::to_string(getESPHeapSizeSPIRAMMinFree()).c_str());
-        return ESP_OK;        
+        return ESP_OK;
     }
     #ifdef TASK_ANALYSIS_ON
     else if (type.compare("task_info") == 0) {
@@ -417,52 +417,52 @@ esp_err_t handler_get_info(httpd_req_t *req)
         else {
             zw += "Task info:<br>E93: Allocation of TaskList buffer in PSRAM failed";
         }
-        
+
         httpd_resp_set_type(req, "text/html");
         httpd_resp_sendstr(req, zw.c_str());
-        return ESP_OK;        
+        return ESP_OK;
     }
     #else
     else if (type.compare("task_info") == 0) {
         httpd_resp_send_err(req, HTTPD_405_METHOD_NOT_ALLOWED, "E01: Service not compiled (#define TASK_ANALYSIS_ON)");
-        return ESP_FAIL;        
+        return ESP_FAIL;
     }
     #endif
     else if (type.compare("git_branch") == 0) {
         httpd_resp_sendstr(req, libfive_git_branch());
-        return ESP_OK;        
+        return ESP_OK;
     }
     else if (type.compare("git_tag") == 0) {
         httpd_resp_sendstr(req, libfive_git_version());
-        return ESP_OK;        
+        return ESP_OK;
     }
     else if (type.compare("git_revision") == 0) {
         httpd_resp_sendstr(req, libfive_git_revision());
-        return ESP_OK;        
+        return ESP_OK;
     }
     else if (type.compare("firmware_version") == 0) {
         httpd_resp_sendstr(req, getFwVersion().c_str());
-        return ESP_OK;        
+        return ESP_OK;
     }
     else if (type.compare("html_version") == 0) {
         httpd_resp_sendstr(req, getHTMLversion().c_str());
-        return ESP_OK;        
+        return ESP_OK;
     }
     else if (type.compare("build_time") == 0) {
         httpd_resp_sendstr(req, build_time());
-        return ESP_OK;        
+        return ESP_OK;
     }
     else if (type.compare("config_file_version") == 0) {
         httpd_resp_sendstr(req, std::to_string(getConfigFileVersion()).c_str());
-        return ESP_OK;        
+        return ESP_OK;
     }
     else if (type.compare("idf_version") == 0) {
         httpd_resp_sendstr(req, getIDFVersion().c_str());
-        return ESP_OK;        
+        return ESP_OK;
     }
     else {
         httpd_resp_send_err(req, HTTPD_404_NOT_FOUND, "E93: Parameter not found");
-        return ESP_FAIL;  
+        return ESP_FAIL;
     }
 }
 
@@ -476,13 +476,13 @@ esp_err_t handler_img_tmp(httpd_req_t *req)
     std::string filetosend(base_path);
 
     const char *filename = get_path_from_uri(filepath, base_path,
-                                             req->uri  + sizeof("/img_tmp/") - 1, sizeof(filepath));    
+                                             req->uri  + sizeof("/img_tmp/") - 1, sizeof(filepath));
     ESP_LOGD(TAG, "1 uri: %s, filename: %s, filepath: %s", req->uri, filename, filepath);
 
     filetosend = filetosend + "/img_tmp/" + std::string(filename);
     ESP_LOGD(TAG, "File to upload: %s", filetosend.c_str());
 
-    esp_err_t res = send_file(req, filetosend); 
+    esp_err_t res = send_file(req, filetosend);
     if (res != ESP_OK)
         return res;
 
@@ -502,7 +502,7 @@ esp_err_t handler_img_tmp_virtual(httpd_req_t *req)
     std::string filetosend(base_path);
 
     const char *filename = get_path_from_uri(filepath, base_path,
-                                             req->uri  + sizeof("/img_tmp/") - 1, sizeof(filepath));    
+                                             req->uri  + sizeof("/img_tmp/") - 1, sizeof(filepath));
     ESP_LOGD(TAG, "1 uri: %s, filename: %s, filepath: %s", req->uri, filename, filepath);
 
     filetosend = std::string(filename);
@@ -531,7 +531,7 @@ esp_err_t handler_main(httpd_req_t *req)
     std::string filetosend(base_path);
 
     const char *filename = get_path_from_uri(filepath, base_path,
-                                             req->uri - 1, sizeof(filepath));    
+                                             req->uri - 1, sizeof(filepath));
     ESP_LOGD(TAG, "1 uri: %s, filename: %s, filepath: %s", req->uri, filename, filepath);
 
     if ((strcmp(req->uri, "/") == 0))
@@ -555,7 +555,7 @@ esp_err_t handler_main(httpd_req_t *req)
         if (isSetSystemStatusFlag(SYSTEM_STATUS_PSRAM_BAD) ||
             isSetSystemStatusFlag(SYSTEM_STATUS_HEAP_TOO_SMALL) ||
             isSetSystemStatusFlag(SYSTEM_STATUS_SDCARD_CHECK_BAD) ||
-            isSetSystemStatusFlag(SYSTEM_STATUS_FOLDER_CHECK_BAD)) 
+            isSetSystemStatusFlag(SYSTEM_STATUS_FOLDER_CHECK_BAD))
         {
             LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "Critical error(s) occured, redirect to reduced web interface");
 
@@ -584,7 +584,7 @@ esp_err_t handler_main(httpd_req_t *req)
     }
 
     ESP_LOGD(TAG, "Filename: %s", filename);
-    
+
     ESP_LOGD(TAG, "File requested: %s", filetosend.c_str());
 
     if (!filename) {
@@ -615,19 +615,19 @@ httpd_handle_t start_webserver(void)
     config.core_id = 1; // previously -> 2023-01-02: 0, 2022-12-11: tskNO_AFFINITY;
     config.server_port = 80;
     config.ctrl_port = 32768;
-    config.max_open_sockets = 5; //20210921 --> previously 7   
-    config.max_uri_handlers = 20; // previously 42  
-    config.max_resp_headers = 8;                        
-    config.backlog_conn = 5;                        
-    config.lru_purge_enable = true; // this cuts old connections if new ones are needed.               
-    config.recv_wait_timeout = 15; // default: 5 20210924 --> previously 30              
-    config.send_wait_timeout = 15; // default: 5 20210924 --> previously 30                    
-    config.global_user_ctx = NULL;                        
-    config.global_user_ctx_free_fn = NULL;                
-    config.global_transport_ctx = NULL;                   
-    config.global_transport_ctx_free_fn = NULL;           
-    config.open_fn = NULL;                                
-    config.close_fn = NULL;                         
+    config.max_open_sockets = 5; //20210921 --> previously 7
+    config.max_uri_handlers = 20; // previously 42
+    config.max_resp_headers = 8;
+    config.backlog_conn = 5;
+    config.lru_purge_enable = true; // this cuts old connections if new ones are needed.
+    config.recv_wait_timeout = 15; // default: 5 20210924 --> previously 30
+    config.send_wait_timeout = 15; // default: 5 20210924 --> previously 30
+    config.global_user_ctx = NULL;
+    config.global_user_ctx_free_fn = NULL;
+    config.global_transport_ctx = NULL;
+    config.global_transport_ctx_free_fn = NULL;
+    config.open_fn = NULL;
+    config.close_fn = NULL;
     config.uri_match_fn = httpd_uri_match_wildcard;
 
     // Start the httpd server
@@ -647,7 +647,7 @@ void stop_webserver(httpd_handle_t server)
 }
 
 
-void disconnect_handler(void* arg, esp_event_base_t event_base, 
+void disconnect_handler(void* arg, esp_event_base_t event_base,
                                int32_t event_id, void* event_data)
 {
     httpd_handle_t* server = (httpd_handle_t*) arg;
@@ -659,7 +659,7 @@ void disconnect_handler(void* arg, esp_event_base_t event_base,
 }
 
 
-void connect_handler(void* arg, esp_event_base_t event_base, 
+void connect_handler(void* arg, esp_event_base_t event_base,
                             int32_t event_id, void* event_data)
 {
     httpd_handle_t* server = (httpd_handle_t*) arg;
@@ -671,12 +671,12 @@ void connect_handler(void* arg, esp_event_base_t event_base,
 
 
 void register_server_main_uri(httpd_handle_t server, const char *base_path)
-{ 
+{
     ESP_LOGI(TAG, "Registering URI handlers");
-    
+
     httpd_uri_t camuri = { };
     camuri.method    = HTTP_GET;
-    
+
     camuri.uri       = "/info";
     camuri.handler   = handler_get_info;
     camuri.user_ctx  = (void*) base_path;   // Pass server data as context

--- a/code/main/softAP.cpp
+++ b/code/main/softAP.cpp
@@ -163,8 +163,8 @@ esp_err_t test_handler(httpd_req_t *req)
 
 esp_err_t reboot_handlerAP(httpd_req_t *req)
 {
-#ifdef DEBUG_DETAIL_ON     
-    LogFile.WriteHeapInfo("handler_ota_update - Start");    
+#ifdef DEBUG_DETAIL_ON
+    LogFile.WriteHeapInfo("handler_ota_update - Start");
 #endif
     LogFile.WriteToFile(ESP_LOG_INFO, TAG, "Trigger reboot due to firmware update.");
     doRebootOTA();
@@ -174,13 +174,13 @@ esp_err_t reboot_handlerAP(httpd_req_t *req)
 
 esp_err_t config_ini_handler(httpd_req_t *req)
 {
-#ifdef DEBUG_DETAIL_ON     
-    LogFile.WriteHeapInfo("handler_ota_update - Start");    
+#ifdef DEBUG_DETAIL_ON
+    LogFile.WriteHeapInfo("handler_ota_update - Start");
 #endif
 
     LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "config_ini_handler");
     char _query[400];
-    char _valuechar[100];    
+    char _valuechar[100];
     std::string fn = "/sdcard/firmware/";
     std::string _task = "";
     std::string ssid = "";
@@ -197,7 +197,7 @@ esp_err_t config_ini_handler(httpd_req_t *req)
     if (httpd_req_get_url_query_str(req, _query, 400) == ESP_OK)
     {
         ESP_LOGD(TAG, "Query: %s", _query);
-        
+
         if (httpd_query_key_value(_query, "ssid", _valuechar, 100) == ESP_OK)
         {
             ESP_LOGD(TAG, "ssid is found: %s", _valuechar);
@@ -260,7 +260,7 @@ esp_err_t config_ini_handler(httpd_req_t *req)
     text += "; ssid: Name of WLAN network (mandatory), e.g. \"WLAN-SSID\"\n";
     text += "; password: Password of WLAN network (mandatory), e.g. \"PASSWORD\"\n\n";
     fputs(text.c_str(), configfilehandle);
-    
+
     if (ssid.length())
         ssid = "ssid = \"" + ssid + "\"\n";
     else
@@ -340,7 +340,7 @@ esp_err_t config_ini_handler(httpd_req_t *req)
 
     std::string zw = "ota without parameter - should not be the case";
     httpd_resp_set_hdr(req, "Access-Control-Allow-Origin", "*");
-    httpd_resp_send(req, zw.c_str(), zw.length()); 
+    httpd_resp_send(req, zw.c_str(), zw.length());
 
     ESP_LOGD(TAG, "end config.ini");
 

--- a/code/platformio.ini
+++ b/code/platformio.ini
@@ -13,7 +13,7 @@ src_dir = main
 default_envs = esp32cam
 
 [common:idf]
-build_flags = 
+build_flags =
     -D USE_ESP_IDF
 lib_deps =
 
@@ -21,15 +21,15 @@ lib_deps =
 extends = common:idf
 platform = platformio/espressif32 @ 6.3.2
 framework = espidf
-lib_deps = 
+lib_deps =
     ${common:idf.lib_deps}
-build_flags = 
+build_flags =
     ${common:idf.build_flags}
     -D USE_ESP32
     -D USE_ESP32_FRAMEWORK_ESP_IDF
 
 [flags:runtime]
-build_flags = 
+build_flags =
     -Wno-nonnull-compare
     -Wno-sign-compare
     -Wno-unused-but-set-variable
@@ -37,7 +37,7 @@ build_flags =
     -fno-exceptions
 
 [flags:clangtidy]
-build_flags = 
+build_flags =
     -Wall
     -Wextra
     -Wunreachable-code
@@ -55,7 +55,7 @@ build_flags =
 extends = common:esp32-idf
 board = esp32cam
 framework = espidf
-build_flags = 
+build_flags =
     ; ### Common flags:
     ${common:esp32-idf.build_flags}
 	${flags:runtime.build_flags}
@@ -76,14 +76,14 @@ monitor_filters = default, esp32_exception_decoder
 
 ; +++++++++++++++++++++++++++++++++++++++++++
 ; Use this environment if building locally
-; Include parameter tooltips to HTML parameter config file 
+; Include parameter tooltips to HTML parameter config file
 ; and hash to HTML files (caching)
 ; +++++++++++++++++++++++++++++++++++++++++++
 [env:esp32cam-localbuild]
 extends = env:esp32cam
-extra_scripts = post:scripts/localbuild.py # Add parameter tooltips to HTML page 
+extra_scripts = post:scripts/localbuild.py # Add parameter tooltips to HTML page
                                            # and hashes to all cached HTML files
-build_flags = 
+build_flags =
     ; ### Common flags:
     ${common:esp32-idf.build_flags}
 	${flags:runtime.build_flags}
@@ -97,9 +97,9 @@ build_flags =
 ; +++++++++++++++++++++++++++++++++++++++++++
 [env:esp32cam-task-analysis]
 extends = env:esp32cam
-; sdkconfig.esp32cam-task-analysis.defaults override some sdkconfig.defaults 
+; sdkconfig.esp32cam-task-analysis.defaults override some sdkconfig.defaults
 ; and enable debug analysis options
-build_flags = 
+build_flags =
     ; ### Hardware: Define board type + camera model
     ; ### (see 'include/defines.h' for definitions)
     -D ENV_BOARD_TYPE=1
@@ -121,8 +121,8 @@ build_flags =
 extends = env:esp32cam
 ; sdkconfig.esp32cam-debug.defaults override some sdkconfig.defaults
 ; and enable debug options and clangtidy
-build_flags = 
-    ; ### clangtidy build flags: 
+build_flags =
+    ; ### clangtidy build flags:
 	${flags:clangtidy.build_flags}
     ; ### Hardware: Define board type + camera model
     ; ### (see 'include/defines.h' for definitions)
@@ -163,8 +163,8 @@ build_flags =
 extends = common:esp32-idf
 board = seeed_xiao_esp32s3
 framework = espidf
-build_flags = 
-    ; ### common imported : 
+build_flags =
+    ; ### common imported :
     ${common:esp32-idf.build_flags}
 	${flags:runtime.build_flags}
     ; ### Hardware: Define board type + camera model
@@ -184,15 +184,15 @@ monitor_filters = default, esp32_exception_decoder
 
 ; +++++++++++++++++++++++++++++++++++++++++++
 ; Use this environment if building locally
-; Include parameter tooltips to HTML parameter config file 
+; Include parameter tooltips to HTML parameter config file
 ; and hash to HTML files (caching)
 ; +++++++++++++++++++++++++++++++++++++++++++
 [env:xiao-esp32s3-sense-localbuild]
 extends = env:xiao-esp32s3-sense
-extra_scripts = post:scripts/localbuild.py # Add parameter tooltips to HTML page 
+extra_scripts = post:scripts/localbuild.py # Add parameter tooltips to HTML page
                                            # and hashes to all cached HTML files
-build_flags = 
-    ; ### common imported : 
+build_flags =
+    ; ### common imported :
     ${common:esp32-idf.build_flags}
 	${flags:runtime.build_flags}
     ; ### Hardware: Define board type + camera model
@@ -205,9 +205,9 @@ build_flags =
 ; +++++++++++++++++++++++++++++++++++++++++++
 [env:xiao-esp32s3-sense-task-analysis]
 extends = env:xiao-esp32s3-sense
-; sdkconfig.xiao-esp32s3-sense-task-analysis.defaults override some sdkconfig.defaults 
+; sdkconfig.xiao-esp32s3-sense-task-analysis.defaults override some sdkconfig.defaults
 ; and enable debug analysis options
-build_flags = 
+build_flags =
     ; ### Hardware: Define board type + camera model
     ; ### (see 'include/defines.h' for definitions)
     -D ENV_BOARD_TYPE=2
@@ -229,8 +229,8 @@ build_flags =
 extends = env:xiao-esp32s3-sense
 ; sdkconfig.xiao-esp32s3-sense-debug.defaults override some sdkconfig.defaults
 ; and enable debug options and clangtidy
-build_flags = 
-    ; ### clangtidy build flags: 
+build_flags =
+    ; ### clangtidy build flags:
 	${flags:clangtidy.build_flags}
     ; ### Hardware: Define board type + camera model
     ; ### (see 'include/defines.h' for definitions)

--- a/code/scripts/localbuild.py
+++ b/code/scripts/localbuild.py
@@ -33,11 +33,11 @@ hash = str(round(time.time()*1000)) # timestamp in miliseconds
 for file in files:
     if not ".html" in file: # Skip non-HTML files
         continue
-    
+
     filename = os.getcwd() + "/" + file
     with open(filename) as file:
         content = file.read()
-    
+
     content = content.replace("$COMMIT_HASH", hash)
 
     with open(filename, 'w') as file:

--- a/code/sdkconfig.defaults
+++ b/code/sdkconfig.defaults
@@ -1,7 +1,7 @@
-################################################## 
+##################################################
 # Application specific and global configuration
 # Edit this file instead of sdkconfig.{board_type}!
-# After editing make sure to explicitly delete 
+# After editing make sure to explicitly delete
 # sdkconfig.{board_type} to apply your changes!
 ##################################################
 
@@ -138,7 +138,7 @@ CONFIG_FATFS_API_ENCODING_ANSI_OEM=y
 
 
 #
-# FreeRTOS 
+# FreeRTOS
 #
 CONFIG_FREERTOS_PLACE_FUNCTIONS_INTO_FLASH=n
 CONFIG_FREERTOS_PLACE_SNAPSHOT_FUNS_INTO_FLASH=n

--- a/code/sdkconfig.esp32cam.defaults
+++ b/code/sdkconfig.esp32cam.defaults
@@ -1,7 +1,7 @@
-################################################## 
+##################################################
 # Application and board specific configuration
 # Edit this file instead of sdkconfig.{board_type}!
-# After editing make sure to explicitly delete 
+# After editing make sure to explicitly delete
 # sdkconfig.{board_type} to apply your changes!
 ##################################################
 
@@ -25,7 +25,7 @@ CONFIG_PARTITION_TABLE_MD5=y
 
 #
 # Common ESP-related
-# 
+#
 CONFIG_ESP_ERR_TO_NAME_LOOKUP=n
 CONFIG_ESP_ALLOW_BSS_SEG_EXTERNAL_MEMORY=y
 

--- a/code/sdkconfig.xiao-esp32s3-sense.defaults
+++ b/code/sdkconfig.xiao-esp32s3-sense.defaults
@@ -1,7 +1,7 @@
-################################################## 
+##################################################
 # Application and board specific configuration
 # Edit this file instead of sdkconfig.{board_type}!
-# After editing make sure to explicitly delete 
+# After editing make sure to explicitly delete
 # sdkconfig.{board_type} to apply your changes!
 ##################################################
 
@@ -25,7 +25,7 @@ CONFIG_PARTITION_TABLE_MD5=y
 
 #
 # Common ESP-related
-# 
+#
 CONFIG_ESP_ERR_TO_NAME_LOOKUP=n
 CONFIG_ESP_ALLOW_BSS_SEG_EXTERNAL_MEMORY=n
 

--- a/code/test/components/jomjol-flowcontroll/CMakeLists.txt
+++ b/code/test/components/jomjol-flowcontroll/CMakeLists.txt
@@ -2,7 +2,7 @@ FILE(GLOB_RECURSE app_sources ${CMAKE_CURRENT_SOURCE_DIR}/*.*)
 
 idf_component_register(SRCS ${app_sources}
                     INCLUDE_DIRS "."
-                    REQUIRES esp_timer esp_wifi jomjol_tfliteclass jomjol_helper jomjol_controlcamera jomjol_mqtt 
+                    REQUIRES esp_timer esp_wifi jomjol_tfliteclass jomjol_helper jomjol_controlcamera jomjol_mqtt
                             jomjol_influxdb jomjol_fileserver_ota jomjol_image_proc jomjol_wlan unity)
 
 

--- a/code/test/components/jomjol-flowcontroll/test_PointerEvalAnalogToDigitNew.cpp
+++ b/code/test/components/jomjol-flowcontroll/test_PointerEvalAnalogToDigitNew.cpp
@@ -6,14 +6,14 @@ class UnderTestCNNGeneral : public ClassFlowCNNGeneral
     public:
         UnderTestCNNGeneral( ClassFlowAlignment *_flowalign, t_CNNType _cnntype) :
             ClassFlowCNNGeneral(_flowalign, "name", _cnntype) {};
-        
+
         using ClassFlowCNNGeneral::EvalAnalogToDigitTransition;
 };
 
 
 /**
- * @brief 
- * 
+ * @brief
+ *
  * Transition = x.8 - x.2 here no transition in the test cases.
  * Offset = dig=x.n, ana= n.y: no offset, because both "n" are the same
  */
@@ -59,14 +59,14 @@ void test_analogToDigit_Standard()
 void test_analogToDigit_Transition()
 {
     UnderTestCNNGeneral* undertest = new UnderTestCNNGeneral(nullptr, Digital100);
-    
+
     // https://github.com/jomjol/AI-on-the-edge-device/issues/921#issuecomment-1222672175
     // Default: dig=3.9, ana=9.7 => erg=3
     // Transition = yes
     // Zero crossing = no
     // Offset = no
     TEST_ASSERT_EQUAL_INT(3,  undertest->EvalAnalogToDigitTransition(39, 97, 9, 92));
-  
+
     // without reference
     // Default: dig=4.0, ana=9.1 => erg=4
     // Transition = yes
@@ -89,7 +89,7 @@ void test_analogToDigit_Transition()
     // Transition = yes
     // Zero crossing = no
     // Offset = no
-    // Special feature: 
+    // Special feature:
     TEST_ASSERT_EQUAL_INT(5,  undertest->EvalAnalogToDigitTransition(59, 94, 9, 92));
 
     // https://github.com/jomjol/AI-on-the-edge-device/issues/1110#issuecomment-1282168030

--- a/code/test/components/jomjol-flowcontroll/test_cnnflowcontroll.cpp
+++ b/code/test/components/jomjol-flowcontroll/test_cnnflowcontroll.cpp
@@ -6,7 +6,7 @@ class UnderTestCNN : public ClassFlowCNNGeneral
     using ClassFlowCNNGeneral::EvalAnalogNumber;
     using ClassFlowCNNGeneral::EvalDigitNumber;
     using ClassFlowCNNGeneral::ClassFlowCNNGeneral;
-    
+
 };
 
 // Helper to enter value as float (1.0 -> 10, 4.5 -> 45)
@@ -14,10 +14,10 @@ class UnderTestCNN : public ClassFlowCNNGeneral
 
 
 /**
- * @brief test if all combinations of digit 
+ * @brief test if all combinations of digit
  * evaluation are running correctly
  */
-void test_EvalAnalogNumber() 
+void test_EvalAnalogNumber()
 {
     UnderTestCNN undertest = UnderTestCNN(nullptr, "analog", Digital100);
 
@@ -37,16 +37,16 @@ void test_EvalAnalogNumber()
 
     printf("Test 4.5, 9\n");
     // the 4.5 (digital100) is not above 5  and the previous digit (analog) too (9.6)
-    TEST_ASSERT_EQUAL(4, undertest.EvalAnalogNumber(FLOAT_AS_INT(4.5), 9));    
+    TEST_ASSERT_EQUAL(4, undertest.EvalAnalogNumber(FLOAT_AS_INT(4.5), 9));
 
 }
 
 
 /**
- * @brief test if all combinations of digit 
+ * @brief test if all combinations of digit
  * evaluation are running correctly
- * 
- * -> Desciption for call undertest.EvalDigitNumber(int _value, int _valuePreviousNumber, int _resultPreviousNumber, 
+ *
+ * -> Desciption for call undertest.EvalDigitNumber(int _value, int _valuePreviousNumber, int _resultPreviousNumber,
  * bool isPreviousAnalog, float digitalAnalogTransitionStart)
  * @param _value: is the current ROI as int value with one decimal digit (e.g. 10 -> 1.0)
  * @param _valuePreviousNumber: is the last (lower) ROI as int with one decimal digit (e.g. 10 -> 1.0)
@@ -54,7 +54,7 @@ void test_EvalAnalogNumber()
  *                          example: 9.8, 9.9, 0.1
  *                          0.1 => 0 (resultPreviousNumber)
  *                          The 0 makes a 9.9 to 0 (resultPreviousNumber)
- *                          The 0 makes a 9.8 to 0 
+ *                          The 0 makes a 9.8 to 0
  * @param isPreviousAnalog: false/true if the last ROI is an analog or digit ROI (default=false == digit)
  *                              runs in special handling because analog is much less precise
  * @param analogDigitalTransitionStart  start of the transitionlogic begins on valuePreviousNumber (default=9.2)
@@ -95,25 +95,25 @@ void test_EvalDigitNumber()
     TEST_ASSERT_EQUAL(5, undertest.EvalDigitNumber(FLOAT_AS_INT(5.7), FLOAT_AS_INT(9.8), 9));
 
     // the 4.5 (digital100) is not above 5 and the previous digit (analog) not over zero (9.7) -> #define Digital_Transition_Area_Forward
-    TEST_ASSERT_EQUAL(4, undertest.EvalDigitNumber(FLOAT_AS_INT(4.5), FLOAT_AS_INT(9.8), 9));    
+    TEST_ASSERT_EQUAL(4, undertest.EvalDigitNumber(FLOAT_AS_INT(4.5), FLOAT_AS_INT(9.8), 9));
 
     // the 4.5 (digital100) is not above 5 and the previous digit (analog) over zero (0.7) -> #define Digital_Transition_Area_Predecessor
-    TEST_ASSERT_EQUAL(4, undertest.EvalDigitNumber(FLOAT_AS_INT(4.5), FLOAT_AS_INT(0.7), 0));   
+    TEST_ASSERT_EQUAL(4, undertest.EvalDigitNumber(FLOAT_AS_INT(4.5), FLOAT_AS_INT(0.7), 0));
 
     // the 4.5 (digital100) is not above 5 and the previous digit (analog) not over zero (9.5)
-    TEST_ASSERT_EQUAL(4, undertest.EvalDigitNumber(FLOAT_AS_INT(4.5), FLOAT_AS_INT(9.5), 9));    
+    TEST_ASSERT_EQUAL(4, undertest.EvalDigitNumber(FLOAT_AS_INT(4.5), FLOAT_AS_INT(9.5), 9));
 
     // 59.96889 - Pre: 58.94888
     // 8.6 : 9.8 : 6.7
     // the 8.6 (digital100) is not above 8 and the previous digit (analog) not over zero (9.8)
-    TEST_ASSERT_EQUAL(8, undertest.EvalDigitNumber(FLOAT_AS_INT(8.6), FLOAT_AS_INT(9.8), 9));    
+    TEST_ASSERT_EQUAL(8, undertest.EvalDigitNumber(FLOAT_AS_INT(8.6), FLOAT_AS_INT(9.8), 9));
 
     // pre = 9.9 (0.0 raw)
     // zahl = 1.8
-    TEST_ASSERT_EQUAL(2, undertest.EvalDigitNumber(FLOAT_AS_INT(1.8), FLOAT_AS_INT(9.0), 9));    
- 
-    // if a digit have an early transition and the pointer is < 9.0 
+    TEST_ASSERT_EQUAL(2, undertest.EvalDigitNumber(FLOAT_AS_INT(1.8), FLOAT_AS_INT(9.0), 9));
+
+    // if a digit have an early transition and the pointer is < 9.0
     // prev (pointer) = 6.2, but on digital readout = 6 (result is int parameter)
     // zahl = 4.6
-    TEST_ASSERT_EQUAL(4, undertest.EvalDigitNumber(FLOAT_AS_INT(4.6), FLOAT_AS_INT(6.2), 6)); 
+    TEST_ASSERT_EQUAL(4, undertest.EvalDigitNumber(FLOAT_AS_INT(4.6), FLOAT_AS_INT(6.2), 6));
 }

--- a/code/test/components/jomjol-flowcontroll/test_flow_postrocess_helper.cpp
+++ b/code/test/components/jomjol-flowcontroll/test_flow_postrocess_helper.cpp
@@ -8,7 +8,7 @@ static const char *TAG = "POSTPROC_TEST";
 
 UnderTestPost* setUpClassFlowPostprocessing(t_CNNType digType, t_CNNType anaType)
 {
-    
+
     ClassFlowCNNGeneral* _analog;
     ClassFlowCNNGeneral* _digit;
     std::vector<ClassFlow*> FlowControll;
@@ -20,18 +20,18 @@ UnderTestPost* setUpClassFlowPostprocessing(t_CNNType digType, t_CNNType anaType
 
     // Die Modeltypen werden gesetzt, da keine Modelle verwendet werden.
     _analog = new ClassFlowCNNGeneral(nullptr, "Analog", anaType);
-    
+
     _digit =  new ClassFlowCNNGeneral(nullptr, "Digit", digType);
 
     return new UnderTestPost(&FlowControll, _analog, _digit);
-  
+
 }
 
 
 std::string process_doFlow(UnderTestPost* _underTestPost)
 {
         std::string time;
- 
+
     // run test
     TEST_ASSERT_TRUE(_underTestPost->doFlow(time));
 
@@ -39,7 +39,7 @@ std::string process_doFlow(UnderTestPost* _underTestPost)
 }
 
 
-std::string process_doFlow(std::vector<float> analog, std::vector<float> digits, t_CNNType digType, 
+std::string process_doFlow(std::vector<float> analog, std::vector<float> digits, t_CNNType digType,
             bool checkConsistency, bool extendedResolution, int decimal_shift)
 {
     // setup the classundertest
@@ -57,7 +57,7 @@ std::string process_doFlow(std::vector<float> analog, std::vector<float> digits,
 }
 
 
-UnderTestPost* init_do_flow(std::vector<float> analog, std::vector<float> digits, t_CNNType digType, 
+UnderTestPost* init_do_flow(std::vector<float> analog, std::vector<float> digits, t_CNNType digType,
                 bool checkConsistency,  bool extendedResolution, int decimal_shift)
 {
     UnderTestPost* _undertestPost = setUpClassFlowPostprocessing(digType, Analogue100);
@@ -72,9 +72,9 @@ UnderTestPost* init_do_flow(std::vector<float> analog, std::vector<float> digits
             digitROI->name = name;
             if (digType != Digital)
                 digitROI->CNNResult = digits[i] * 10.0 + 0.1; // + 0.1 due to float to int rounding, will be truncated anyway
-            else 
+            else
                 digitROI->CNNResult = digits[i];
-            
+
             gen_digit->ROI.push_back(digitROI);
         }
     }
@@ -97,7 +97,7 @@ UnderTestPost* init_do_flow(std::vector<float> analog, std::vector<float> digits
     ESP_LOGD(TAG, "Setting up of ROIs completed.");
 
     _undertestPost->InitNUMBERS();
-   
+
     setConsitencyCheck(_undertestPost, checkConsistency);
     setExtendedResolution(_undertestPost, extendedResolution);
     setDecimalShift(_undertestPost, decimal_shift);
@@ -112,7 +112,7 @@ void SetFallbackValue(UnderTestPost* _underTestPost, double _fallbackValue)
 {
         if (_fallbackValue > 0) {
         ESP_LOGD(TAG, "fallbackValue=%f", _fallbackValue);
-        std::vector<NumberPost*>* NUMBERS = _underTestPost->GetNumbers();    
+        std::vector<NumberPost*>* NUMBERS = _underTestPost->GetNumbers();
         for (int _n = 0; _n < (*NUMBERS).size(); ++_n) {
             (*NUMBERS)[_n]->fallbackValue = _fallbackValue;
             (*NUMBERS)[_n]->isFallbackValueValid = true;
@@ -125,11 +125,11 @@ void SetFallbackValue(UnderTestPost* _underTestPost, double _fallbackValue)
 void setAllowNegatives(UnderTestPost* _underTestPost, bool _allowNegatives)
 {
         ESP_LOGD(TAG, "checkConsistency=true");
-        std::vector<NumberPost*>* NUMBERS = _underTestPost->GetNumbers();    
+        std::vector<NumberPost*>* NUMBERS = _underTestPost->GetNumbers();
         for (int _n = 0; _n < (*NUMBERS).size(); ++_n) {
             (*NUMBERS)[_n]->allowNegativeRates = _allowNegatives;
         }
-    
+
 }
 
 
@@ -137,7 +137,7 @@ void setConsitencyCheck(UnderTestPost* _underTestPost, bool _checkConsistency)
 {
         if (_checkConsistency) {
         ESP_LOGD(TAG, "checkConsistency=true");
-        std::vector<NumberPost*>* NUMBERS = _underTestPost->GetNumbers();    
+        std::vector<NumberPost*>* NUMBERS = _underTestPost->GetNumbers();
         for (int _n = 0; _n < (*NUMBERS).size(); ++_n) {
             (*NUMBERS)[_n]->checkDigitIncreaseConsistency = true;
         }
@@ -148,7 +148,7 @@ void setConsitencyCheck(UnderTestPost* _underTestPost, bool _checkConsistency)
 void setExtendedResolution(UnderTestPost* _underTestPost, bool _extendedResolution)
 {
     if (_extendedResolution ) {
-       std::vector<NumberPost*>* NUMBERS = _underTestPost->GetNumbers();    
+       std::vector<NumberPost*>* NUMBERS = _underTestPost->GetNumbers();
         for (int _n = 0; _n < (*NUMBERS).size(); ++_n) {
             (*NUMBERS)[_n]->isExtendedResolution = true;
         }
@@ -159,11 +159,11 @@ void setExtendedResolution(UnderTestPost* _underTestPost, bool _extendedResoluti
 void setDecimalShift(UnderTestPost* _underTestPost, int _decimal_shift)
 {
     if (_decimal_shift!=0) {
-        std::vector<NumberPost*>* NUMBERS = _underTestPost->GetNumbers();    
+        std::vector<NumberPost*>* NUMBERS = _underTestPost->GetNumbers();
         for (int _n = 0; _n < (*NUMBERS).size(); ++_n) {
             ESP_LOGD(TAG, "Setting decimal shift on number: %d to %d", _n, _decimal_shift);
             (*NUMBERS)[_n]->decimalShift = _decimal_shift;
-        }       
+        }
     }
 }
 
@@ -171,11 +171,11 @@ void setDecimalShift(UnderTestPost* _underTestPost, int _decimal_shift)
 void setAnalogdigitTransistionStart(UnderTestPost* _underTestPost, float _analogdigitTransistionStart)
 {
     if (_analogdigitTransistionStart!=0) {
-        std::vector<NumberPost*>* NUMBERS = _underTestPost->GetNumbers();    
+        std::vector<NumberPost*>* NUMBERS = _underTestPost->GetNumbers();
         for (int _n = 0; _n < (*NUMBERS).size(); ++_n) {
             ESP_LOGD(TAG, "Setting decimal shift on number: %d to %f", _n, _analogdigitTransistionStart);
-            (*NUMBERS)[_n]->analogDigitalTransitionStart = _analogdigitTransistionStart; 
-        }       
+            (*NUMBERS)[_n]->analogDigitalTransitionStart = _analogdigitTransistionStart;
+        }
     }
 }
 

--- a/code/test/components/jomjol-flowcontroll/test_flow_postrocess_helper.h
+++ b/code/test/components/jomjol-flowcontroll/test_flow_postrocess_helper.h
@@ -12,18 +12,18 @@ class UnderTestPost : public ClassFlowPostProcessing
     public:
         UnderTestPost(std::vector<ClassFlow*>* lfc, ClassFlowCNNGeneral *_analog, ClassFlowCNNGeneral *_digit)
             : ClassFlowPostProcessing::ClassFlowPostProcessing(lfc, _analog, _digit) {}
-        
+
         using ClassFlowPostProcessing::InitNUMBERS;
         using ClassFlowPostProcessing::setDecimalShift;
         using ClassFlowPostProcessing::flowAnalog;
-        using ClassFlowPostProcessing::flowDigit;    
+        using ClassFlowPostProcessing::flowDigit;
 
 };
 
 
 /**
  * @brief Set the Up Class Flow Postprocessing object
- * 
+ *
  * @param digType the model type of digits
  * @param anaType the model type of analog
  * @return UnderTestPost* a created, but not setted up testobject
@@ -33,7 +33,7 @@ UnderTestPost* setUpClassFlowPostprocessing(t_CNNType digType, t_CNNType anaType
 
 /**
  * @brief creates a testobject (including setup). AnalogType is Class100, because all analog types do the same.
- * 
+ *
  * @param analog the analog recognitions
  * @param digits the digit recognitions
  * @param digType the digit model type (default Digital100)
@@ -42,14 +42,14 @@ UnderTestPost* setUpClassFlowPostprocessing(t_CNNType digType, t_CNNType anaType
  * @param decimal_shift set property decimal_shift (Nachkommastellen, default = 0)
  * @return UnderTestPost* the created testobject
  */
-UnderTestPost* init_do_flow(std::vector<float> analog, std::vector<float> digits, t_CNNType digType = Digital100, 
+UnderTestPost* init_do_flow(std::vector<float> analog, std::vector<float> digits, t_CNNType digType = Digital100,
                             bool checkConsistency=false,  bool extendedResolution=false, int decimal_shift=0);
 
 
 
 /**
  * @brief creates a testobject an run do flow (including setup). AnalogType is Class100, because all analog types do the same.
- * 
+ *
  * @param analog the analog recognitions
  * @param digits the digit recognitions
  * @param digType the digit model type (default Digital100)
@@ -58,14 +58,14 @@ UnderTestPost* init_do_flow(std::vector<float> analog, std::vector<float> digits
  * @param decimal_shift set property decimal_shift (Nachkommastellen, default = 0)
  * @return std::string the return value of do_Flow is the Value as string
  */
-std::string process_doFlow(std::vector<float> analog, std::vector<float> digits, t_CNNType digType = Digital100, 
+std::string process_doFlow(std::vector<float> analog, std::vector<float> digits, t_CNNType digType = Digital100,
                             bool checkConsistency=false,  bool extendedResolution=false, int decimal_shift=0);
 
 
 
 /**
  * @brief run do_Flow on the testobject
- * 
+ *
  * @param _underTestPost the testobject
  * @return std::string the return value of do_Flow is the Value as string
  */
@@ -74,7 +74,7 @@ std::string process_doFlow(UnderTestPost* _underTestPost);
 
 /**
  * @brief Set the Consitency Check on testobject
- * 
+ *
  * @param _UnderTestPost the testobject
  * @param _checkConsistency true/false if checkConsistency
  */
@@ -83,7 +83,7 @@ void setConsitencyCheck(UnderTestPost* _UnderTestPost, bool _checkConsistency);
 
 /**
  * @brief Set the Pre Value on testobject
- * 
+ *
  * @param _UnderTestPost the testobject
  * @param _fallbackValue the last valid reading value
  */
@@ -92,46 +92,46 @@ void SetFallbackValue(UnderTestPost* _UnderTestPost, double _fallbackValue);
 
 /**
  * @brief Set the Extended Resolution on undertest
- * 
+ *
  * @param _UnderTestPost the testobject
- * @param _extendedResolution true/false 
+ * @param _extendedResolution true/false
  */
 void setExtendedResolution(UnderTestPost* _UnderTestPost, bool _extendedResolution);
 
 
 /**
  * @brief Set the Decimal Shift (Nachkomma)
- * 
- * @param _UnderTestPost the testobject  
+ *
+ * @param _UnderTestPost the testobject
  * @param decimal_shift  count of nachkomma
  */
 void setDecimalShift(UnderTestPost* _UnderTestPost, int decimal_shift);
 
 
 /**
- * @brief Set the Analogdigit Transistion Start 
- * 
- * @param _underTestPost the testobject  
+ * @brief Set the Analogdigit Transistion Start
+ *
+ * @param _underTestPost the testobject
  * @param _analogdigitTransistionStart the analog to digit transition start
  */
 void setAnalogdigitTransistionStart(UnderTestPost* _underTestPost, float _analogdigitTransistionStart);
 
 
 /**
- * @brief Set the allowNegatives in testobject 
- * 
- * @param _underTestPost the testobject  
+ * @brief Set the allowNegatives in testobject
+ *
+ * @param _underTestPost the testobject
  * @param _allowNegatives if should be set true or false
  */
 void setAllowNegatives(UnderTestPost* _underTestPost, bool _allowNegatives);
 
 
 /**
- * @brief Get the count of decimal places 
- * 
+ * @brief Get the count of decimal places
+ *
  * @param _underTestPost the testobject
  * @return Number of decimal places
- * 
+ *
  */
 int getDecimalPlaceCount(UnderTestPost* _underTestPost);
 

--- a/code/test/components/jomjol-flowcontroll/test_flow_pp_negative.cpp
+++ b/code/test/components/jomjol-flowcontroll/test_flow_pp_negative.cpp
@@ -3,7 +3,7 @@
 
 /**
  * @brief Testfall für Überprüfung allowNegatives
- * 
+ *
  */
 void testNegative()
 {
@@ -33,7 +33,7 @@ void testNegative()
     SetFallbackValue(underTestPost, fallbackValue_extended);
     result = process_doFlow(underTestPost);
     TEST_ASSERT_EQUAL_STRING("E91 Rate negative", underTestPost->getReadoutStatus().c_str());
-    TEST_ASSERT_EQUAL_STRING(to_stringWithPrecision(fallbackValue_extended, 
+    TEST_ASSERT_EQUAL_STRING(to_stringWithPrecision(fallbackValue_extended,
                                     getDecimalPlaceCount(underTestPost)).c_str(), result.c_str()); // Use Fallback value
     delete underTestPost;
 
@@ -45,7 +45,7 @@ void testNegative()
     SetFallbackValue(underTestPost, fallbackValue_extended);
     result = process_doFlow(underTestPost);
     TEST_ASSERT_EQUAL_STRING("E91 Rate negative", underTestPost->getReadoutStatus().c_str());
-    TEST_ASSERT_EQUAL_STRING(to_stringWithPrecision(fallbackValue_extended, 
+    TEST_ASSERT_EQUAL_STRING(to_stringWithPrecision(fallbackValue_extended,
                                     getDecimalPlaceCount(underTestPost)).c_str(), result.c_str()); // Use Fallback value
     delete underTestPost;
 
@@ -57,7 +57,7 @@ void testNegative()
     SetFallbackValue(underTestPost, fallbackValue_extended);
     result = process_doFlow(underTestPost);
     TEST_ASSERT_EQUAL_STRING("E91 Rate negative", underTestPost->getReadoutStatus().c_str());
-    TEST_ASSERT_EQUAL_STRING(to_stringWithPrecision(fallbackValue, 
+    TEST_ASSERT_EQUAL_STRING(to_stringWithPrecision(fallbackValue,
                                     getDecimalPlaceCount(underTestPost)).c_str(), result.c_str()); // Use Fallback value
     delete underTestPost;
 
@@ -78,7 +78,7 @@ void testNegative()
 
 /**
  * @brief Fehlerberichte aus Issues
- * 
+ *
  */
 void testNegative_Issues()
 {
@@ -87,14 +87,14 @@ void testNegative_Issues()
     std::vector<float> analogs = { };
     double fallbackValue_extended = 22018.080;
     double fallbackValue = 22018.08;
-    
+
     const char* expected = "22017.98";
 
     // https://github.com/jomjol/AI-on-the-edge-device/issues/2145#issuecomment-1461899094
     // extendResolution=false
     // value < fallbackValue
     // Prüfung eingeschaltet => Fehler
-    fallbackValue = 22018.08; // zu groß 
+    fallbackValue = 22018.08; // zu groß
     UnderTestPost* underTestPost = init_do_flow(analogs, digits, Digital100, false, false, -2);
     setAllowNegatives(underTestPost, false);
     SetFallbackValue(underTestPost, fallbackValue);

--- a/code/test/components/jomjol-flowcontroll/test_flowpostprocessing.cpp
+++ b/code/test/components/jomjol-flowcontroll/test_flowpostprocessing.cpp
@@ -2,22 +2,22 @@
 
 
 /**
- * 
+ *
  * @brief Testet die doFlow-Methode von ClassFlowPostprocessing
  * digits[] - enthält die liste der vom Model zurückgegebenen Ergebnisse (class100/cont) in der Reihenfolge von links nach rechts
  * analog[] - enthält die Liste der Zeiger vom Model, wie bei den digits
  * expected - enthält das erwartete Ergebnis, wobei der Dezimalpunkt genau zwischen digits und analog ist.
- * 
+ *
  */
 void test_doFlowPP()
-{    
+{
     /*
-        * 
+        *
         * digit1 = 1.2
         * digit2 = 6.7
         * analog1 = 9.5
         * analog2 = 8.4
-        * 
+        *
         * Das Ergebnis sollte "16.984" sein. Bzw. 16.98 ohne Extended true
         */
     std::vector<float> digits = { 1.2, 6.7};
@@ -29,8 +29,8 @@ void test_doFlowPP()
 
     /*
         * https://github.com/jomjol/AI-on-the-edge-device/issues/921#issue-1344032217
-        * 
-        * Das Ergebnis sollte "376529.6" sein. 
+        *
+        * Das Ergebnis sollte "376529.6" sein.
         */
     digits = { 3.0, 7.0, 6.0, 5.0, 2.5, 9.6};
     analogs = { 6.4};
@@ -40,7 +40,7 @@ void test_doFlowPP()
 
     /*
         * https://github.com/jomjol/AI-on-the-edge-device/issues/921#issuecomment-1220365920
-        * 
+        *
         * Das Ergebnis sollte "167734.6" sein. Bzw. 16.98 ohne Extended true
         */
     digits = { 1.1, 6.0, 7.0, 7.0, 3.0, 4.6};
@@ -51,7 +51,7 @@ void test_doFlowPP()
 
     /*
         * https://github.com/jomjol/AI-on-the-edge-device/issues/919
-        * 
+        *
         * Das Ergebnis sollte "58.96889" sein. Bzw. 16.98 ohne Extended true
         */
     digits = { 5.0, 8.6};
@@ -62,7 +62,7 @@ void test_doFlowPP()
 
     /*
         * https://github.com/jomjol/AI-on-the-edge-device/issues/921#issuecomment-1222672175
-        * 
+        *
         * Das Ergebnis sollte "376529.6" sein. Bzw. 16.98 ohne Extended true
         */
     digits = { 2.9, 7.0, 6.8, 9.9, 8.0, 3.9};
@@ -102,7 +102,7 @@ void test_doFlowPP()
     analogs = { 7.1, 4.8, 8.3};
     expected = "199.748";
     result = process_doFlow(analogs, digits);
-    TEST_ASSERT_EQUAL_STRING(expected, result.c_str());     
+    TEST_ASSERT_EQUAL_STRING(expected, result.c_str());
 }
 
 
@@ -167,7 +167,7 @@ void test_doFlowPP1()
     result = process_doFlow(analogs, digits);
     TEST_ASSERT_EQUAL_STRING(expected, result.c_str());
 
-    // Fehler bei V11.2.0 
+    // Fehler bei V11.2.0
     // https://github.com/jomjol/AI-on-the-edge-device/issues/921#issuecomment-1236119370
     digits = { 3.1, 9.1, 5.7};  // 9.1 führt zu falscher Erkennung eines unvollständigen Übergangs
     analogs = { 8.8, 6.1, 3.0, 2.0};
@@ -179,7 +179,7 @@ void test_doFlowPP1()
 
 void test_doFlowPP2()
 {
-    // Fehler bei V11.2.0 
+    // Fehler bei V11.2.0
     // https://github.com/jomjol/AI-on-the-edge-device/discussions/950#discussion-4338615
     std::vector<float> digits = { 1.0, 9.0, 9.0};  // Übergang wurde um 1 erhöht (200, statt 199)
     std::vector<float> analogs = { 7.1, 4.8, 8.3};
@@ -238,7 +238,7 @@ void test_doFlowPP2()
     analogs = { };
     expected = "123235";
     expected_extended= "123235.6";
-    
+
     // checkConsistency=true
     result = process_doFlow(analogs, digits, Digital100, false, false);
     TEST_ASSERT_EQUAL_STRING(expected, result.c_str());
@@ -252,7 +252,7 @@ void test_doFlowPP2()
     result = process_doFlow(analogs, digits, Digital100, false, true);
     TEST_ASSERT_EQUAL_STRING(expected_extended, result.c_str());
 
-    // Fehler bei V11.2.0 
+    // Fehler bei V11.2.0
     // https://github.com/jomjol/AI-on-the-edge-device/discussions/950#discussioncomment-3661982
     digits = { 3.0, 2.0, 4.1, 9.0, 4.0, 6.3, 9.2};  // 3249.459 als falsches Ergebnis
     analogs = { };
@@ -267,13 +267,13 @@ void test_doFlowPP2()
     result = process_doFlow(analogs, digits, Digital100, false, true, -3);
     TEST_ASSERT_EQUAL_STRING(expected_extended, result.c_str());
 
-    // Fehler bei V11.2.0 
+    // Fehler bei V11.2.0
     // https://github.com/jomjol/AI-on-the-edge-device/issues/1020#issue-1375648891
     digits = { 0.0, 2.0, 6.1, 9.2};  // 259.9227 als falsches Ergebnis
     analogs = { 9.0, 2.5, 2.9, 7.2};
     expected = "269.9227";
     expected_extended= "269.92272";
-    
+
     // extendResolution=true
     result = process_doFlow(analogs, digits, Digital100, false, false);
     TEST_ASSERT_EQUAL_STRING(expected, result.c_str());
@@ -282,13 +282,13 @@ void test_doFlowPP2()
     result = process_doFlow(analogs, digits, Digital100, false, true);
     TEST_ASSERT_EQUAL_STRING(expected_extended, result.c_str());
 
-    // Fehler bei V11.3.1 
+    // Fehler bei V11.3.1
     // https://github.com/jomjol/AI-on-the-edge-device/issues/1028#issuecomment-1250239481
     digits = { 1.1, 6.0, 9.1, 3.0, 5.3, 9.4};  // 169.3493 als falsches Ergebnis
     analogs = { 3.5};
     expected = "169.3593";
     expected_extended= "169.35935";
-    
+
     // extendResolution=false
     result = process_doFlow(analogs, digits, Digital100, false, false, -3);
     TEST_ASSERT_EQUAL_STRING(expected, result.c_str());
@@ -297,13 +297,13 @@ void test_doFlowPP2()
     result = process_doFlow(analogs, digits, Digital100, false, true, -3);
     TEST_ASSERT_EQUAL_STRING(expected_extended, result.c_str());
 
-    // Fehler bei V12.0.1 
+    // Fehler bei V12.0.1
     // Lokal
     digits = { 9.8, 9.8, 1.9, 0.9, 0.9, 9.9, 2.9, 4.8};  // 211.0345 als falsches Ergebnis
     analogs = { 5.5};
     expected = "211.0355";
     expected_extended= "211.03555";
-    
+
     // extendResolution=false
     result = process_doFlow(analogs, digits, Digital100, false, false, -3);
     TEST_ASSERT_EQUAL_STRING(expected, result.c_str());
@@ -312,13 +312,13 @@ void test_doFlowPP2()
     result = process_doFlow(analogs, digits, Digital100, false, true, -3);
     TEST_ASSERT_EQUAL_STRING(expected_extended, result.c_str());
 
-    // Fehler bei V12.0.1 
+    // Fehler bei V12.0.1
     // https://github.com/jomjol/AI-on-the-edge-device/issues/1110#issuecomment-1277425333
     digits = { 2.2, 4.5, 5.9};  // 245.938 als falsches Ergebnis
     analogs = { 9.4, 3.8, 8.6};
     expected = "245.938";
     expected_extended= "245.9386";
-    
+
     // extendResolution=false
     result = process_doFlow(analogs, digits, Digital100, false, false, 0);
     TEST_ASSERT_EQUAL_STRING(expected, result.c_str());
@@ -327,13 +327,13 @@ void test_doFlowPP2()
     result = process_doFlow(analogs, digits, Digital100, false, true, 0);
     TEST_ASSERT_EQUAL_STRING(expected_extended, result.c_str());
 
-    // Fehler bei V12.0.1 
+    // Fehler bei V12.0.1
     // https://github.com/jomjol/AI-on-the-edge-device/issues/1110#issuecomment-1277425333
     digits = { 2.2, 4.5, 5.9};  // 245.938 kein Fehler. Aber Grenzfall, deshalb mit als Test aufgenommen.
     analogs = { 9.4, 3.8, 8.6};
     expected = "245.938";
     expected_extended= "245.9386";
-    
+
     // extendResolution=false
     result = process_doFlow(analogs, digits, Digital100, false, false, 0);
     TEST_ASSERT_EQUAL_STRING(expected, result.c_str());
@@ -346,13 +346,13 @@ void test_doFlowPP2()
 
 void test_doFlowPP3()
 {
-    // Fehler bei V12.0.1 
+    // Fehler bei V12.0.1
     // https://github.com/jomjol/AI-on-the-edge-device/issues/1110#issuecomment-1265523710
     std::vector<float> digits = { 2.0, 4.0, 6.8};  // 246.2045 als falsches Ergebnis
     std::vector<float> analogs = { 2.2, 0.1, 4.5};
     const char* expected = "247.204";
     const char* expected_extended= "247.2045";
-    
+
     // extendResolution=false
     std::string result = process_doFlow(analogs, digits, Digital100, false, false, 0);
     TEST_ASSERT_EQUAL_STRING(expected, result.c_str());
@@ -361,14 +361,14 @@ void test_doFlowPP3()
     result = process_doFlow(analogs, digits, Digital100, false, true, 0);
     TEST_ASSERT_EQUAL_STRING(expected_extended, result.c_str());
 
-    
-    // Fehler bei V12.0.1 
+
+    // Fehler bei V12.0.1
     // https://github.com/jomjol/AI-on-the-edge-device/issues/1110#issue-1391153343
     digits = { 1.0, 4.0, 2.0};  // 141.9269 als falsches Ergebnis
     analogs = { 9.2, 2.5, 6.8, 9.0};
     expected = "142.9269";
     expected_extended= "142.92690";
-    
+
     // extendResolution=false
     result = process_doFlow(analogs, digits, Digital100, false, false, 0);
     TEST_ASSERT_EQUAL_STRING(expected, result.c_str());
@@ -378,14 +378,14 @@ void test_doFlowPP3()
     TEST_ASSERT_EQUAL_STRING(expected_extended, result.c_str());
 
 
-    // Fehler bei V12.0.1 
+    // Fehler bei V12.0.1
     // https://github.com/jomjol/AI-on-the-edge-device/issues/1110#issuecomment-1262626388
     digits = { 1.2, 6.8, 0.0, 0.0, 5.0, 2.8};  //170.05387 als falsches Ergebnis
     // letztes digit läuft mit analog zeiger mit. Hier nur lösbar mit setAnalogdigitTransistionStart=7.7
     analogs = { 8.7};
     expected = "170.0528";
     expected_extended= "170.05287";
-    
+
     // extendResolution=false
     UnderTestPost* undertestPost = init_do_flow(analogs, digits, Digital100, false, false, -3);
     setAnalogdigitTransistionStart(undertestPost, 7.7);
@@ -400,13 +400,13 @@ void test_doFlowPP3()
     TEST_ASSERT_EQUAL_STRING(expected_extended, result.c_str());
     delete undertestPost;
 
-    // Fehler bei rolling post V12.0.1 
+    // Fehler bei rolling post V12.0.1
     // lokal watermeter1
     digits = { 0.0, 0.0, 9.0, 1.0};  //90.88174 als falsches Ergebnis
     analogs = {9.0,  8.0, 1.8, 7.4};
     expected = "91.8817";
     expected_extended= "91.88174";
-    
+
     // extendResolution=false
     result = process_doFlow(analogs, digits, Digital100, false, false, 0);
     TEST_ASSERT_EQUAL_STRING(expected, result.c_str());
@@ -416,13 +416,13 @@ void test_doFlowPP3()
     TEST_ASSERT_EQUAL_STRING(expected_extended, result.c_str());
 
 
-    // Fehler bei rolling post V12.0.1 
+    // Fehler bei rolling post V12.0.1
     // lokal watermeter1
     digits = { 0.0, 0.0, 9.0, 1.9};  //91.38403 als falsches Ergebnis
     analogs = {3.6,  8.2, 3.2, 2.0};
     expected = "92.3832";
     expected_extended= "92.38320";
-    
+
     // extendResolution=false
     result = process_doFlow(analogs, digits, Digital100, false, false, 0);
     TEST_ASSERT_EQUAL_STRING(expected, result.c_str());
@@ -431,13 +431,13 @@ void test_doFlowPP3()
     result = process_doFlow(analogs, digits, Digital100, false, true, 0);
     TEST_ASSERT_EQUAL_STRING(expected_extended, result.c_str());
 
-    // Fehler  V11.3.0 
+    // Fehler  V11.3.0
     // https://github.com/jomjol/AI-on-the-edge-device/issues/1143#issue-1400807695
     digits = { 7.0, 4.0, 7.0, 2.0, 7.0, 5.4, 9.4};  // 7472.749 als falsches Ergebnis
     analogs = {};
     expected = "7472.759";
     expected_extended= "7472.7594";
-    
+
     // extendResolution=false
     result = process_doFlow(analogs, digits, Digital100, false, false, -3);
     TEST_ASSERT_EQUAL_STRING(expected, result.c_str());
@@ -446,13 +446,13 @@ void test_doFlowPP3()
     result = process_doFlow(analogs, digits, Digital100, false, true, -3);
     TEST_ASSERT_EQUAL_STRING(expected_extended, result.c_str());
 
-    // Fehler  V12.0.1 
+    // Fehler  V12.0.1
     // https://github.com/jomjol/AI-on-the-edge-device/issues/1143#issuecomment-1274434805
     digits = { 4.9, 6.9, 6.8};  // 576.8649 als falsches Ergebnis
     analogs = {8.6, 6.2, 5.0, 9.0};
     expected = "577.8649";
     expected_extended= "577.86490";
-    
+
     // extendResolution=false
     result = process_doFlow(analogs, digits, Digital100, false, false, 0);
     TEST_ASSERT_EQUAL_STRING(expected, result.c_str());
@@ -468,7 +468,7 @@ void test_doFlowPP3()
     analogs = {8.0};
     expected = "211.0358";
     expected_extended= "211.03580";
-    
+
     // extendResolution=false
     result = process_doFlow(analogs, digits, Digital100, false, false, -3);
     TEST_ASSERT_EQUAL_STRING(expected, result.c_str());
@@ -477,13 +477,13 @@ void test_doFlowPP3()
     result = process_doFlow(analogs, digits, Digital100, false, true, -3);
     TEST_ASSERT_EQUAL_STRING(expected_extended, result.c_str());
 
-    // Fehler  V12.0.1 
+    // Fehler  V12.0.1
     // https://github.com/jomjol/AI-on-the-edge-device/issues/1143#issuecomment-1281231468
     digits = {  1.0, 1.9, 6.0};  // 125.923 als falsches Ergebnis
     analogs = {9.3, 2.3, 3.1};
     expected = "126.923";
     expected_extended= "126.9231";
-    
+
     // extendResolution=false
     result = process_doFlow(analogs, digits, Digital100, false, false, 0);
     TEST_ASSERT_EQUAL_STRING(expected, result.c_str());
@@ -492,13 +492,13 @@ void test_doFlowPP3()
     result = process_doFlow(analogs, digits, Digital100, false, true, 0);
     TEST_ASSERT_EQUAL_STRING(expected_extended, result.c_str());
 
-    // Fehler  V12.0.1 
+    // Fehler  V12.0.1
     // https://github.com/jomjol/AI-on-the-edge-device/issues/1110#issuecomment-1282168030
     digits = {  3.0, 8.1, 5.9, 0.0, 5.0, 6.7};  // 386.05672 als richtiges Ergebnis. Letztes digit schein mit dem Analogzeiger mitzulaufen
     analogs = {7.2};
     expected = "386.0567";
     expected_extended= "386.05672";
-    
+
     // extendResolution=false
     result = process_doFlow(analogs, digits, Digital100, false, false, -3);
     TEST_ASSERT_EQUAL_STRING(expected, result.c_str());
@@ -507,14 +507,14 @@ void test_doFlowPP3()
     result = process_doFlow(analogs, digits, Digital100, false, true, -3);
     TEST_ASSERT_EQUAL_STRING(expected_extended, result.c_str());
 
-    // Fehler  V12.0.1 
+    // Fehler  V12.0.1
     // https://github.com/jomjol/AI-on-the-edge-device/issues/1110#issuecomment-1282168030
-    digits = {  1.2, 7.0, 1.2, 2.0, 4.0, 1.8};  // 171.24278 als falsches Ergebnis. 
+    digits = {  1.2, 7.0, 1.2, 2.0, 4.0, 1.8};  // 171.24278 als falsches Ergebnis.
     // Test ist nur erfolgreich mit Veränderung des AnalogdigitTransistionStart
     analogs = {7.8};
     expected = "171.2417";
     expected_extended= "171.24178";
-    
+
     // extendResolution=false
     undertestPost = init_do_flow(analogs, digits, Digital100, false, false, -3);
     setAnalogdigitTransistionStart(undertestPost, 7.7);
@@ -533,14 +533,14 @@ void test_doFlowPP3()
 
 void test_doFlowPP4()
 {
-    // Fehler  V13.0.4 
+    // Fehler  V13.0.4
     // https://github.com/jomjol/AI-on-the-edge-device/issues/1503#issuecomment-1343335855
-    std::vector<float> digits = {  0.0, 0.0, 6.9, 1.0, 6.6};  // 716.0199 als falsches Ergebnis. 
+    std::vector<float> digits = {  0.0, 0.0, 6.9, 1.0, 6.6};  // 716.0199 als falsches Ergebnis.
     // Test ist nur erfolgreich mit Veränderung des AnalogdigitTransistionStart
     std::vector<float> analogs = {9.9, 1.8, 6.6, 5.8};
     const char* expected = "717.0165";
     const char* expected_extended= "717.01658";
-    
+
     // extendResolution=false
     std::string result = process_doFlow(analogs, digits, Digital100, false, false);
     TEST_ASSERT_EQUAL_STRING(expected, result.c_str());
@@ -558,7 +558,7 @@ void test_doFlowPP5()
     std::vector<float> analogs = {9.9, 9.4};
     const char* expected = "99.99";
     const char* expected_extended= "99.994";
-    
+
     // extendResolution=false
     std::string result = process_doFlow(analogs, digits, Digital100, false, false);
     TEST_ASSERT_EQUAL_STRING(expected, result.c_str());
@@ -567,12 +567,12 @@ void test_doFlowPP5()
     result = process_doFlow(analogs, digits, Digital100, false, true);
     TEST_ASSERT_EQUAL_STRING(expected_extended, result.c_str());
 
-    
+
     digits = {1.0, 9.9, 9.8};  // wrong result: 199.994
     analogs = {9.9, 9.4};
     expected = "99.99";
     expected_extended= "99.994";
-    
+
     // extendResolution=false
     result = process_doFlow(analogs, digits, Digital100, false, false);
     TEST_ASSERT_EQUAL_STRING(expected, result.c_str());
@@ -585,7 +585,7 @@ void test_doFlowPP5()
     analogs = {9.9, 9.4};
     expected = "99.99";
     expected_extended= "99.994";
-    
+
     // extendResolution=false
     result = process_doFlow(analogs, digits, Digital100, false, false);
     TEST_ASSERT_EQUAL_STRING(expected, result.c_str());
@@ -598,7 +598,7 @@ void test_doFlowPP5()
     analogs = {9.9, 0.1};
     expected = "100.00";
     expected_extended= "100.001";
-    
+
     // extendResolution=false
     result = process_doFlow(analogs, digits, Digital100, false, false);
     TEST_ASSERT_EQUAL_STRING(expected, result.c_str());

--- a/code/test/test_suite_flowcontroll.cpp
+++ b/code/test/test_suite_flowcontroll.cpp
@@ -32,23 +32,23 @@ esp_err_t initSDCard();
 
 
 /**
- * @brief Startup the test. Like a test-suite 
+ * @brief Startup the test. Like a test-suite
  * all test methods must be called here
  */
 void task_UnityTesting(void *pvParameter)
 {
     vTaskDelay( 5000 / portTICK_PERIOD_MS ); // 5s delay to ensure established serial connection
-    
+
     UNITY_BEGIN();
         printf("BEGIN TESTING -------------------------------------------------------------\n");
         RUN_TEST(test_getReadoutRawString);
         printf("---------------------------------------------------------------------------\n");
-        
+
         RUN_TEST(test_EvalAnalogNumber);
         printf("---------------------------------------------------------------------------\n");
         RUN_TEST(test_EvalDigitNumber);
         printf("---------------------------------------------------------------------------\n");
-        
+
         RUN_TEST(testNegative_Issues);
         printf("---------------------------------------------------------------------------\n");
         RUN_TEST(testNegative);
@@ -87,7 +87,7 @@ extern "C" void app_main()
         ESP_LOGE(TAG, "Device init aborted");
         return; // Stop here, NVS is needed for proper operation
     }
-    
+
     // Init SD card
     // ********************************************
     if (ESP_OK != initSDCard()) {
@@ -125,11 +125,11 @@ esp_err_t initNVSFlash()
         ESP_ERROR_CHECK(nvs_flash_erase());
         ret = nvs_flash_init();
     }
-    
+
     if (ret != ESP_OK) {
         if (ret == ESP_ERR_NOT_FOUND) {
             ESP_LOGE(TAG, "NVS flash init failed. No NVS partition found");
-        } 
+        }
         else if (ret == ESP_ERR_NVS_NO_FREE_PAGES) {
             ESP_LOGE(TAG, "NVS flash init failed. No free NVS pages found");
         }
@@ -137,7 +137,7 @@ esp_err_t initNVSFlash()
             ESP_LOGE(TAG, "NVS flash init failed. Check error code");
         }
     }
-    
+
     return ret;
 }
 
@@ -184,7 +184,7 @@ esp_err_t initSDCard()
     // formatted in case when mounting fails.
     esp_vfs_fat_sdmmc_mount_config_t mount_config = {
         .format_if_mount_failed = false,
-        .max_files = 12,                         // previously -> 2022-09-21: 5, 2023-01-02: 7 
+        .max_files = 12,                         // previously -> 2022-09-21: 5, 2023-01-02: 7
         .allocation_unit_size = 16 * 1024,
         .disk_status_check_enable = 0
     };
@@ -200,7 +200,7 @@ esp_err_t initSDCard()
     if (ret != ESP_OK) {
         if (ret == ESP_FAIL) {
             ESP_LOGE(TAG, "Failed to mount FAT filesystem on SD card. Check SD card filesystem (only FAT supported) or try another card");
-        } 
+        }
         else if (ret == 263) { // Error code: 0x107 --> usually: SD not found
             ESP_LOGE(TAG, "SD card init failed. Check if SD card is properly inserted into SD card slot or try another card");
         }

--- a/sd-card/html/backup.html
+++ b/sd-card/html/backup.html
@@ -1,10 +1,10 @@
 <!DOCTYPE html>
-<html lang="en" xml:lang="en"> 
+<html lang="en" xml:lang="en">
 <head>
     <meta charset="UTF-8">
     <title>Backup/Restore Configuration</title>
 
-    <style>  
+    <style>
         h1 {font-size: 1.8em;}
         h2 {font-size: 1.5em; margin-block-start: 0.0em; margin-block-end: 0.2em;}
         h3 {font-size: 1.2em;}
@@ -21,7 +21,7 @@
             padding: 10px 5px;
             display: inline-block;
             border: 1px solid #ccc;
-            font-size: 16px; 
+            font-size: 16px;
         }
 
         .button {
@@ -53,9 +53,9 @@
 <script src="FileSaver.min.js?v=$COMMIT_HASH"></script>
 <script>
 
-function startBackup() {  
+function startBackup() {
     document.getElementById("progress").innerHTML = "Creating backup...<br>\n";
-    
+
     // Get hostname
     try {
         var xhttp = new XMLHttpRequest();
@@ -67,10 +67,10 @@ function startBackup() {
         setStatus("<span style=\"color: red\">Failed to fetch hostname: " + err.message + "!</span>");
         return;
     }
-    
+
     // get date/time
     var dateTime = new Date().toJSON().slice(0,10) + "_" + new Date().toJSON().slice(11,19).replaceAll(":", "-");
-    
+
     zipFilename = hostname + "_" + dateTime + ".zip";
     //console.log(zipFilename);
 
@@ -80,23 +80,23 @@ function startBackup() {
             var xhttp = new XMLHttpRequest();
             xhttp.open("GET", getDomainname() + "/fileserver/config/", false);
             xhttp.send();
-            
+
             var parser = new DOMParser();
             var content = parser.parseFromString(xhttp.responseText, 'text/html');    }
         catch(err) {
             setStatus("Failed to fetch files list: " + err.message);
             return;
         }
-        
+
         const list = content.querySelectorAll("a");
-        
+
         var urls = [];
-        
+
         for (a of list) {
             url = a.getAttribute("href");
             urls.push(getDomainname() + url);
         }
-        
+
         // Pack as zip and download
         try {
             backup(urls, zipFilename);
@@ -187,7 +187,7 @@ function startBackup() {
 
         var zip = new JSZip();
 
-        for (var i = 0; i < urls.length; i++) {        
+        for (var i = 0; i < urls.length; i++) {
             zip.file(getFilenameFromUrl(urls[i]), filesData[i]);
         }
 

--- a/sd-card/html/common.js
+++ b/sd-card/html/common.js
@@ -5,7 +5,7 @@
 */
 var DUTDeviceIP = "192.168.2.68";      // Set the IP of physical device under test
 var TestEnvironmentActive = false;
- 
+
 
 /* Returns the domainname with prepended protocol.
 * E.g. http://watermeter.fritz.box or http://192.168.1.5
@@ -15,7 +15,7 @@ function getDomainname()
     var domainname;
 
     // NOTE: The if condition cannot be used in this way: if (((host == "127.0.0.1") || (host == "localhost") || (host == ""))
-    //       This breaks access through a forwarded port: https://github.com/jomjol/AI-on-the-edge-device/issues/2681 
+    //       This breaks access through a forwarded port: https://github.com/jomjol/AI-on-the-edge-device/issues/2681
     if (window.location.hostname == "localhost") {
          console.log("Test environment active! Device IP: " + DUTDeviceIP);
          domainname = "http://" + DUTDeviceIP
@@ -42,17 +42,17 @@ function UpdatePage(_dosession = true){
     var zw = location.href;
     zw = zw.substring(0, zw.indexOf("?"));
     if (_dosession) {
-        window.location = zw + '?' + Math.floor((Math.random() * 1000000) + 1); 
+        window.location = zw + '?' + Math.floor((Math.random() * 1000000) + 1);
     }
     else {
-        window.location = zw; 
+        window.location = zw;
     }
 }
 
-        
+
 function LoadHostname()
 {
-    var url = getDomainname() + '/info?type=hostname';   
+    var url = getDomainname() + '/info?type=hostname';
 
     var xhttp = new XMLHttpRequest();
     xhttp.onreadystatechange = function() {
@@ -77,7 +77,7 @@ var webUiVersion = "";
 function LoadFwVersion()
 {
     var url = getDomainname() + '/info?type=firmware_version';
-    
+
     var xhttp = new XMLHttpRequest();
     xhttp.onreadystatechange = function() {
         if (this.readyState == 4) {
@@ -134,10 +134,10 @@ function compareVersions()
     arr = webUiVersion.split(" ");
     webUiHash = arr[arr.length - 1].substring(0, 7);
     //console.log("FW Hash: " + fWGitHash + ", Web UI Hash: " + webUiHash);
-    
+
     if (fWGitHash != webUiHash) {
-        firework.launch("Web interface version does not match the firmware version. " + 
-                        "It's strongly advised to use matching version. Check logs for more details.", 
+        firework.launch("Web interface version does not match the firmware version. " +
+                        "It's strongly advised to use matching version. Check logs for more details.",
                         'warning', 10000);
     }
 }

--- a/sd-card/html/data.html
+++ b/sd-card/html/data.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" xml:lang="en"> 
+<html lang="en" xml:lang="en">
 <head>
     <meta charset="UTF-8">
     <title>Data Viewer</title>
@@ -69,13 +69,13 @@
         </div>
         </div>
 
-<script src="common.js?v=$COMMIT_HASH"></script> 
-<script>  
+<script src="common.js?v=$COMMIT_HASH"></script>
+<script>
     function reload() {
         document.getElementById('data').innerHTML += "<b>Refreshing...</b>";
         window.scrollBy(0,document.body.scrollHeight);
         funcRequest(getDomainname() + '/data');
-    } 
+    }
 
     async function funcRequest(url){
         await fetch(url)

--- a/sd-card/html/doc_api_mqtt.html
+++ b/sd-card/html/doc_api_mqtt.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" xml:lang="en"> 
+<html lang="en" xml:lang="en">
 <head>
 	<meta charset="UTF-8">
 	<title>Documentation MQTT API</title>

--- a/sd-card/html/doc_api_mqtt.md
+++ b/sd-card/html/doc_api_mqtt.md
@@ -1,6 +1,6 @@
 ## Overview: MQTT API
 
-Offline data view is not built in. Use correct WebUI package or check online: 
+Offline data view is not built in. Use correct WebUI package or check online:
 <a href="https://github.com/Slider0007/AI-on-the-edge-device/tree/develop/docs/API/MQTT" target="_blank">MQTT API Docs</a><br>
 <br>
 NOTE: Please make sure using matching doumentation of version in use.

--- a/sd-card/html/doc_api_rest.html
+++ b/sd-card/html/doc_api_rest.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" xml:lang="en"> 
+<html lang="en" xml:lang="en">
 <head>
 	<meta charset="UTF-8">
 	<title>Documentation REST API</title>

--- a/sd-card/html/doc_api_rest.md
+++ b/sd-card/html/doc_api_rest.md
@@ -1,6 +1,6 @@
 ## Overview: REST API
 
-Offline data view is not built in. Use correct WebUI package or check online: 
+Offline data view is not built in. Use correct WebUI package or check online:
 <a href="https://github.com/Slider0007/AI-on-the-edge-device/tree/develop/docs/API/REST" target="_blank">REST API Docs</a><br>
 <br>
 NOTE: Please make sure using matching doumentation of version in use.

--- a/sd-card/html/edit_alignment.html
+++ b/sd-card/html/edit_alignment.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" xml:lang="en"> 
+<html lang="en" xml:lang="en">
 <head>
     <meta charset="UTF-8">
     <title>Alignment marker</title>
@@ -22,14 +22,14 @@
             padding: 3px 5px;
             display: inline-block;
             border: 1px solid #ccc;
-            font-size: 16px; 
+            font-size: 16px;
         }
 
         input[type=text] {
             padding: 3px 5px;
             display: inline-block;
             border: 1px solid #ccc;
-            font-size: 16px; 
+            font-size: 16px;
         }
 
         input:out-of-range {
@@ -41,7 +41,7 @@
             padding: 3px 5px;
             display: inline-block;
             border: 1px solid #ccc;
-            font-size: 16px; 
+            font-size: 16px;
             margin-right: 10px;
             min-width: 100px;
             vertical-align: middle;
@@ -69,45 +69,45 @@
             margin-right: 10px;
         }
     </style>
-   
+
     <script src="jquery-3.6.0.min.js?v=$COMMIT_HASH"></script>
     <link href="firework.css?v=$COMMIT_HASH" rel="stylesheet">
     <script src="firework.js?v=$COMMIT_HASH"></script>
 </head>
 
 <body style="font-family: arial; padding: 0px 10px; width:660px; max-width:660px;">
-	
+
 	<h2>Alignment Marker</h2>
     <details id="desc_details">
-        <summary><b>CLICK HERE</b> for usage description. Further documentation:   
+        <summary><b>CLICK HERE</b> for usage description. Further documentation:
             <a href=https://jomjol.github.io/AI-on-the-edge-device-docs/Alignment/ target=_blank>Alignment</a>
         </summary>
         <p>
-            The two alignment marker are required to correct possible small misalignments of the image. The possible misalignment 
-            is determined by an alignment alogrithm, which works according to the principle of SAD (sum of absolute differences). 
-            In a defined search window (expert parameter: Search Field X / Y), the alogrithm attempts to find the pattern specified 
-            by the alignment marker as congruently as possible. The derived correction factors are applied to the image for an 
+            The two alignment marker are required to correct possible small misalignments of the image. The possible misalignment
+            is determined by an alignment alogrithm, which works according to the principle of SAD (sum of absolute differences).
+            In a defined search window (expert parameter: Search Field X / Y), the alogrithm attempts to find the pattern specified
+            by the alignment marker as congruently as possible. The derived correction factors are applied to the image for an
             orientation correction (rotation around the image center and / or linear shift).<br>
 
-            When defining the marker position, please make sure that the distance between the two markers is as large as possible 
-            and that they are ideally arranged with respect to the center of the image, e.g. one marker to the left or top of the 
-            center and one to the right or bottom. The markers should not be placed over a variable part of the image, e.g. other 
+            When defining the marker position, please make sure that the distance between the two markers is as large as possible
+            and that they are ideally arranged with respect to the center of the image, e.g. one marker to the left or top of the
+            center and one to the right or bottom. The markers should not be placed over a variable part of the image, e.g. other
             ROIs or moving parts.<br>
 
-            The marker size should only be as large as necessary to depict a clean, high-contrast edge or contour. 
+            The marker size should only be as large as necessary to depict a clean, high-contrast edge or contour.
             (Tip: The smaller the marker area, the faster the processing).<br>
 
-            The histogram can be used to find image sections with high contrast or only to better evaluate the already marked areas. 
+            The histogram can be used to find image sections with high contrast or only to better evaluate the already marked areas.
             (Note: 'Default' alignment algorithm is using only RED color channel of image. Only 'High Accuracy' alignment algorithm
             is using all three channels (RGB) with the drawback of three times the processing time.)
         </p>
         <p>
-            Select an alignment marker area using drag and dop feature by mouse operation or by manually entering the coordinates 
+            Select an alignment marker area using drag and dop feature by mouse operation or by manually entering the coordinates
             and sizes in the respective fields. After palcement of a first alignment marker area, push the <b>"Update Marker"</b>
             button. Choose to second alignment marker with <b>"Marker"</b> dropdown and repeat the procedure.
         </p>
         <p>
-            After the definition of both alignment marker is completed don't forget to save the new configuration with the button 
+            After the definition of both alignment marker is completed don't forget to save the new configuration with the button
             <b>"Save And Apply"</b>. The new configuration gets automatically applied. No reboot is required.
         </p>
     </details>
@@ -121,7 +121,7 @@
             <col span="1" style="width: 30%;">
         </colgroup>
 	    <tr>
-            <td colspan="2" style="height:25px;">Marker: 
+            <td colspan="2" style="height:25px;">Marker:
                 <select id="marker_selection" name="marker_selection" onchange="onMarkerSelectionChanged()">
                 <option value="0" selected>Marker 1</option>
                 <option value="1" >Marker 2</option>
@@ -167,18 +167,18 @@
         <tr>
             <td style="vertical-align:bottom;"><b>Reference Image</b></td>
             <td><input disabled style="float:right" class="button" type="button" id="updatemarker"
-                    value="Update Marker" onclick="RequestMarkerCut()"></td>	
+                    value="Update Marker" onclick="RequestMarkerCut()"></td>
             <td ><input disabled style="font-weight:bold; float:right" class="button" type="submit"
                     name="saveroi" id="savemarker" onclick="SaveToConfig()" value="Save And Apply">
             </td>
-        </tr> 
+        </tr>
         <tr>
             <td style="padding-right:0px; margin-right:0px" colspan="4"><canvas style="max-width: 100%" id="canvas"></canvas></td>
         </tr>
     </table>
 
 
-<script src="common.js?v=$COMMIT_HASH"></script> 
+<script src="common.js?v=$COMMIT_HASH"></script>
 <script src="readconfigcommon.js?v=$COMMIT_HASH"></script>
 <script src="readconfigparam.js?v=$COMMIT_HASH"></script>
 <script>
@@ -191,8 +191,8 @@
             MarkerROI,
             param,
             domainname = getDomainname();
-    
-        
+
+
     function onMarkerSelectionChanged()
     {
         marker_selected = parseInt(document.getElementById("marker_selection").value);
@@ -204,18 +204,18 @@
     {
         if (!drag) {
             rect.w = document.getElementById("refdx").value;
-            rect.h = document.getElementById("refdy").value;                  
+            rect.h = document.getElementById("refdy").value;
             rect.startX = document.getElementById("refx").value;
-            rect.startY = document.getElementById("refy").value; 
+            rect.startY = document.getElementById("refy").value;
             MarkerROI[marker_selected]["x"] = document.getElementById("refx").value;
             MarkerROI[marker_selected]["y"] = document.getElementById("refy").value;
             MarkerROI[marker_selected]["dx"] = document.getElementById("refdx").value;
-            MarkerROI[marker_selected]["dy"] = document.getElementById("refdy").value;   
+            MarkerROI[marker_selected]["dy"] = document.getElementById("refdy").value;
         }
 
         // Validate ROI position
         ROIPositionValidation(MarkerROI[marker_selected]);
-        
+
         // Update ROI coordinates
         document.getElementById("refx").value = MarkerROI[marker_selected]["x"];
         document.getElementById("refy").value = MarkerROI[marker_selected]["y"];
@@ -230,15 +230,15 @@
     {
         firework.launch('Request marker update...', 'success', 2000, true);
         MarkerROI[marker_selected]["x"] = document.getElementById("refx").value;
-        MarkerROI[marker_selected]["y"] = document.getElementById("refy").value; 
+        MarkerROI[marker_selected]["y"] = document.getElementById("refy").value;
         MarkerROI[marker_selected]["dx"] = document.getElementById("refdx").value;
         MarkerROI[marker_selected]["dy"] = document.getElementById("refdy").value;
 
         let filetarget = MarkerROI[marker_selected]["name"].replace("/config/", "/img_tmp/");
-        let url = getDomainname() + "/editflow?task=cutref&in=/config/reference.jpg&out=" + filetarget + "&x=" + 
-                    MarkerROI[marker_selected]["x"] + "&y="  + MarkerROI[marker_selected]["y"] + "&dx=" + 
+        let url = getDomainname() + "/editflow?task=cutref&in=/config/reference.jpg&out=" + filetarget + "&x=" +
+                    MarkerROI[marker_selected]["x"] + "&y="  + MarkerROI[marker_selected]["y"] + "&dx=" +
                     MarkerROI[marker_selected]["dx"] + "&dy=" + MarkerROI[marker_selected]["dy"];
-        
+
         let xhttp = new XMLHttpRequest();
         xhttp.onreadystatechange = function() {
             if (this.readyState == 4) {
@@ -250,16 +250,16 @@
                 else if (this.status == 403) {
                     document.getElementById("savemarker").disabled = false;
                     firework.launch("Marker update rejected. Process not (yet) initialized. Repeat action or check logs.", 'warning', 5000);
-                    console.error("Marker update rejected. Process not (yet) initialized. Response status: " + this.status);  
+                    console.error("Marker update rejected. Process not (yet) initialized. Response status: " + this.status);
                 }
                 else if (this.status == 405) {
                     firework.launch("Marker update only possible in any IDLE state. Wait a few moments and repeat action. [" +
                                         xhttp.responseText.split(" | ")[1] + "]", 'warning', 3000, true);
                 }
                 else {
-                    firework.launch("Marker update failed (Response status: " + this.status + 
+                    firework.launch("Marker update failed (Response status: " + this.status +
                                     "). Repeat action or check logs.", 'danger', 30000);
-                    console.error("Marker update failed. Response status: " + this.status);  
+                    console.error("Marker update failed. Response status: " + this.status);
                 }
             }
         };
@@ -271,12 +271,12 @@
 
 
     function RefreshMarker()
-    {      
+    {
         // Load marker image
         var filenameurl = MarkerROI[marker_selected]["name"].replace("/config/", "/img_tmp/");
         var url = domainname + "/fileserver" + filenameurl + "?" + Math.floor((Math.random() * 1000000) + 1);
         document.getElementById("img_marker").src = loadImage(url, url).src; // No alternative image
-        
+
         // Execute after marker image gets loaded
         document.getElementById("img_marker").onload = function () {
             // Load x,y coordinates from config
@@ -295,7 +295,7 @@
 
             // Validate ROI position
             ROIPositionValidation(MarkerROI[marker_selected]);
-            
+
             // Update ROI coordinates
             document.getElementById("refx").value = MarkerROI[marker_selected]["x"];
             document.getElementById("refy").value = MarkerROI[marker_selected]["y"];
@@ -417,7 +417,7 @@
         rect.startX = e.pageX - zw.left;
         rect.startY = e.pageY - zw.top;
         document.getElementById("refx").value =  rect.startX;
-        document.getElementById("refy").value =  rect.startY;    
+        document.getElementById("refy").value =  rect.startY;
         drag = true;
     }
 
@@ -437,14 +437,14 @@
         document.getElementById("refdy").value = rect.h;
         document.getElementById("refx").value = rect.startX;
         document.getElementById("refy").value = rect.startY;
-        onValueManualChanged(); 
+        onValueManualChanged();
     }
 
 
     function mouseMove(e)
     {
         if (drag) {
-            zw = getCoords(this)        
+            zw = getCoords(this)
             rect.w = (e.pageX - zw.left) - rect.startX;
             rect.h = (e.pageY - zw.top) - rect.startY ;
             document.getElementById("refdx").value = rect.w;
@@ -457,19 +457,19 @@
             zw = getCoords(this);
             x = e.pageX - zw.left;
             y = e.pageY - zw.top;
-            
+
             context.lineWidth = 1;
             context.strokeStyle = "#00FF00";
-            context.beginPath(); 
+            context.beginPath();
             context.moveTo(0,y);
             context.lineTo(canvas.width, y);
             context.moveTo(x, 0);
             context.lineTo(x, canvas.height);
-            context.stroke();            
+            context.stroke();
         }
     }
 
-    
+
     function processImageHistogram(inImg)
     {
         const width = inImg.width;
@@ -477,7 +477,7 @@
         const src = new Uint32Array(inImg.data.buffer);
         const isValueHistogram = $("#HistogramTypeValue").prop('checked');
         const isRedChannel = $("#HistogramTypeRed").prop('checked');
-        
+
         let histBrightness = (new Array(256)).fill(0);
         let histR = (new Array(256)).fill(0);
         let histG = (new Array(256)).fill(0);
@@ -493,7 +493,7 @@
             histG[g]++;
             histB[b]++;
         }
-        
+
         let maxBrightness = 0;
         if (isValueHistogram) {
             for (let i = 1; i < 256; i++) {
@@ -515,7 +515,7 @@
                 }
             }
         }
-        
+
         const canvas = document.getElementById('canvasHistogram');
         const ctx = canvas.getContext('2d');
         let guideHeight = 4;
@@ -525,7 +525,7 @@
         ctx.lineWidth = dx;
         ctx.fillStyle = "#fff";
         ctx.fillRect(0, 0, canvas.width, canvas.height);
-        
+
         for (let i = 0; i < 256; i++) {
             let x = i * dx;
             if (isValueHistogram) {
@@ -535,7 +535,7 @@
                 ctx.moveTo(x, startY);
                 ctx.lineTo(x, startY - histBrightness[i] * dy);
                 ctx.closePath();
-                ctx.stroke(); 
+                ctx.stroke();
             }
             else {
                 // Red
@@ -544,7 +544,7 @@
                 ctx.moveTo(x, startY);
                 ctx.lineTo(x, startY - histR[i] * dy);
                 ctx.closePath();
-                ctx.stroke(); 
+                ctx.stroke();
                 if (!isRedChannel) {
                     // Green
                     ctx.strokeStyle = "rgba(0,210,0,0.5)";
@@ -552,7 +552,7 @@
                     ctx.moveTo(x, startY);
                     ctx.lineTo(x, startY - histG[i] * dy);
                     ctx.closePath();
-                    ctx.stroke(); 
+                    ctx.stroke();
                     // Blue
                     ctx.strokeStyle = "rgba(0,0,255,0.5)";
                     ctx.beginPath();
@@ -569,7 +569,7 @@
             ctx.moveTo(x, startY);
             ctx.lineTo(x, canvas.height);
             ctx.closePath();
-            ctx.stroke(); 
+            ctx.stroke();
         }
     }
 
@@ -581,8 +581,8 @@
         const img = document.getElementById(el);
 
         if (getTestEnvironmentActive()) // Avoid error in testing mode: The canvas has been tainted by cross-origin data.
-            img.crossOrigin = "Anonymous"; 
-        
+            img.crossOrigin = "Anonymous";
+
         canvas.width = img.width;
         canvas.height = img.height;
         context.drawImage(img, 0, 0);
@@ -609,14 +609,14 @@
             // Copy alignment marker to config folder
             FileCopyOnServer("/img_tmp/ref0.jpg", "/config/ref0.jpg", domainname, false);
             FileCopyOnServer("/img_tmp/ref1.jpg", "/config/ref1.jpg", domainname, false);
-            
+
             firework.launch('Save and apply configuration...', 'success', 2000, true);
             setTimeout(function() {
                 reload_config();
             }, 200);
         }
     }
-    
+
 
     /* hash #description open the details part of the page */
     function openDescription()
@@ -646,7 +646,7 @@
         loadCanvas(domainname + "/fileserver/config/reference.jpg?" + Math.floor((Math.random() * 1000000) + 1));
         canvas.addEventListener('mousedown', mouseDown, false);
         canvas.addEventListener('mouseup', mouseUp, false);
-        canvas.addEventListener('mousemove', mouseMove, false); 
+        canvas.addEventListener('mousemove', mouseMove, false);
     }
 
 

--- a/sd-card/html/edit_analog.html
+++ b/sd-card/html/edit_analog.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" xml:lang="en"> 
+<html lang="en" xml:lang="en">
 <head>
     <meta charset="UTF-8">
     <title>Analog ROI</title>
@@ -23,14 +23,14 @@
             padding: 3px 5px;
             display: inline-block;
             border: 1px solid #ccc;
-            font-size: 16px; 
+            font-size: 16px;
         }
 
         input[type=text] {
             padding: 3px 5px;
             display: inline-block;
             border: 1px solid #ccc;
-            font-size: 16px; 
+            font-size: 16px;
         }
 
         input:out-of-range {
@@ -42,7 +42,7 @@
             padding: 3px 5px;
             display: inline-block;
             border: 1px solid #ccc;
-            font-size: 16px; 
+            font-size: 16px;
             margin-right: 10px;
             min-width: 100px;
             max-width: 100%;
@@ -95,11 +95,11 @@
 
     <h2>Analog ROI</h2>
     <details id="desc_details">
-        <summary><b>CLICK HERE</b> for usage description. Further documentation: 
+        <summary><b>CLICK HERE</b> for usage description. Further documentation:
             <a href=https://jomjol.github.io/AI-on-the-edge-device-docs/ROI-Configuration/ target=_blank>ROI Configuration</a>
         </summary>
         <p>
-            <b>R</b>egion <b>O</b>f <b>I</b>nterest (ROI) for analog counter can be defined on this page. If no analog counter 
+            <b>R</b>egion <b>O</b>f <b>I</b>nterest (ROI) for analog counter can be defined on this page. If no analog counter
             needs to be processed, disable analog counter processing by deselecting <b>"Analog ROI Processing"</b>.
         </p>
         <p>
@@ -115,7 +115,7 @@
             <a href=https://jomjol.github.io/AI-on-the-edge-device-docs/ROI-Configuration/ target=_blank>ROI Configuration</a>.
             With the drop down <b>"ROI"</b> the different ROIs in the respective number sequence can be selected.<br>
 
-            To create new ROIs use <b>"New ROI"</b>. The new ROIs are automatically named uniquely and in ascending order 
+            To create new ROIs use <b>"New ROI"</b>. The new ROIs are automatically named uniquely and in ascending order
             (e.g. ana1, ana2, ...). Deleting a ROI between exisitung ones will rename the remaining ROIs in ascending order
             without keeping any naming gap.
         </p>
@@ -124,10 +124,10 @@
             The position in the number sequence can be changed with the buttons <b>"Move Lower"</b> and <b>"Move Higher"</b>.
             The multiplication factor which is shown below the ROI drop down is the multiplication factor of pure position/order
             in number sequence and the factor right-hand side to this is the additionally corrected by decimal shift setting
-            (expert parameter: Decimal Shift, default: 0). 
+            (expert parameter: Decimal Shift, default: 0).
         </p>
         <p>
-            After the definition of analog ROIs is completed don't forget to save the new configuration with the button 
+            After the definition of analog ROIs is completed don't forget to save the new configuration with the button
             <b>"Save And Apply"</b>. The new configuration gets automatically applied. No reboot is required.
         </p>
     </details>
@@ -165,7 +165,7 @@
                 </select>
             </td>
             <td><input class="button" type="submit" id="newSequence" name="newSequence" value="New" onclick="onClickNewSequence()"></td>
-            <td><input class="button" type="submit" id="renameSequence" name="renameSequence" value="Rename" onclick="onClickRenameSequence()"></td> 
+            <td><input class="button" type="submit" id="renameSequence" name="renameSequence" value="Rename" onclick="onClickRenameSequence()"></td>
             <td><input class="button" type="submit" id="deleteSequence" name="deleteSequence" value="Delete" onclick="onClickDeleteSequence()"></td>
         </tr>
     </table>
@@ -185,14 +185,14 @@
             <td><input class="button" type="submit" id="newROI" name="newROI" onclick="onClickNewROI()" value="New"></td>
             <td><input class="button" type="submit" id="deleteROI" name="deleteROI" onclick="onClickDeleteROI()" value="Delete"></td>
         </tr>
-        <tr>       
+        <tr>
             <td class="multiplier">Multiplier: <output id="multiplier" name="multiplier"></output><br>
                 (only based on order)
             </td>
             <td class="multiplier">Multiplier: <output id="multiplier_decshift" name="multiplier_decshift"></output><br>
                 (order + decimal shift: <output id="decimalShift" name="decimalShift"></output>)
             </td>
-            <td><input class="button" type="submit" id="moveROIHigher" onclick="onClickMoveROIHigher()" value="Move Higher"></td> 
+            <td><input class="button" type="submit" id="moveROIHigher" onclick="onClickMoveROIHigher()" value="Move Higher"></td>
             <td><input class="button" type="submit" id="moveROILower" onclick="onClickMoveROILower()" value="Move Lower"></td>
         </tr>
     </table>
@@ -204,17 +204,17 @@
             <col span="1" style="width: 62%;">
         </colgroup>
         <tr>
-            <td>x: <input type="number" name="refx" id="refx" min=1 step=1 onchange="onValueManualChanged()" 
-                        oninput="(!validity.rangeUnderflow||(value=1));"></td>	  
-            <td>Δx: <input type="number" name="refdx" id="refdx" min=1 step=1 onchange="onValueManualChangedDx()" 
+            <td>x: <input type="number" name="refx" id="refx" min=1 step=1 onchange="onValueManualChanged()"
+                        oninput="(!validity.rangeUnderflow||(value=1));"></td>
+            <td>Δx: <input type="number" name="refdx" id="refdx" min=1 step=1 onchange="onValueManualChangedDx()"
                         oninput="(!validity.rangeUnderflow||(value=1));"></td>
             <td><input type="checkbox" id="lockAspectRatio" name="lockAspectRatio" value="1" onclick="onClickLockAspectRatio()" checked>
                             <label for="lockAspectRatio"> Lock aspect ratio </label></td>
         </tr>
         <tr>
-            <td>y: <input type="number" name="refy" id="refy" min=1 step=1 onchange="onValueManualChanged()" 
-                        oninput="(!validity.rangeUnderflow||(value=1));"></td>	
-            <td>Δy: <input type="number" name="refdy" id="refdy" min=1 step=1 onchange="onValueManualChanged()" 
+            <td>y: <input type="number" name="refy" id="refy" min=1 step=1 onchange="onValueManualChanged()"
+                        oninput="(!validity.rangeUnderflow||(value=1));"></td>
+            <td>Δy: <input type="number" name="refdy" id="refdy" min=1 step=1 onchange="onValueManualChanged()"
                         oninput="(!validity.rangeUnderflow||(value=1));"></td>
             <td><input type="checkbox" id="lockSizes" name="lockSizes" value="1" onclick="onClickLockSizes()" checked>
                             <label for="lockSizes"> Synchronize Δx and Δy</label></td>
@@ -238,7 +238,7 @@
         </colgroup>
         <tr>
             <td colspan="3" style="vertical-align: bottom;"><b>Reference Image</b></td>
-            <td><input disabled style="font-weight:bold;" class="button" type="submit" id="saveconfig" name="saveconfig" 
+            <td><input disabled style="font-weight:bold;" class="button" type="submit" id="saveconfig" name="saveconfig"
                         onclick="SaveToConfig()" value="Save And Apply"></td>
         </tr>
         <tr>
@@ -247,10 +247,10 @@
     </table>
 
 
-<script src="common.js?v=$COMMIT_HASH"></script> 
+<script src="common.js?v=$COMMIT_HASH"></script>
 <script src="readconfigcommon.js?v=$COMMIT_HASH"></script>
-<script src="readconfigparam.js?v=$COMMIT_HASH"></script>  
-    
+<script src="readconfigparam.js?v=$COMMIT_HASH"></script>
+
 <script>
     var canvas = document.getElementById('canvas'),
         context = canvas.getContext('2d'),
@@ -269,12 +269,12 @@
     function EnDisableAnalog()
     {
         isEnabled = document.getElementById("Category_Analog_enabled").checked;
-        
+
         sah1(document.getElementById("div1"), !isEnabled);
-        
+
         param_category["Analog"]["enabled"] = isEnabled;
         document.getElementById("saveconfig").disabled = false;
-        
+
         if (isEnabled) {
             RefreshROI();
         }
@@ -336,7 +336,7 @@
     function removeNumber(){
         if (confirm("The entire number sequence will be removed (digit + analog parts). " +
                     "To remove single ROI of the number sequence, use \"Delete ROI\" instead.\n" +
-                    "Do you really want to proceed?")) 
+                    "Do you really want to proceed?"))
         {
             var sel_sequence = document.getElementById("SequenceSelect");
             var sequence_name = sel_sequence.options[sel_sequence.selectedIndex].text;
@@ -344,7 +344,7 @@
             if (erg != "")
                 firework.launch(erg, 'danger', 30000);
             RefreshSequences();
-        }	    
+        }
     }
 
 
@@ -388,7 +388,7 @@
         }
 
         if (ROIInfo.length > 0)
-            erg = CreateROI(sequence_name, "analog", roi_index, roi_name, 15, 30, 
+            erg = CreateROI(sequence_name, "analog", roi_index, roi_name, 15, 30,
                             ROIInfo[roi_selected]["dx"], ROIInfo[roi_selected]["dy"], ROIInfo[roi_selected]["CCW"]=="true");
         else
             erg = CreateROI(sequence_name, "analog", roi_index, roi_name, 15, 30, 30, 30, false);
@@ -453,7 +453,7 @@
     function onClickLockSizes()
     {
         lockSizes = document.getElementById("lockSizes").checked;
-        RefreshROI(); 
+        RefreshROI();
     }
 
 
@@ -469,7 +469,7 @@
             ROIInfo[roi_selected]["CCW"] = "true";
         else
             ROIInfo[roi_selected]["CCW"] = "false";
-        
+
         RefreshROI();
     }
 
@@ -490,7 +490,7 @@
             }
 
             rect.startX = document.getElementById("refx").value;
-            rect.startY = document.getElementById("refy").value; 
+            rect.startY = document.getElementById("refy").value;
 
             RefreshDraw();
         }
@@ -515,8 +515,8 @@
             }
 
             rect.startX = document.getElementById("refx").value;
-            rect.startY = document.getElementById("refy").value; 
-            RefreshDraw();            
+            rect.startY = document.getElementById("refy").value;
+            RefreshDraw();
         }
         RefreshROI();
         document.getElementById("saveconfig").disabled = false;
@@ -561,10 +561,10 @@
         else if (CategoryInfo["Analog"]["enabled"] == true && CategoryInfo["Digits"]["enabled"] == false) { // Only Analog
             multiplier = ROIInfo.length - 1 - roi_selected;
             multiplier_decshift = fixedDecimals_decshift = multiplier + Number(decimalShift);
-            
+
             if (multiplier_decshift > 0)
                 fixedDecimals_decshift = 0;
-            
+
             if (fixedDecimals_decshift < 0) {
                 fixedDecimals_decshift = -1 * fixedDecimals_decshift;
             }
@@ -589,7 +589,7 @@
             var option = document.createElement("option");
             option.text = NumberSequence[i]["name"];
             option.value = i;
-            sel_sequence.add(option); 
+            sel_sequence.add(option);
 
             if (typeof _sel !== 'undefined') {
                 if (NumberSequence[i]["name"] == _sel)
@@ -617,18 +617,18 @@
             firework.launch('Analog ROI processing is disabled. Activate with checkbox if needed', 'warning', 5000);
             return;
         }
-        
+
         var sel_roi = document.getElementById("ROISelect");
 
         if (ROIInfo.length == 0) {
             firework.launch('No analog ROIs defined in selected number sequence', 'warning', 5000);
             document.getElementById("newROI").disabled = false;
             document.getElementById("deleteROI").disabled = true;
-            
+
             document.getElementById("ROISelect").disabled = true;
             sel_roi.selectedIndex = 0;
             sel_roi.options[sel_roi.selectedIndex].text = "N/A";
-            
+
             document.getElementById("multiplier").style.display = "none";
             document.getElementById("multiplier_decshift").style.display = "none";
             document.getElementById("refx").disabled = true;
@@ -662,10 +662,10 @@
             while (sel_roi.length){
                 sel_roi.remove(0);
             }
-            
+
             if (roi_selected > ROIInfo.length)
                 roi_selected = ROIInfo.length-1;
-            
+
             for (var i = 0; i < ROIInfo.length; ++i){
                 var option = document.createElement("option");
                 option.text = ROIInfo[i]["name"];
@@ -678,7 +678,7 @@
 
                 ROIPositionValidation(ROIInfo[i]);
             }
-            sel_roi.selectedIndex = roi_selected; 
+            sel_roi.selectedIndex = roi_selected;
         }
 
         document.getElementById("moveROIHigher").disabled = false;
@@ -692,15 +692,15 @@
         }
 
         ShowMultiplier();
-        
+
         document.getElementById("lockAspectRatio").checked = lockAspectRatio;
         document.getElementById("lockSizes").checked = lockSizes;
         document.getElementById("CCW").checked = ROIInfo[roi_selected]["CCW"] == "true";
-        
+
         document.getElementById("refx").value = ROIInfo[roi_selected]["x"];
-        document.getElementById("refy").value = ROIInfo[roi_selected]["y"];  
-        document.getElementById("refdx").value = ROIInfo[roi_selected]["dx"];  
-        document.getElementById("refdy").value = ROIInfo[roi_selected]["dy"];  
+        document.getElementById("refy").value = ROIInfo[roi_selected]["y"];
+        document.getElementById("refdx").value = ROIInfo[roi_selected]["dx"];
+        document.getElementById("refdy").value = ROIInfo[roi_selected]["dy"];
         rect.startX = ROIInfo[roi_selected]["x"];
         rect.startY = ROIInfo[roi_selected]["y"];
         rect.w = ROIInfo[roi_selected]["dx"];
@@ -716,7 +716,7 @@
         if (ROIInfo.length > 1) {
             for (var i = 1; i < (ROIInfo.length); ++i) { // 2nd .. last ROI
                 if (parseInt(ROIInfo[i].dx) != parseInt(ROIInfo[0].dx) ||
-                    parseInt(ROIInfo[i].dy) != parseInt(ROIInfo[0].dy)) { 
+                    parseInt(ROIInfo[i].dy) != parseInt(ROIInfo[0].dy)) {
                     all_dx_dy_Identical = false;
                     break;
                 }
@@ -875,24 +875,24 @@
                         var dx = parseInt(ROIInfo[i].dx) + parseInt(lw);
                         var dy = parseInt(ROIInfo[i].dy) + parseInt(lw);
                         context.strokeRect(x0, y0, dx, dy);
-                        
+
                         if (ROIInfo[i]["CCW"] != "true")
                             drawTextBG(context, ROIInfo[i]["name"], x0+dx/2-0.5, parseInt(ROIInfo[i].y), parseInt(rect.h), 2, false);
                         else
                             drawTextBG(context, ROIInfo[i]["name"] + " (CCW)", x0+dx/2-0.5, parseInt(ROIInfo[i].y), parseInt(rect.h), 2, false);
-                        
+
                         lw = 1;
                         var x0 = parseInt(ROIInfo[i].x) - parseInt(lw/2);
                         var y0 = parseInt(ROIInfo[i].y) - parseInt(lw/2);
                         var dx = parseInt(ROIInfo[i].dx) + parseInt(lw);
                         var dy = parseInt(ROIInfo[i].dy) + parseInt(lw);
-                        context.strokeRect(x0, y0, dx, dy); 
+                        context.strokeRect(x0, y0, dx, dy);
 
                         context.lineWidth = lw;
                         context.beginPath();
                         //context.arc(x0+dx/2, y0+dy/2, dx/2, 0, 2 * Math.PI); -> use ellispe instead; fix https://github.com/jomjol/AI-on-the-edge-device/issues/2403
                         context.ellipse(x0+dx/2, y0+dy/2, dx/2, dy/2, 0, 0, 2 * Math.PI);
-                        
+
                         context.moveTo(x0+dx/2, y0);
                         context.lineTo(x0+dx/2, y0+dy);
                         context.moveTo(x0, y0+dy/2);
@@ -924,8 +924,8 @@
             context.lineTo(x0+dx/2, y0+dy);
             context.moveTo(x0, y0+dy/2);
             context.lineTo(x0+dx, y0+dy/2);
-            context.stroke();   
-            
+            context.stroke();
+
             ROIInfo[roi_selected]["x"] = rect.startX;
             ROIInfo[roi_selected]["y"] = rect.startY;
             ROIInfo[roi_selected]["dx"] = rect.w;
@@ -933,7 +933,7 @@
         }
     }
 
-    
+
     function getCoords(elem) // crossbrowser version
     {
         var box = elem.getBoundingClientRect();
@@ -955,7 +955,7 @@
         rect.startX = e.pageX - zw.left;
         rect.startY = e.pageY - zw.top;
         document.getElementById("refx").value =  rect.startX;
-        document.getElementById("refy").value =  rect.startY;    
+        document.getElementById("refy").value =  rect.startY;
         drag = true;
     }
 
@@ -975,14 +975,14 @@
         document.getElementById("refdy").value = rect.h;
         document.getElementById("refx").value = rect.startX;
         document.getElementById("refy").value = rect.startY;
-        RefreshROI();    
+        RefreshROI();
     }
 
 
     function mouseMove(e)
     {
         if (drag) {
-            zw = getCoords(this)        
+            zw = getCoords(this)
 
             if (ROIInfo.length == 0) {
                 return;
@@ -1006,15 +1006,15 @@
             zw = getCoords(this);
             x = e.pageX - zw.left;
             y = e.pageY - zw.top;
-            
+
             context.lineWidth = 1;
             context.strokeStyle = "#00FF00";
-            context.beginPath(); 
+            context.beginPath();
             context.moveTo(0,y);
             context.lineTo(canvas.width, y);
             context.moveTo(x, 0);
             context.lineTo(x, canvas.height);
-            context.stroke();            
+            context.stroke();
         }
     }
 
@@ -1060,7 +1060,7 @@
     function loadConfigData()
     {
         ParseConfig();
-        param = getConfigParameters(); 
+        param = getConfigParameters();
         param_category = getConfigCategory();
 
         RefreshSequences();
@@ -1074,7 +1074,7 @@
     function init()
     {
         openDescription();
-        
+
         loadReferenceImage();
         loadConfig().then(() => loadConfigData());
     }

--- a/sd-card/html/edit_config.html
+++ b/sd-card/html/edit_config.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" xml:lang="en"> 
+<html lang="en" xml:lang="en">
 <head>
 	<meta charset="UTF-8">
 	<title>Edit Config</title>
@@ -19,7 +19,7 @@
 		.button {
 			padding: 5px 10px;
 			width: 220px;
-			font-size: 16px;	
+			font-size: 16px;
 		}
 
 		textarea {
@@ -52,12 +52,12 @@
 	</table>
 
 
-<script src="common.js?v=$COMMIT_HASH"></script> 
+<script src="common.js?v=$COMMIT_HASH"></script>
 <script src="readconfigcommon.js?v=$COMMIT_HASH"></script>
-<script src="readconfigparam.js?v=$COMMIT_HASH"></script>  
+<script src="readconfigparam.js?v=$COMMIT_HASH"></script>
 <script>
 	var canvas = document.getElementById('canvas'),
-		domainname = getDomainname(); 
+		domainname = getDomainname();
 
 
 	function loadConfigData()
@@ -81,7 +81,7 @@
 		}
 	}
 
-	
+
 	function init()
 	{
 		loadConfig().then(() => loadConfigData());
@@ -91,6 +91,6 @@
 	init();
 
 </script>
- 
+
 </body>
 </html>

--- a/sd-card/html/edit_config_param.html
+++ b/sd-card/html/edit_config_param.html
@@ -42,7 +42,7 @@
 		.button {
 			padding: 5px 10px;
 			width: 220px;
-			font-size: 1em;	
+			font-size: 1em;
 		}
 
 		input[type=number] {
@@ -75,7 +75,7 @@
 			padding: 3px 5px;
 			display: inline-block;
 			border: 1px solid #ccc;
-			font-size: 1em; 
+			font-size: 1em;
 			margin-right: 10px;
 			vertical-align: middle;
 		}
@@ -87,7 +87,7 @@
 			padding: 3px 5px;
 			display: inline-block;
 			border: 1px solid #ccc;
-			font-size: 1em; 
+			font-size: 1em;
 			margin-right: 10px;
 			vertical-align: middle;
 		}
@@ -160,7 +160,7 @@
 			padding-left: 10px;
 			padding-right: 10px;
 
-			border: solid black 1px; 
+			border: solid black 1px;
 
 			/* Position the tooltip */
 			position: absolute;
@@ -185,30 +185,30 @@
 
 		.tooltip .tooltiptext h1 { /* Tooltip headline, e.g. parameter name */
 			font-size: 1.5em;
-			margin-top: 0.2em !important; 
+			margin-top: 0.2em !important;
 			margin-bottom: 0.3em !important;
 		}
 
 		.tooltip .tooltiptext h2 { /* Tooltip sub-headline, e.g. description*/
 			font-size: 1.2em;
-			margin-top: 1em !important; 
+			margin-top: 1em !important;
 			margin-bottom: 0.3em !important;
 		}
 
-		.tooltip .tooltiptext h3 { 
+		.tooltip .tooltiptext h3 {
 			font-size: 1.05em;
-			margin-top: 1em !important; 
+			margin-top: 1em !important;
 			margin-bottom: 0.3em !important;
 		}
 
-		.tooltip .tooltiptext h4 { 
+		.tooltip .tooltiptext h4 {
 			font-size: 0.83em;
-			margin-top: 1em !important; 
+			margin-top: 1em !important;
 			margin-bottom: 0.3em !important;
 		}
 
 		.tooltip .tooltiptext p {
-			margin-top: 0.3em !important; 
+			margin-top: 0.3em !important;
 			margin-bottom: 0.3em !important;
 		}
 
@@ -239,15 +239,15 @@
         <summary><b>CLICK HERE</b> for usage description.
         </summary>
 		<p>
-			This page lists all available configuration parameters of the device. 
-			The description of each parameter can be shown by hovering over or by clicking the 
+			This page lists all available configuration parameters of the device.
+			The description of each parameter can be shown by hovering over or by clicking the
 			<img src="help.png" width="16"> icon.
 		</p>
-		<p>	
-			The page gets opened with the default view which should be sufficient for regular configuration tasks. 
+		<p>
+			The page gets opened with the default view which should be sufficient for regular configuration tasks.
 			Enabling the <b>"Expert View"</b> some expert parameters (light red background color) will be added to
-			the parameter list. Additionally the button <b>"Edit "Config.ini" File"</b> to edit the underlaying 
-			configuration file (config.ini) manually is now shown on top of the page. This function should be only 
+			the parameter list. Additionally the button <b>"Edit "Config.ini" File"</b> to edit the underlaying
+			configuration file (config.ini) manually is now shown on top of the page. This function should be only
 			used for special cases.
 		</p>
 		<p>
@@ -255,7 +255,7 @@
 			Disabling results in a disabled functionality.
 		</p>
 		<p>
-			Don't forget to save the changes with the button <b>"Save And Apply"</b> at the bottom of this page. 
+			Don't forget to save the changes with the button <b>"Save And Apply"</b> at the bottom of this page.
             The new configuration gets automatically applied. No reboot is required.
 		</p>
     </details>
@@ -274,11 +274,11 @@
 
 		<tr>
             <th colspan="3">Configuration View</th>
-		</tr> 
+		</tr>
 		<tr>
 			<td class="indent1">
 				<input style="margin-top:12px;margin-bottom:12px" type="checkbox" id="ExpertModus_enabled" value="1"  onclick='UpdateExpertModus()' >
-					<label for="ExpertModus_enabled">Expert View</label> 
+					<label for="ExpertModus_enabled">Expert View</label>
 			</td>
 			<td>
 				<button style="display:none;" class="button" id="Edit_Config_Direct" onclick="editConfigDirect()">Edit "Config.ini" File</button>
@@ -298,11 +298,11 @@
 
 		<tr>
 			<th colspan="3">Take Image</th>
-		</tr> 
+		</tr>
 
 		<tr class="expert">
 			<td class="indent1">
-				<input type="checkbox" id="TakeImage_RawImagesLocation_enabled" value="1" 
+				<input type="checkbox" id="TakeImage_RawImagesLocation_enabled" value="1"
 								onclick='InvertEnableItem("TakeImage", "RawImagesLocation")'  >
 				<label for=TakeImage_RawImagesLocation_enabled>
 						<span id="TakeImage_RawImagesLocation_text">Raw Images Location</span></label>
@@ -315,7 +315,7 @@
 
 		<tr class="expert">
 			<td class="indent1">
-				<input type="checkbox" id="TakeImage_RawImagesRetention_enabled" value="1" 
+				<input type="checkbox" id="TakeImage_RawImagesRetention_enabled" value="1"
 								onclick='InvertEnableItem("TakeImage", "RawImagesRetention")'  >
 				<label for=TakeImage_RawImagesRetention_enabled>
 						<span id="TakeImage_RawImagesRetention_text">Raw Images Retention</span></label>
@@ -327,7 +327,7 @@
 			<td>$TOOLTIP_TakeImage_RawImagesRetention</td>
 		</tr>
 
-		<tr>		
+		<tr>
 			<td class="indent1">
 				<span id="TakeImage_FlashlightGPIOMapping">Flashlight GPIO Mapping</span>
 			</td>
@@ -337,7 +337,7 @@
 			<td>$TOOLTIP_TakeImage_FlashlightGPIOMapping</td>
 		</tr>
 
-		<tr>		
+		<tr>
 			<td class="indent1">
 				<span id="TakeImage_FlashTime_text">Flash Time</span>
 			</td>
@@ -354,7 +354,7 @@
 			</td>
 			<td>
 				<input required type="number" id="TakeImage_FlashIntensity_value1" min="0" max="100"
-					oninput="(!validity.rangeUnderflow||(value=0)) && (!validity.rangeOverflow||(value=100)) && 
+					oninput="(!validity.rangeUnderflow||(value=0)) && (!validity.rangeOverflow||(value=100)) &&
 						(!validity.stepMismatch||(value=parseInt(this.value)));">%
 			</td>
 			<td>$TOOLTIP_TakeImage_FlashIntensity</td>
@@ -381,7 +381,7 @@
 			</td>
 			<td>
 				<input required type="number" id="TakeImage_ImageQuality_value1" min="8" max="63"
-					oninput="(!validity.rangeUnderflow||(value=8)) && (!validity.rangeOverflow||(value=63)) && 
+					oninput="(!validity.rangeUnderflow||(value=8)) && (!validity.rangeOverflow||(value=63)) &&
 						(!validity.stepMismatch||(value=parseInt(this.value)));">
 			</td>
 			<td>$TOOLTIP_TakeImage_ImageQuality</td>
@@ -399,14 +399,14 @@
 			</td>
 			<td>$TOOLTIP_TakeImage_ImageSize</td>
 		</tr>
-			
+
 		<tr>
 			<td class="indent1">
 				<span id="TakeImage_Brightness_text">Brightness</span>
 			</td>
 			<td>
 				<input required type="number" id="TakeImage_Brightness_value1" value="0" min="-2" max="2"
-					oninput="(!validity.rangeUnderflow||(value=-2)) && (!validity.rangeOverflow||(value=2)) && 
+					oninput="(!validity.rangeUnderflow||(value=-2)) && (!validity.rangeOverflow||(value=2)) &&
 						(!validity.stepMismatch||(value=parseInt(this.value)));">
 			</td>
 			<td>$TOOLTIP_TakeImage_Brightness</td>
@@ -418,7 +418,7 @@
 			</td>
 			<td>
 				<input required type="number" id="TakeImage_Contrast_value1" value="0" min="-2" max="2"
-					oninput="(!validity.rangeUnderflow||(value=-2)) && (!validity.rangeOverflow||(value=2)) && 
+					oninput="(!validity.rangeUnderflow||(value=-2)) && (!validity.rangeOverflow||(value=2)) &&
 						(!validity.stepMismatch||(value=parseInt(this.value)));">
 			</td>
 			<td>$TOOLTIP_TakeImage_Contrast</td>
@@ -430,12 +430,12 @@
 			</td>
 			<td>
 				<input required type="number" id="TakeImage_Saturation_value1" value="0" min="-2" max="2"
-					oninput="(!validity.rangeUnderflow||(value=-2)) && (!validity.rangeOverflow||(value=2)) && 
+					oninput="(!validity.rangeUnderflow||(value=-2)) && (!validity.rangeOverflow||(value=2)) &&
 						(!validity.stepMismatch||(value=parseInt(this.value)));">
 			</td>
 			<td>$TOOLTIP_TakeImage_Saturation</td>
 		</tr>
-		
+
 		<tr>
 			<td class="indent1">
 				<span id="TakeImage_Sharpness_text">Sharpness</span>
@@ -460,7 +460,7 @@
 				<span id="TakeImage_ExposureControlMode_text">Exposure Control Mode</span>
 			</td>
 			<td>
-				<select id="TakeImage_ExposureControlMode_value1" 
+				<select id="TakeImage_ExposureControlMode_value1"
 						onchange='setEnabled("TakeImage_ExposureControlModeAuto_parameter", this.value > 0 ? true : false);
 						setEnabled("TakeImage_ExposureControlModeManual_parameter", this.value == 0 ? true : false);'>
                     <option value="0">Manual</option>
@@ -498,7 +498,7 @@
 				<span id="TakeImage_GainControlMode_text">Gain Control Mode</span>
 			</td>
 			<td>
-				<select id="TakeImage_GainControlMode_value1" 
+				<select id="TakeImage_GainControlMode_value1"
 						onchange='setEnabled("TakeImage_GainControlModeManual_parameter", this.value == 0 ? true : false);'>
                     <option value="0">Manual</option>
 					<option value="1" selected>Auto</option>
@@ -564,7 +564,7 @@
 				<span id="TakeImage_ZoomMode_text">Zoom Mode</span>
 			</td>
 			<td>
-				<select id="TakeImage_ZoomMode_value1" 
+				<select id="TakeImage_ZoomMode_value1"
 						onchange='setEnabled("TakeImage_Zoom_parameter", this.value > 0 ? true : false);'>
                     <option value="0" selected>Off</option>
 					<option value="1">Crop</option>
@@ -580,7 +580,7 @@
 				<span id="TakeImage_ZoomOffsetX_text">Zoom Offset X</span>
 			</td>
 			<td>
-				<input required type="number" id="TakeImage_ZoomOffsetX_value1" value="0" min="0" max="960" 
+				<input required type="number" id="TakeImage_ZoomOffsetX_value1" value="0" min="0" max="960"
 					oninput="(!validity.rangeOverflow||(value=960)) && (!validity.rangeUnderflow||(value=0));">Pixel
 			</td>
 			<td>$TOOLTIP_TakeImage_ZoomOffsetX</td>
@@ -592,7 +592,7 @@
 				<span id="TakeImage_ZoomOffsetY_text">Zoom Offset Y</span>
 			</td>
 			<td>
-				<input required type="number" id="TakeImage_ZoomOffsetY_value1" value="0" min="0" max="720" 
+				<input required type="number" id="TakeImage_ZoomOffsetY_value1" value="0" min="0" max="720"
 					oninput="(!validity.rangeOverflow||(value=720)) && (!validity.rangeUnderflow||(value=0));">Pixel
 			</td>
 			<td>$TOOLTIP_TakeImage_ZoomOffsetY</td>
@@ -640,7 +640,7 @@
 			</td>
 			<td>$TOOLTIP_Alignment_AlignmentAlgo</td>
 		</tr>
-		
+
 		<tr class="expert">
 			<td class="indent1">
 			    <span id="Alignment_SearchFieldX_text" style="color:black;">Search Field X</span>
@@ -669,7 +669,7 @@
 			</td>
 			<td>
 				<input required type="number" name="name" id="Alignment_InitialRotate_value1" min="-360.0" max="360.0" step="0.1"
-				oninput="(!validity.rangeUnderflow||(value=-360.0)) && (!validity.rangeOverflow||(value=360.0)) && 
+				oninput="(!validity.rangeUnderflow||(value=-360.0)) && (!validity.rangeOverflow||(value=360.0)) &&
 				(!validity.stepMismatch||(value=parseInt(this.value)));">Degree
 			</td>
 			<td>$TOOLTIP_Alignment_InitialRotate</td>
@@ -728,14 +728,14 @@
 			</td>
 			<td>$TOOLTIP_Digits_Model</td>
 		</tr>
-		
+
 		<tr class="DigitItem expert">
 			<td class="indent1">
 				<span id="Digits_CNNGoodThreshold_text" style="color:black;">CNN Good Threshold</span>
 			</td>
 			<td>
 				<input required type="number" id="Digits_CNNGoodThreshold_value1" min="0" max="1" step="0.01"
-					oninput="(!validity.rangeUnderflow||(value=0)) && (!validity.rangeOverflow||(value=1)) && 
+					oninput="(!validity.rangeUnderflow||(value=0)) && (!validity.rangeOverflow||(value=1)) &&
 						(!validity.stepMismatch||(value=parseInt(this.value)));">
 			</td>
 			<td>$TOOLTIP_Digits_CNNGoodThreshold</td>
@@ -743,9 +743,9 @@
 
 		<tr class="DigitItem expert">
 			<td class="indent1">
-				<input type="checkbox" id="Digits_ROIImagesLocation_enabled" value="1" 
+				<input type="checkbox" id="Digits_ROIImagesLocation_enabled" value="1"
 								onclick='InvertEnableItem("Digits", "ROIImagesLocation")'>
-				<label for=Digits_ROIImagesLocation_enabled><span id="Digits_ROIImagesLocation_text" 
+				<label for=Digits_ROIImagesLocation_enabled><span id="Digits_ROIImagesLocation_text"
 								style="color:black;">ROI Images Location</span></label>
 			</td>
 			<td>
@@ -756,9 +756,9 @@
 
 		<tr class="DigitItem expert">
 			<td class="indent1">
-				<input type="checkbox" id="Digits_ROIImagesRetention_enabled" value="1" 
+				<input type="checkbox" id="Digits_ROIImagesRetention_enabled" value="1"
 								onclick='InvertEnableItem("Digits", "ROIImagesRetention")'>
-				<label for=Digits_ROIImagesRetention_enabled><span id="Digits_ROIImagesRetention_text" 
+				<label for=Digits_ROIImagesRetention_enabled><span id="Digits_ROIImagesRetention_text"
 								style="color:black;">ROI Images Retention</span></label>
 			</td>
 			<td>
@@ -789,7 +789,7 @@
 			<td class="indent1">
 			    <span id="Analog_Model_text" style="color:black;">Model</span>
 			</td>
-			<td> 
+			<td>
 				<select class="select_large" id="Analog_Model_value1">
 				</select>
 			</td>
@@ -798,7 +798,7 @@
 
 		<tr class="AnalogItem expert">
 			<td class="indent1">
-				<input type="checkbox" id="Analog_ROIImagesLocation_enabled" value="1" 
+				<input type="checkbox" id="Analog_ROIImagesLocation_enabled" value="1"
 								onclick='InvertEnableItem("Analog", "ROIImagesLocation")'>
 				<label for=Analog_ROIImagesLocation_enabled>
 							<span id="Analog_ROIImagesLocation_text" style="color:black;">ROI Images Location</span>
@@ -810,11 +810,11 @@
 
 		<tr class="AnalogItem expert">
 			<td class="indent1">
-				<input type="checkbox" id="Analog_ROIImagesRetention_enabled" value="1" 
+				<input type="checkbox" id="Analog_ROIImagesRetention_enabled" value="1"
 								onclick='InvertEnableItem("Analog", "ROIImagesRetention")'>
 				<label for=Analog_ROIImagesRetention_enabled>
 							<span id="Analog_ROIImagesRetention_text" style="color:black;">ROI Images Retention</span></label></td>
-			<td> 
+			<td>
 				<input required type="number" id="Analog_ROIImagesRetention_value1" min="0" step="1"
 					oninput="(!validity.rangeUnderflow||(value=0)) && (!validity.stepMismatch||(value=parseInt(this.value)));">Days
 			</td>
@@ -875,7 +875,7 @@
 		<tr style="margin-top:12px">
 			<td class="indent1" style="padding-top:25px" colspan="3">
 				<b>Parameter per number sequence:</b>
-                <select 
+                <select
 					style="font-weight: bold; margin-left:15px" id="Numbers_value1" onchange="numberChanged()">
 				</select>
 			</td>
@@ -900,7 +900,7 @@
 			</td>
 			<td>
 				<input required type="number" id="PostProcessing_DecimalShift_value1" value="0" step="1" min="-9" max="9"
-					oninput="(!validity.rangeUnderflow||(value=-9)) && (!validity.rangeOverflow||(value=9)) && 
+					oninput="(!validity.rangeUnderflow||(value=-9)) && (!validity.rangeOverflow||(value=9)) &&
 						(!validity.stepMismatch||(value=parseInt(this.value)));">
 			</td>
 			<td>$TOOLTIP_PostProcessing_NUMBER.DecimalShift</td>
@@ -911,8 +911,8 @@
 				<span id="PostProcessing_AnalogDigitalTransitionStart_text" style="color:black;">Analog/Digital Transition Start</span>
 			</td>
 			<td>
-				<input required type="number" id="PostProcessing_AnalogDigitalTransitionStart_value1" step="0.1" 
-					min="6.0" max="9.9" value="9.2" oninput="(!validity.rangeUnderflow||(value=6.0)) && 
+				<input required type="number" id="PostProcessing_AnalogDigitalTransitionStart_value1" step="0.1"
+					min="6.0" max="9.9" value="9.2" oninput="(!validity.rangeUnderflow||(value=6.0)) &&
 					(!validity.rangeOverflow||(value=9.9)) && (!validity.stepMismatch||(value=parseInt(this.value)));">
 			</td>
 			<td>$TOOLTIP_PostProcessing_NUMBER.AnalogDigitalTransitionStart</td>
@@ -983,7 +983,7 @@
 		</tr>
 	</table>
 
-	
+
 	<!-- MQTT -->
 	<table class="table">
 		<colgroup>
@@ -1056,7 +1056,7 @@
 				<span id="MQTT_TLSEncryption_text" style="color:black;">TLS Encryption</span>
 			</td>
 			<td>
-				<select id="MQTT_TLSEncryption_value1" onchange='setEnabled("MQTT_TLSEncryption_parameter", 
+				<select id="MQTT_TLSEncryption_value1" onchange='setEnabled("MQTT_TLSEncryption_parameter",
 																 	this.value == "true" ? true : false);'>
 					<option value="false" selected>false</option>
 					<option value="true">true</option>
@@ -1133,7 +1133,7 @@
 				<span id="MQTT_HomeassistantDiscovery_text">Enable Discovery</span>
 			</td>
 			<td>
-				<select id="MQTT_HomeassistantDiscovery_value1" onchange='setEnabled("MQTT_HomeassistantDiscovery_parameter", 
+				<select id="MQTT_HomeassistantDiscovery_value1" onchange='setEnabled("MQTT_HomeassistantDiscovery_parameter",
 																        	this.value == "true" ? true : false);'>
 					<option value="false" selected>false</option>
 					<option value="true">true</option>
@@ -1214,7 +1214,7 @@
 				<label for=Category_InfluxDB_enabled>InfluxDB v1.x</label>
 			</th>
 		</tr>
-		
+
 		<tr class="InfluxDBv1Item">
 			<td class="indent1">
 				<span id="InfluxDB_Uri_text" style="color:black;">URI</span>
@@ -1262,7 +1262,7 @@
 				<span id="InfluxDB_TLSEncryption_text" style="color:black;">TLS Encryption</span>
 			</td>
 			<td>
-				<select id="InfluxDB_TLSEncryption_value1" onchange='setEnabled("InfluxDB_TLSEncryption_parameter", 
+				<select id="InfluxDB_TLSEncryption_value1" onchange='setEnabled("InfluxDB_TLSEncryption_parameter",
 						this.value == "true" ? true : false);'>
 					<option value="false" selected>false</option>
 					<option value="true">true</option>
@@ -1309,7 +1309,7 @@
                 </select>
 			</td>
 		</tr>
-		
+
 		<tr class="InfluxDBv1Item">
 			<td class="indent2">
 				<span id="InfluxDB_Measurement_text" style="color:black;">Measurement</span>
@@ -1394,7 +1394,7 @@
 				<span id="InfluxDBv2_TLSEncryption_text" style="color:black;">TLS Encryption</span>
 			</td>
 			<td>
-				<select id="InfluxDBv2_TLSEncryption_value1" onchange='setEnabled("InfluxDBv2_TLSEncryption_parameter", 
+				<select id="InfluxDBv2_TLSEncryption_value1" onchange='setEnabled("InfluxDBv2_TLSEncryption_parameter",
 						this.value == "true" ? true : false);'>
 					<option value="false" selected>false</option>
 					<option value="true">true</option>
@@ -1451,7 +1451,7 @@
 			</td>
 			<td>$TOOLTIP_InfluxDBv2_NUMBER.Measurement</td>
 		</tr>
-		
+
 		<tr class="InfluxDBv2Item">
 			<td class="indent2">
 				<span id="InfluxDBv2_Field_text" style="color:black;">Field</span>
@@ -1474,7 +1474,7 @@
 
 		<tr>
 			<th colspan="3">
-				<input type="checkbox" id="Category_GPIO_enabled" value="1" onclick='UpdateAfterCategoryCheck()'> 
+				<input type="checkbox" id="Category_GPIO_enabled" value="1" onclick='UpdateAfterCategoryCheck()'>
 				    <label for=Category_GPIO_enabled>GPIO (General Purpose Input / Output)</label>
 			</th>
 		</tr>
@@ -1509,7 +1509,7 @@
 				<span id="GPIO_RestrictedUsageText" style="display:none; color:red;"></span>
 			</td>
 			<td>
-				<select class="GPIO_EnablePin_parameter" id="GPIO_IO_value1" 
+				<select class="GPIO_EnablePin_parameter" id="GPIO_IO_value1"
 					onchange='GpioPinSelectBeforeChange(); GpioPinSelectAfterChange();'>
 				</select>
 			</td>
@@ -1521,7 +1521,7 @@
 				<span id="GPIO_IO_text2">GPIO Capture Mode</span>
 			</td>
 			<td>
-				<select class="GPIO_EnablePin_parameter" id="GPIO_IO_value2" 
+				<select class="GPIO_EnablePin_parameter" id="GPIO_IO_value2"
 					onchange='GpioCaptureModeChange();'>
 				</select>
 			</td>
@@ -1620,13 +1620,13 @@
 			</td>
 			<td>
 				R <input required style="min-width:45px;width:45px;" type="number" id="GPIO_IO_value9"
-						 min="0" max="255" step="1" oninput="(!validity.rangeUnderflow||(value=0)) && (!validity.rangeOverflow||(value=255)) && 
+						 min="0" max="255" step="1" oninput="(!validity.rangeUnderflow||(value=0)) && (!validity.rangeOverflow||(value=255)) &&
 							(!validity.stepMismatch||(value=parseInt(this.value)));">
 				G <input required style="min-width:45px;width:45px" type="number" id="GPIO_IO_value10"
-						 min="0" max="255" step="1" oninput="(!validity.rangeUnderflow||(value=0)) && (!validity.rangeOverflow||(value=255)) && 
+						 min="0" max="255" step="1" oninput="(!validity.rangeUnderflow||(value=0)) && (!validity.rangeOverflow||(value=255)) &&
 							(!validity.stepMismatch||(value=parseInt(this.value)));">
 				B <input required style="min-width:45px;width:45px" type="number" id="GPIO_IO_value11"
-						 min="0" max="255" step="1" oninput="(!validity.rangeUnderflow||(value=0)) && (!validity.rangeOverflow||(value=255)) && 
+						 min="0" max="255" step="1" oninput="(!validity.rangeUnderflow||(value=0)) && (!validity.rangeOverflow||(value=255)) &&
 							(!validity.stepMismatch||(value=parseInt(this.value)));">
 			</td>
 			<td>$TOOLTIP_GPIO_LEDColor</td>
@@ -1644,7 +1644,7 @@
 		</tr>
 	</table>
 
-	
+
 	<!-- Autotimer -->
 	<table class="table">
 		<colgroup>
@@ -1676,7 +1676,7 @@
 			</td>
 			<td>
 				<input required type="number" id="AutoTimer_Interval_value1" min="0.1" step="0.1"
-					oninput="(!validity.rangeUnderflow||(value=0.1)) && 
+					oninput="(!validity.rangeUnderflow||(value=0.1)) &&
 						     (!validity.stepMismatch||(value=parseInt(this.value)));">Minutes
 			</td>
 			<td>$TOOLTIP_AutoTimer_Interval</td>
@@ -1818,14 +1818,14 @@
 
 		<tr class="expert">
 			<td class="indent1">
-				<input type="checkbox" id="System_RSSIThreshold_enabled" value="1" 
+				<input type="checkbox" id="System_RSSIThreshold_enabled" value="1"
 							onclick='InvertEnableItem("System", "RSSIThreshold")'>
 				<label for=System_RSSIThreshold_enabled>
 						<span id="System_RSSIThreshold_text" style="color:black;">WIFI Roaming RSSI Threshold</span></label>
 			</td>
 			<td>
 				<input required type="number" name="name" id="System_RSSIThreshold_value1" min="-100" max="0" step="1"
-					oninput="(!validity.rangeUnderflow||(value=-100)) && (!validity.rangeOverflow||(value=0)) && 
+					oninput="(!validity.rangeUnderflow||(value=-100)) && (!validity.rangeOverflow||(value=0)) &&
 						(!validity.stepMismatch||(value=parseInt(this.value)));">dBm
 			</td>
 			<td>$TOOLTIP_System_RSSIThreshold</td>
@@ -1867,7 +1867,7 @@
 				<span id="WebUI_OverviewAutoRefresh_text" style="color:black;">Auto Refresh</span>
 			</td>
 			<td>
-				<select id="WebUI_OverviewAutoRefresh_value1" onchange='setEnabled("WebUI_OverviewAutoRefresh_parameter", 
+				<select id="WebUI_OverviewAutoRefresh_value1" onchange='setEnabled("WebUI_OverviewAutoRefresh_parameter",
 						this.value == "true" ? true : false);'>
 					<option value="false" >false</option>
 					<option value="true" selected>true</option>
@@ -1898,7 +1898,7 @@
 				<span id="WebUI_DataGraphAutoRefresh_text" style="color:black;">Auto Refresh</span>
 			</td>
 			<td>
-				<select id="WebUI_DataGraphAutoRefresh_value1" onchange='setEnabled("WebUI_DataGraphAutoRefresh_parameter", 
+				<select id="WebUI_DataGraphAutoRefresh_value1" onchange='setEnabled("WebUI_DataGraphAutoRefresh_parameter",
 						this.value == "true" ? true : false);'>
 					<option value="false" selected>false</option>
 					<option value="true">true</option>
@@ -1929,9 +1929,9 @@
 </div>
 
 
-<script src="common.js?v=$COMMIT_HASH"></script> 
-<script src="readconfigcommon.js?v=$COMMIT_HASH"></script>  
-<script src="readconfigparam.js?v=$COMMIT_HASH"></script>  
+<script src="common.js?v=$COMMIT_HASH"></script>
+<script src="readconfigcommon.js?v=$COMMIT_HASH"></script>
+<script src="readconfigparam.js?v=$COMMIT_HASH"></script>
 <script>
 	var canvas = document.getElementById('canvas'),
 		domainname = getDomainname(),
@@ -1975,7 +1975,7 @@
 			_indexInfluxv1.add(optionInfluxv1);
 
 		}
-		_index.selectedIndex = 0; 
+		_index.selectedIndex = 0;
 		_indexInflux.selectedIndex = 0;
 		_indexInfluxv1.selectedIndex = 0;
 	}
@@ -1989,14 +1989,14 @@
 		if (!results) return null;
 		if (!results[2]) return '';
 		return decodeURIComponent(results[2].replace(/\+/g, ' '));
-	}	
+	}
 
 
 	// Read parameter out of the variables and display in WebUI config page
 	function WriteParameter(_param, _category, _cat, _name, _optional, _number = -1){
 		let anzpara;
 		try {
-			anzpara = _param[_cat][_name].anzParam;	
+			anzpara = _param[_cat][_name].anzParam;
 		}
 		catch (error) {
 			firework.launch("Parameter '" + _name + "' in category '" + _cat + "' is unknown!", 'danger', 30000);
@@ -2010,8 +2010,8 @@
 			if (_optional) {
 				document.getElementById(_cat+"_"+_name+"_enabled").checked = NUMBERS[_number][_cat][_name]["enabled"];
 				for (var j = 1; j <= anzpara; ++j) {
-					document.getElementById(_cat+"_"+_name+"_value"+j).disabled = !NUMBERS[_number][_cat][_name]["enabled"];	
-				}		
+					document.getElementById(_cat+"_"+_name+"_value"+j).disabled = !NUMBERS[_number][_cat][_name]["enabled"];
+				}
 			}
 			document.getElementById(_cat+"_"+_name+"_text").style.color = "black"
 			setEnabled(_cat+"_"+_name, true);
@@ -2056,7 +2056,7 @@
 					var textToFind = _param[_cat][_name]["value"+j];
 					if (textToFind == undefined)
 						continue;
-					
+
 					_isFound = false;
 					element.selectedIndex = -1;
 					for (var i = 0; i < element.options.length; i++) {
@@ -2091,17 +2091,17 @@
 						smartled = true;
 				}
 
-				if ((pwm && _param[_cat][_name]["value1"] == "flashlight-default") || 
+				if ((pwm && _param[_cat][_name]["value1"] == "flashlight-default") ||
 					_param[_cat][_name]["value1"] == "flashlight-pwm" ||
 					_param[_cat][_name]["value1"] == "output-pwm"
 				)
 					setVisible("GPIO_ShowPWMFrequency", true);
 				else
 					setVisible("GPIO_ShowPWMFrequency", false);
-	
+
 				if (_param[_cat][_name]["value1"] == "input" ||
 					_param[_cat][_name]["value1"] == "input-pullup" ||
-					_param[_cat][_name]["value1"] == "input-pulldown") 
+					_param[_cat][_name]["value1"] == "input-pulldown")
 				{
 					setVisible("GPIO_ShowGPIOCaptureMode", true);
 
@@ -2122,8 +2122,8 @@
 				else
 					setVisible("GPIO_ShowSmartLed", false);
 
-				
-				if (_param[_cat][_name]["value1"].substring(0,10) == "flashlight" && 
+
+				if (_param[_cat][_name]["value1"].substring(0,10) == "flashlight" &&
 					_param[_cat][_name]["value1"] != "flashlight-digital"
 				)
 					setVisible("GPIO_ShowIntersityCorrection", true);
@@ -2137,8 +2137,8 @@
 			if (_optional) {
 				document.getElementById(_cat+"_"+_name+"_enabled").checked = _param[_cat][_name]["enabled"];
 				for (var j = 1; j <= anzpara; ++j) {
-					document.getElementById(_cat+"_"+_name+"_value"+j).disabled = !_param[_cat][_name]["enabled"];	
-				}		
+					document.getElementById(_cat+"_"+_name+"_value"+j).disabled = !_param[_cat][_name]["enabled"];
+				}
 			}
 			document.getElementById(_cat+"_"+_name+"_text").style.color = "black"
 			setEnabled(_cat+"_"+_name, true);
@@ -2149,7 +2149,7 @@
 					var textToFind = _param[_cat][_name]["value"+j];
 					if (textToFind == undefined)
 						continue;
-					
+
 					_isFound = false;
 					element.selectedIndex = -1;
 					for (var i = 0; i < element.options.length; i++) {
@@ -2171,17 +2171,17 @@
 				else {
 					element.value = _param[_cat][_name]["value"+j];
 				}
-			}	
+			}
 		}
 
 		///////////////// am Ende, falls Kategorie als gesamtes nicht ausgewählt --> deaktivieren
-		if (_category[_cat]["enabled"] == false) 
+		if (_category[_cat]["enabled"] == false)
 		{
 			if (_optional) {
 				document.getElementById(_cat+"_"+_name+"_enabled").disabled = true;
 				for (var j = 1; j <= anzpara; ++j) {
 					document.getElementById(_cat+"_"+_name+"_value"+j).disabled = true;
-				}	
+				}
 			}
 			document.getElementById(_cat+"_"+_name+"_text").style="color: gray;"
 			setEnabled(_cat+"_"+_name, false);
@@ -2208,7 +2208,7 @@
 		setEnabled(_cat + "_" + _param, _isOn);
 
 		for (var j = 1; j <= param[_cat][_param]["anzParam"]; ++j) {
-				document.getElementById(_cat+"_"+_param+"_value"+j).disabled = !_isOn;	
+				document.getElementById(_cat+"_"+_param+"_value"+j).disabled = !_isOn;
 				document.getElementById(_cat+"_"+_param+"_value"+j).style.color = _color;
 		}
 	}
@@ -2282,7 +2282,7 @@
 
 		if (_optional) {
 			document.getElementById(_cat+"_"+_name+"_enabled").disabled = !_status;
-			document.getElementById(_cat+"_"+_name+"_enabled").style.color = _color;	
+			document.getElementById(_cat+"_"+_name+"_enabled").style.color = _color;
 		}
 
 		if (_number == -1){
@@ -2304,8 +2304,8 @@
 		setEnabled(_cat+"_"+_name, _status);
 
 		for (var j = 1; j <= _param[_cat][_name]["anzParam"]; ++j) {
-				document.getElementById(_cat+"_"+_name+"_value"+j).disabled = !_status;	
-				document.getElementById(_cat+"_"+_name+"_value"+j).style.color = _color;	
+				document.getElementById(_cat+"_"+_name+"_value"+j).disabled = !_status;
+				document.getElementById(_cat+"_"+_name+"_value"+j).style.color = _color;
 		}
 	}
 
@@ -2323,7 +2323,7 @@
 				return;
 
 			if (_optional) {	// If checkbox is avaiable -> set by selection
-				NUMBERS[_number][_cat][_name]["enabled"] = document.getElementById(_cat+"_"+_name+"_enabled").checked;			
+				NUMBERS[_number][_cat][_name]["enabled"] = document.getElementById(_cat+"_"+_name+"_enabled").checked;
 			}
 			else {				// If no checkbox is available -> always enabled
 				NUMBERS[_number][_cat][_name]["enabled"] = true;
@@ -2350,7 +2350,7 @@
 			}
 		}
 		else if (_cat == "GPIO") {
-			_param[_cat][_name]["enabled"] = document.getElementById("GPIO_EnablePin_value1").value == "true" ? true : false;			
+			_param[_cat][_name]["enabled"] = document.getElementById("GPIO_EnablePin_value1").value == "true" ? true : false;
 
 			for (var j = 1; j <= _param[_cat][_name]["anzParam"]; ++j) {
 				let element = document.getElementById("GPIO_IO_value"+j);
@@ -2373,9 +2373,9 @@
 			}
 		}
 		else
-		{	
+		{
 			if (_optional) {	// If checkbox is avaiable -> set by selection
-				_param[_cat][_name]["enabled"] = document.getElementById(_cat+"_"+_name+"_enabled").checked;			
+				_param[_cat][_name]["enabled"] = document.getElementById(_cat+"_"+_name+"_enabled").checked;
 			}
 			else {				// If no checkbox is available -> always enabled
 				_param[_cat][_name]["enabled"] = true;
@@ -2399,7 +2399,7 @@
 					}
 					_param[_cat][_name]["value"+j] = element.value;
 				}
-			}		
+			}
 		}
 	}
 
@@ -2483,29 +2483,29 @@
         WriteParameter(param, category, "TakeImage", "ZoomOffsetY", false);
 		WriteParameter(param, category, "TakeImage", "Demo", false);
 
-		WriteParameter(param, category, "Alignment", "SearchFieldX", false);		
-		WriteParameter(param, category, "Alignment", "SearchFieldY", false);		
+		WriteParameter(param, category, "Alignment", "SearchFieldX", false);
+		WriteParameter(param, category, "Alignment", "SearchFieldY", false);
 		WriteParameter(param, category, "Alignment", "AlignmentAlgo", false);
 		WriteParameter(param, category, "Alignment", "InitialRotate", false);
 		WriteParameter(param, category, "Alignment", "FlipImageSize", false);
 		WriteParameter(param, category, "Alignment", "SaveDebugInfo", false);
 
 		WriteParameter(param, category, "Digits", "CNNGoodThreshold", false);
-		WriteParameter(param, category, "Digits", "ROIImagesLocation", true);		
-		WriteParameter(param, category, "Digits", "ROIImagesRetention", true);		
-		
-		WriteParameter(param, category, "Analog", "ROIImagesLocation", true);		
-		WriteParameter(param, category, "Analog", "ROIImagesRetention", true);		
-		
-		WriteParameter(param, category, "PostProcessing", "FallbackValueUse", false);		
-		WriteParameter(param, category, "PostProcessing", "FallbackValueAgeStartup", false);		
-		WriteParameter(param, category, "PostProcessing", "CheckDigitIncreaseConsistency", false);
-		WriteParameter(param, category, "PostProcessing", "SaveDebugInfo", false);	
+		WriteParameter(param, category, "Digits", "ROIImagesLocation", true);
+		WriteParameter(param, category, "Digits", "ROIImagesRetention", true);
 
-		WriteParameter(param, category, "MQTT", "Uri", false);	
-		WriteParameter(param, category, "MQTT", "MainTopic", false);	
-		WriteParameter(param, category, "MQTT", "ClientID", false);	
-		WriteParameter(param, category, "MQTT", "user", true);	
+		WriteParameter(param, category, "Analog", "ROIImagesLocation", true);
+		WriteParameter(param, category, "Analog", "ROIImagesRetention", true);
+
+		WriteParameter(param, category, "PostProcessing", "FallbackValueUse", false);
+		WriteParameter(param, category, "PostProcessing", "FallbackValueAgeStartup", false);
+		WriteParameter(param, category, "PostProcessing", "CheckDigitIncreaseConsistency", false);
+		WriteParameter(param, category, "PostProcessing", "SaveDebugInfo", false);
+
+		WriteParameter(param, category, "MQTT", "Uri", false);
+		WriteParameter(param, category, "MQTT", "MainTopic", false);
+		WriteParameter(param, category, "MQTT", "ClientID", false);
+		WriteParameter(param, category, "MQTT", "user", true);
 		WriteParameter(param, category, "MQTT", "password", true);
 		WriteParameter(param, category, "MQTT", "TLSEncryption", false);
 		WriteParameter(param, category, "MQTT", "TLSCACert", false);
@@ -2518,19 +2518,19 @@
 		WriteParameter(param, category, "MQTT", "HAStatusTopic", false);
 		WriteParameter(param, category, "MQTT", "HARetainDiscovery", false);
 		WriteParameter(param, category, "MQTT", "HAMeterType", false);
-		
-		WriteParameter(param, category, "InfluxDB", "Uri", false);	
-		WriteParameter(param, category, "InfluxDB", "Database", false);	
-		WriteParameter(param, category, "InfluxDB", "user", true);	
+
+		WriteParameter(param, category, "InfluxDB", "Uri", false);
+		WriteParameter(param, category, "InfluxDB", "Database", false);
+		WriteParameter(param, category, "InfluxDB", "user", true);
 		WriteParameter(param, category, "InfluxDB", "password", true);
 		WriteParameter(param, category, "InfluxDB", "TLSEncryption", false);
 		WriteParameter(param, category, "InfluxDB", "TLSCACert", false);
 		WriteParameter(param, category, "InfluxDB", "TLSClientCert", false);
 		WriteParameter(param, category, "InfluxDB", "TLSClientKey", false);
 
-		WriteParameter(param, category, "InfluxDBv2", "Uri", false);	
-		WriteParameter(param, category, "InfluxDBv2", "Bucket", false);	
-		WriteParameter(param, category, "InfluxDBv2", "Org", true);	
+		WriteParameter(param, category, "InfluxDBv2", "Uri", false);
+		WriteParameter(param, category, "InfluxDBv2", "Bucket", false);
+		WriteParameter(param, category, "InfluxDBv2", "Org", true);
 		WriteParameter(param, category, "InfluxDBv2", "Token", true);
 		WriteParameter(param, category, "InfluxDBv2", "TLSEncryption", false);
 		WriteParameter(param, category, "InfluxDBv2", "TLSCACert", false);
@@ -2539,11 +2539,11 @@
 
 		// GPIO values are getting updated by GpioPinSelectAfterChange()
 
-		WriteParameter(param, category, "AutoTimer", "AutoStart", false);	
+		WriteParameter(param, category, "AutoTimer", "AutoStart", false);
 		WriteParameter(param, category, "AutoTimer", "Interval", false);
 
-		WriteParameter(param, category, "DataLogging", "DataLogActive", false);	
-		WriteParameter(param, category, "DataLogging", "DataFilesRetention", false);	
+		WriteParameter(param, category, "DataLogging", "DataLogActive", false);
+		WriteParameter(param, category, "DataLogging", "DataFilesRetention", false);
 
 		WriteParameter(param, category, "Debug", "LogLevel", false);
 		WriteParameter(param, category, "Debug", "LogfilesRetention", false);
@@ -2589,7 +2589,7 @@
 		for (var i = 0; i < tflite_list.length; ++i) {
 			var optionDig = document.createElement("option");
 			var optionAna = document.createElement("option");
-			
+
 			var text = tflite_list[i].replace("/config/", "");
 
             if (tflite_list[i].includes("/dig")) { // Its a digit model, only show in the digital list box
@@ -2610,8 +2610,8 @@
 			}
 		}
 
-		WriteParameter(param, category, "Analog", "Model", false);		
-		WriteParameter(param, category, "Digits", "Model", false);		
+		WriteParameter(param, category, "Analog", "Model", false);
+		WriteParameter(param, category, "Digits", "Model", false);
 	}
 
 
@@ -2623,7 +2623,7 @@
 		category["InfluxDB"]["enabled"] = document.getElementById("Category_InfluxDB_enabled").checked;
 		category["InfluxDBv2"]["enabled"] = document.getElementById("Category_InfluxDBv2_enabled").checked;
 		category["GPIO"]["enabled"] = document.getElementById("Category_GPIO_enabled").checked;
-		
+
 		ReadParameter(param, "TakeImage", "RawImagesLocation", true);
 		ReadParameter(param, "TakeImage", "RawImagesRetention", true);
 		ReadParameter(param, "TakeImage", "FlashTime", false);
@@ -2648,7 +2648,7 @@
         ReadParameter(param, "TakeImage", "ZoomOffsetY", false);
 		ReadParameter(param, "TakeImage", "Demo", false);
 
-		ReadParameter(param, "Alignment", "SearchFieldX", false);	
+		ReadParameter(param, "Alignment", "SearchFieldX", false);
 		ReadParameter(param, "Alignment", "SearchFieldY", false);
 		ReadParameter(param, "Alignment", "AlignmentAlgo", false);
 		ReadParameter(param, "Alignment", "InitialRotate", false);
@@ -2708,7 +2708,7 @@
 
 		ReadParameter(param, "AutoTimer", "AutoStart", false);
 		ReadParameter(param, "AutoTimer", "Interval", false);
-		
+
 		ReadParameter(param, "DataLogging", "DataLogActive", false);
 		ReadParameter(param, "DataLogging", "DataFilesRetention", false);
 
@@ -2774,7 +2774,7 @@
 		}
 		else
 		{
-			document.getElementById("Edit_Config_Direct").style.display = "none"; 
+			document.getElementById("Edit_Config_Direct").style.display = "none";
 		}
 
 		getGPIOPins();
@@ -2804,7 +2804,7 @@
 			firework.launch('Save and apply configuration...', 'success', 2000, true);
 			setTimeout(function() {
 				reload_config();
-			}, 200);    
+			}, 200);
 		}
 	}
 
@@ -2816,7 +2816,7 @@
 			window.location.href = stringota;
 			window.location.assign(stringota);
 			window.location.replace(stringota);
-		}	
+		}
 	}
 
 
@@ -2880,7 +2880,7 @@
 					if (pinConfig.gpio[i].usage.substring(0,10) == "restricted") {
 						elements[j].classList.add("expert");
 						document.getElementById("GPIO_RestrictedUsageText").style.display = "";
-						document.getElementById("GPIO_RestrictedUsageText").innerText = "[Default: " + 
+						document.getElementById("GPIO_RestrictedUsageText").innerText = "[Default: " +
 											pinConfig.gpio[i].usage.substring(12).replace(/\-/g, " ") + "]";
 					}
 					else {
@@ -2898,7 +2898,7 @@
 	{
 		if (document.getElementById("GPIO_IO_value1").value == "input" ||
 			document.getElementById("GPIO_IO_value1").value == "input-pullup" ||
-			document.getElementById("GPIO_IO_value1").value == "input-pulldown") 
+			document.getElementById("GPIO_IO_value1").value == "input-pulldown")
 		{
 			if (document.getElementById("GPIO_IO_value2").value != "cyclic-polling")
 				setVisible("GPIO_ShowGPIODebounceTime", true);
@@ -2953,7 +2953,7 @@
 					}
 
 					if (category["GPIO"]["enabled"] == false)
-						document.getElementById("TakeImage_FlashlightGPIOMapping_value").innerText = 
+						document.getElementById("TakeImage_FlashlightGPIOMapping_value").innerText =
 								"Default [GPIO" + pinConfig.gpio[i].name + "]";
 					else
 						document.getElementById("TakeImage_FlashlightGPIOMapping_value").innerText = "Customized [GPIO Section]";
@@ -2990,7 +2990,7 @@
 		}
 	}
 
-	
+
 	function GpioConfigCheck()
 	{
 		for (let i = 0; i < pinConfig.gpio.length; ++i) {
@@ -3001,7 +3001,7 @@
 
 
 	/* hash #description open the details part of the page */
-	function openDescription() 
+	function openDescription()
 	{
 		if(window.location.hash) {
 			var hash = window.location.hash.substring(1); //Puts hash in variable, and removes the # character
@@ -3026,7 +3026,7 @@
 		document.getElementById("divloading").style.display = 'none'; // Hide loading indicator
 		document.getElementById("divcontent").style.display = ''; 	// Show parameter content
 	}
-	
+
 
 	async function init()
 	{
@@ -3045,6 +3045,6 @@
 	init();
 
 </script>
-	
+
 </body>
 </html>

--- a/sd-card/html/edit_digits.html
+++ b/sd-card/html/edit_digits.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" xml:lang="en"> 
+<html lang="en" xml:lang="en">
 <head>
     <meta charset="UTF-8">
     <title>Digit ROI</title>
@@ -23,14 +23,14 @@
             padding: 3px 5px;
             display: inline-block;
             border: 1px solid #ccc;
-            font-size: 16px; 
+            font-size: 16px;
         }
 
         input[type=text] {
             padding: 3px 5px;
             display: inline-block;
             border: 1px solid #ccc;
-            font-size: 16px; 
+            font-size: 16px;
         }
 
         input:out-of-range {
@@ -42,7 +42,7 @@
             padding: 3px 5px;
             display: inline-block;
             border: 1px solid #ccc;
-            font-size: 16px; 
+            font-size: 16px;
             margin-right: 10px;
             min-width: 100px;
             max-width: 100%;
@@ -95,11 +95,11 @@
 
     <h2>Digit ROI</h2>
     <details id="desc_details">
-        <summary><b>CLICK HERE</b> for usage description. Further documentation: 
+        <summary><b>CLICK HERE</b> for usage description. Further documentation:
             <a href=https://jomjol.github.io/AI-on-the-edge-device-docs/ROI-Configuration/ target=_blank>ROI Configuration</a>
         </summary>
         <p>
-            <b>R</b>egion <b>O</b>f <b>I</b>nterest (ROI) for digit numbers can be defined on this page. If no digit number 
+            <b>R</b>egion <b>O</b>f <b>I</b>nterest (ROI) for digit numbers can be defined on this page. If no digit number
             needs to be processed, disable digit number processing by deselecting <b>"Digit ROI Processing"</b>.
         </p>
         <p>
@@ -115,7 +115,7 @@
             <a href=https://jomjol.github.io/AI-on-the-edge-device-docs/ROI-Configuration/ target=_blank>ROI Configuration</a>.
             With the drop down <b>"ROI"</b> the different ROIs in the respective number sequence can be selected.<br>
 
-            To create new ROIs use <b>"New ROI"</b>. The new ROIs are automatically named uniquely and in ascending order 
+            To create new ROIs use <b>"New ROI"</b>. The new ROIs are automatically named uniquely and in ascending order
             (e.g. dig1, dig2, ...). Deleting a ROI between exisitung ones will rename the remaining ROIs in ascending order
             without keeping any naming gap.
         </p>
@@ -124,10 +124,10 @@
             The position in the number sequence can be changed with the buttons <b>"Move Lower"</b> and <b>"Move Higher"</b>.
             The multiplication factor which is shown below the ROI drop down is the multiplication factor of pure position/order
             in number sequence and the factor right-hand side to this is the additionally corrected by decimal shift setting
-            (expert parameter: Decimal Shift, default: 0). 
+            (expert parameter: Decimal Shift, default: 0).
         </p>
         <p>
-            After the definition of digit ROIs is completed don't forget to save the new configuration with the button 
+            After the definition of digit ROIs is completed don't forget to save the new configuration with the button
             <b>"Save And Apply"</b>. The new configuration gets automatically applied. No reboot is required.
         </p>
     </details>
@@ -165,7 +165,7 @@
                 </select>
             </td>
             <td><input class="button" type="submit" id="newSequence" name="newSequence" value="New" onclick="onClickNewSequence()"></td>
-            <td><input class="button" type="submit" id="renameSequence" name="renameSequence" value="Rename" onclick="onClickRenameSequence()"></td> 
+            <td><input class="button" type="submit" id="renameSequence" name="renameSequence" value="Rename" onclick="onClickRenameSequence()"></td>
             <td><input class="button" type="submit" id="deleteSequence" name="deleteSequence" value="Delete" onclick="onClickDeleteSequence()"></td>
         </tr>
     </table>
@@ -185,14 +185,14 @@
             <td><input class="button" type="submit" id="newROI" name="newROI" onclick="onClickNewROI()" value="New"></td>
             <td><input class="button" type="submit" id="deleteROI" name="deleteROI" onclick="onClickDeleteROI()" value="Delete"></td>
         </tr>
-        <tr>       
+        <tr>
             <td class="multiplier">Multiplier: <output id="multiplier" name="multiplier"></output><br>
                 (only based on order)
             </td>
             <td class="multiplier">Multiplier: <output id="multiplier_decshift" name="multiplier_decshift"></output><br>
                 (order + decimal shift: <output id="decimalShift" name="decimalShift"></output>)
             </td>
-            <td><input class="button" type="submit" id="moveROIHigher" onclick="onClickMoveROIHigher()" value="Move Higher"></td> 
+            <td><input class="button" type="submit" id="moveROIHigher" onclick="onClickMoveROIHigher()" value="Move Higher"></td>
             <td><input class="button" type="submit" id="moveROILower" onclick="onClickMoveROILower()" value="Move Lower"></td>
         </tr>
     </table>
@@ -204,17 +204,17 @@
             <col span="1" style="width: 62%;">
         </colgroup>
         <tr>
-            <td>x: <input type="number" name="refx" id="refx" min=1 step=1 onchange="onValueManualChanged()" 
-                        oninput="(!validity.rangeUnderflow||(value=1));"></td>	  
-            <td>Δx: <input type="number" name="refdx" id="refdx" min=1 step=1 onchange="onValueManualChangedDx()" 
+            <td>x: <input type="number" name="refx" id="refx" min=1 step=1 onchange="onValueManualChanged()"
+                        oninput="(!validity.rangeUnderflow||(value=1));"></td>
+            <td>Δx: <input type="number" name="refdx" id="refdx" min=1 step=1 onchange="onValueManualChangedDx()"
                         oninput="(!validity.rangeUnderflow||(value=1));"></td>
             <td><input type="checkbox" id="lockAspectRatio" name="lockAspectRatio" value="1" onclick="onClickLockAspectRatio()" checked>
                             <label for="lockAspectRatio"> Lock aspect ratio </label></td>
         </tr>
         <tr>
-            <td>y: <input type="number" name="refy" id="refy" min=1 step=1 onchange="onValueManualChanged()" 
-                        oninput="(!validity.rangeUnderflow||(value=1));"></td>	
-            <td>Δy: <input type="number" name="refdy" id="refdy" min=1 step=1 onchange="onValueManualChanged()" 
+            <td>y: <input type="number" name="refy" id="refy" min=1 step=1 onchange="onValueManualChanged()"
+                        oninput="(!validity.rangeUnderflow||(value=1));"></td>
+            <td>Δy: <input type="number" name="refdy" id="refdy" min=1 step=1 onchange="onValueManualChanged()"
                         oninput="(!validity.rangeUnderflow||(value=1));"></td>
             <td><input type="checkbox" id="lockSizes" name="lockSizes" value="1" onclick="onClickLockSizes()" checked>
                             <label for="lockSizes"> Synchronize y, Δx and Δy</label></td>
@@ -248,7 +248,7 @@
     </table>
 
 
-<script src="common.js?v=$COMMIT_HASH"></script> 
+<script src="common.js?v=$COMMIT_HASH"></script>
 <script src="readconfigcommon.js?v=$COMMIT_HASH"></script>
 <script src="readconfigparam.js?v=$COMMIT_HASH"></script>
 <script>
@@ -272,12 +272,12 @@
     function EnDisableDigits()
     {
         isEnabled = document.getElementById("Category_Digits_enabled").checked;
-        
+
         sah1(document.getElementById("div1"), !isEnabled);
-        
+
         param_category["Digits"]["enabled"] = isEnabled;
         document.getElementById("saveconfig").disabled = false;
-        
+
         if (isEnabled) {
             RefreshROI();
         }
@@ -340,7 +340,7 @@
     {
         if (confirm("The entire number sequence will be removed (digit + analog parts). " +
                     "To remove single ROI of the number sequence, use \"Delete ROI\" instead.\n" +
-                    "Do you really want to proceed?")) 
+                    "Do you really want to proceed?"))
         {
             var sel_sequence = document.getElementById("SequenceSelect");
             var sequence_name = sel_sequence.options[sel_sequence.selectedIndex].text;
@@ -348,7 +348,7 @@
             if (erg != "")
                 firework.launch(erg, 'danger', 30000);
             RefreshSequences();
-        }	    
+        }
     }
 
 
@@ -396,7 +396,7 @@
                 space = ROIInfo[1].x - parseInt(ROIInfo[0].x) - parseInt(ROIInfo[0].dx);
 
             var roi_x = parseInt(ROIInfo[sel_roi.length-1].x) + parseInt(ROIInfo[sel_roi.length-1].dx) + space;
-            
+
             erg = CreateROI(sequence_name, "digit", roi_index, roi_name, roi_x, parseInt(ROIInfo[sel_roi.length-1].y),
                             ROIInfo[sel_roi.length-1]["dx"], ROIInfo[sel_roi.length-1]["dy"], 0);
         }
@@ -463,7 +463,7 @@
     function onClickLockSizes()
     {
         lockSizes = document.getElementById("lockSizes").checked;
-        RefreshROI(); 
+        RefreshROI();
         onValueManualChangedSpace();
 
         if (!lockSizes) {
@@ -501,15 +501,15 @@
             }
 
             rect.startX = document.getElementById("refx").value;
-            rect.startY = document.getElementById("refy").value; 
+            rect.startY = document.getElementById("refy").value;
 
             RefreshDraw();
-            
+
             if (lockSpaceEquidistant) {
                 makeX_SpaceEquidistant();
             }
-              
-            RefreshDraw();  
+
+            RefreshDraw();
         }
         RefreshROI();
         document.getElementById("saveconfig").disabled = false;
@@ -532,13 +532,13 @@
             }
 
             rect.startX = document.getElementById("refx").value;
-            rect.startY = document.getElementById("refy").value; 
+            rect.startY = document.getElementById("refy").value;
 
             if (lockSpaceEquidistant) {
                 makeX_SpaceEquidistant();
             }
 
-            RefreshDraw();            
+            RefreshDraw();
         }
         RefreshROI();
         document.getElementById("saveconfig").disabled = false;
@@ -550,11 +550,11 @@
         if (!drag) {
            space = document.getElementById("space").value;
            onValueManualChanged();
-           RefreshDraw(); 
+           RefreshDraw();
         }
     }
 
-    
+
     // Make all X spaces equidistant
     function makeX_SpaceEquidistant()
     {
@@ -595,7 +595,7 @@
             var option = document.createElement("option");
             option.text = NumberSequence[i]["name"];
             option.value = i;
-            sel_sequence.add(option); 
+            sel_sequence.add(option);
 
             if (typeof _sel !== 'undefined') {
                 if (NumberSequence[i]["name"] == _sel)
@@ -622,18 +622,18 @@
             firework.launch('Digit ROI processing is disabled. Activate with checkbox if needed', 'warning', 5000);
             return;
         }
-        
+
         var sel_roi = document.getElementById("ROISelect");
 
         if (ROIInfo.length == 0) {
             firework.launch('No digit ROIs defined in selected number sequence', 'warning', 5000);
             document.getElementById("newROI").disabled = false;
             document.getElementById("deleteROI").disabled = true;
-            
+
             document.getElementById("ROISelect").disabled = true;
             sel_roi.selectedIndex = 0;
             sel_roi.options[sel_roi.selectedIndex].text = "N/A";
-            
+
             document.getElementById("multiplier").style.display = "none";
             document.getElementById("multiplier_decshift").style.display = "none";
             document.getElementById("refx").disabled = true;
@@ -667,10 +667,10 @@
             while (sel_roi.length){
                 sel_roi.remove(0);
             }
-            
+
             if (roi_selected > ROIInfo.length)
                 roi_selected = ROIInfo.length-1;
-            
+
             for (var i = 0; i < ROIInfo.length; ++i){
                 var option = document.createElement("option");
                 option.text = ROIInfo[i]["name"];
@@ -683,7 +683,7 @@
 
                 ROIPositionValidation(ROIInfo[i]);
             }
-            sel_roi.selectedIndex = roi_selected; 
+            sel_roi.selectedIndex = roi_selected;
         }
 
         document.getElementById("moveROIHigher").disabled = false;
@@ -697,7 +697,7 @@
         }
 
         ShowMultiplier();
-        
+
         document.getElementById("lockAspectRatio").checked = lockAspectRatio;
         document.getElementById("lockSizes").checked = lockSizes;
         document.getElementById("lockSpaceEquidistant").checked = lockSpaceEquidistant;
@@ -708,11 +708,11 @@
         else {
             document.getElementById("space").disabled = false;
         }
-        
+
         document.getElementById("refx").value = ROIInfo[roi_selected]["x"];
-        document.getElementById("refy").value = ROIInfo[roi_selected]["y"];  
-        document.getElementById("refdx").value = ROIInfo[roi_selected]["dx"];  
-        document.getElementById("refdy").value = ROIInfo[roi_selected]["dy"];  
+        document.getElementById("refy").value = ROIInfo[roi_selected]["y"];
+        document.getElementById("refdx").value = ROIInfo[roi_selected]["dx"];
+        document.getElementById("refdy").value = ROIInfo[roi_selected]["dy"];
         rect.startX = ROIInfo[roi_selected]["x"];
         rect.startY = ROIInfo[roi_selected]["y"];
         rect.w = ROIInfo[roi_selected]["dx"];
@@ -752,7 +752,7 @@
             for (var i = 1; i < (ROIInfo.length); ++i) { // 2nd .. last ROI
                 if (parseInt(ROIInfo[i].y) != parseInt(ROIInfo[0].y) ||
                     parseInt(ROIInfo[i].dx) != parseInt(ROIInfo[0].dx) ||
-                    parseInt(ROIInfo[i].dy) != parseInt(ROIInfo[0].dy)) { 
+                    parseInt(ROIInfo[i].dy) != parseInt(ROIInfo[0].dy)) {
                     all_y_dx_dy_Identical = false;
                     break;
                 }
@@ -867,7 +867,7 @@
         if (fixedDecimals_decshift < 0) {
             fixedDecimals_decshift = -1*fixedDecimals_decshift;
         }
-        
+
         document.getElementById("multiplier").value="x" + Number(10 ** multiplier).toFixed(0);
         document.getElementById("multiplier_decshift").value="x" + Number(10 ** multiplier_decshift).toFixed(fixedDecimals_decshift);
     }
@@ -954,9 +954,9 @@
                         var dx = parseInt(ROIInfo[i].dx) + parseInt(lw);
                         var dy = parseInt(ROIInfo[i].dy) + parseInt(lw);
                         context.strokeRect(x0, y0, dx, dy);
-                        
+
                         drawTextBG(context, ROIInfo[i]["name"], x0+dx/2, parseInt(ROIInfo[i].y), parseInt(rect.h), 2, false);
-    
+
                         lw = 1;
                         var x0 = parseInt(ROIInfo[i].x) - parseInt(lw/2);
                         var y0 = parseInt(ROIInfo[i].y) - parseInt(lw/2);
@@ -979,9 +979,9 @@
             var dx = parseInt(rect.w) + parseInt(lw);
             var dy = parseInt(rect.h) + parseInt(lw);
             context.strokeRect(x0, y0, dx, dy);
-            
+
             drawTextBG(context, ROIInfo[roi_selected]["name"], x0+dx/2, parseInt(rect.startY), parseInt(rect.h), 2, true);
-            
+
             context.lineWidth = 1;
             context.strokeRect(x0+dx*0.2, y0+dy*0.2, dx*0.6, dy*0.6);
 
@@ -990,8 +990,8 @@
             context.beginPath();
             context.moveTo(x0, y0+dy/2);
             context.lineTo(x0+dx, y0+dy/2);
-            context.stroke();   
-            
+            context.stroke();
+
             ROIInfo[roi_selected]["x"] = rect.startX;
             ROIInfo[roi_selected]["y"] = rect.startY;
             ROIInfo[roi_selected]["dx"] = rect.w;
@@ -999,7 +999,7 @@
         }
     }
 
-    
+
     function getCoords(elem) // crossbrowser version
     {
         var box = elem.getBoundingClientRect();
@@ -1021,7 +1021,7 @@
         rect.startX = e.pageX - zw.left;
         rect.startY = e.pageY - zw.top;
         document.getElementById("refx").value =  rect.startX;
-        document.getElementById("refy").value =  rect.startY;    
+        document.getElementById("refy").value =  rect.startY;
         drag = true;
     }
 
@@ -1041,14 +1041,14 @@
         document.getElementById("refdy").value = rect.h;
         document.getElementById("refx").value = rect.startX;
         document.getElementById("refy").value = rect.startY;
-        RefreshROI();    
+        RefreshROI();
     }
 
 
     function mouseMove(e)
     {
         if (drag) {
-            zw = getCoords(this)        
+            zw = getCoords(this)
 
             if (ROIInfo.length == 0) {
                 return;
@@ -1072,15 +1072,15 @@
             zw = getCoords(this);
             x = e.pageX - zw.left;
             y = e.pageY - zw.top;
-            
+
             context.lineWidth = 1;
             context.strokeStyle = "#00FF00";
-            context.beginPath(); 
+            context.beginPath();
             context.moveTo(0,y);
             context.lineTo(canvas.width, y);
             context.moveTo(x, 0);
             context.lineTo(x, canvas.height);
-            context.stroke();            
+            context.stroke();
         }
     }
 
@@ -1122,11 +1122,11 @@
         canvas.addEventListener('mousemove', mouseMove, false);
     }
 
-    
+
     function loadConfigData()
     {
         ParseConfig();
-        param = getConfigParameters(); 
+        param = getConfigParameters();
         param_category = getConfigCategory();
 
         RefreshSequences();
@@ -1140,7 +1140,7 @@
     function init()
     {
         openDescription();
-        
+
         loadReferenceImage();
         loadConfig().then(() => loadConfigData());
     }

--- a/sd-card/html/edit_reference.html
+++ b/sd-card/html/edit_reference.html
@@ -1,9 +1,9 @@
 <!DOCTYPE html>
-<html lang="en" xml:lang="en"> 
+<html lang="en" xml:lang="en">
 <head>
     <meta charset="UTF-8">
     <title>Reference Image</title>
-        
+
     <style>
         h1 {font-size: 1.8em;}
         h2 {font-size: 1.5em; margin-block-start: 0.0em; margin-block-end: 0.2em;}
@@ -32,7 +32,7 @@
 			padding: 3px 5px;
 			display: inline-block;
 			border: 1px solid #ccc;
-			font-size: 1em; 
+			font-size: 1em;
 			margin-right: 10px;
 			vertical-align: middle;
 		}
@@ -85,7 +85,7 @@
 			padding-bottom: 10px;
 			padding-left: 10px;
 			padding-right: 10px;
-			border: solid black 1px; 
+			border: solid black 1px;
 			position: absolute; /* Position the tooltip */
 			z-index: 1;
 			top: 100%;
@@ -107,30 +107,30 @@
 
 		.tooltip .tooltiptext h1 { /* Tooltip headline, e.g. parameter name */
 			font-size: 1.5em;
-			margin-top: 0.2em !important; 
+			margin-top: 0.2em !important;
 			margin-bottom: 0.3em !important;
 		}
 
 		.tooltip .tooltiptext h2 { /* Tooltip sub-headline, e.g. description*/
 			font-size: 1.2em;
-			margin-top: 1em !important; 
+			margin-top: 1em !important;
 			margin-bottom: 0.3em !important;
 		}
 
-		.tooltip .tooltiptext h3 { 
+		.tooltip .tooltiptext h3 {
 			font-size: 1.05em;
-			margin-top: 1em !important; 
+			margin-top: 1em !important;
 			margin-bottom: 0.3em !important;
 		}
 
-		.tooltip .tooltiptext h4 { 
+		.tooltip .tooltiptext h4 {
 			font-size: 0.83em;
-			margin-top: 1em !important; 
+			margin-top: 1em !important;
 			margin-bottom: 0.3em !important;
 		}
 
 		.tooltip .tooltiptext p {
-			margin-top: 0.3em !important; 
+			margin-top: 0.3em !important;
 			margin-bottom: 0.3em !important;
 		}
 
@@ -151,25 +151,25 @@
 <body style="font-family: arial; padding: 0px 10px; width:660px; max-width:660px;">
     <h2>Reference Image</h2>
     <details id="desc_details">
-        <summary><b>CLICK HERE</b> for usage description. Further documentation: 
+        <summary><b>CLICK HERE</b> for usage description. Further documentation:
                 <a href=https://jomjol.github.io/AI-on-the-edge-device-docs/Reference-Image/ target=_blank>Reference Image</a>
         </summary>
         <p>
             The reference image is the base image on which the alignment marker, digit ROIs and analog ROIs will be defined.
-        </p>        
+        </p>
         <p>
             Firstly the actual saved reference image is shown. If you start with the setup from scratch a default image is shown
             as placeholder. Use the button <b>"Create New Reference"</b> to start creation of your own reference image. After
-            selecting the button a new image will be taken using all configured parameter. With the button <b>"Update Image"</b> 
+            selecting the button a new image will be taken using all configured parameter. With the button <b>"Update Image"</b>
             the image can be refreshed (still all parameter get applied to the new image).
-        </p>            
+        </p>
         <p>
             To have reliable evaluation processing a properly horizontal aligned evaluation area is mandatory. Using the parameter
             "Image Rotation" and "Image Rotation (Fine-tune)" the image can be rotated in both directions. The resulting rotation
             angle is used to prerotate the image before the alignment algorithm is processed to compensate only small misalignments.
         </p>
         <p>
-            After setting up your reference image don't forget to save the new configuration  with the button <b>"Save And Apply"</b>.  
+            After setting up your reference image don't forget to save the new configuration  with the button <b>"Save And Apply"</b>.
             The new configuration gets automatically applied. No reboot is required.
         </p>
     </details>
@@ -182,7 +182,7 @@
             <col span="1" style="width: 33.3%;">
         </colgroup>
         <tr>
-            <td><input class="button" type="button" value="Show Actual Reference" onclick="showReference()"></td>	  
+            <td><input class="button" type="button" value="Show Actual Reference" onclick="showReference()"></td>
             <td><input class="button" type="button" id="createreference" value="Create New Reference" onclick="loadRawImage(false)"></td>
         </tr>
     </table>
@@ -212,9 +212,9 @@
                 <span id="TakeImage_Brightness_text">Brightness</span>
             </td>
             <td>
-                <input class="camParameter" style="clear: both; width: 80%;vertical-align:middle" type="range" id="TakeImage_Brightness_value1" 
+                <input class="camParameter" style="clear: both; width: 80%;vertical-align:middle" type="range" id="TakeImage_Brightness_value1"
                         value=0 min="-2" max="2" onchange="this.nextElementSibling.value = this.value">
-                <output id="TakeImage_Brightness_value1_output" style="vertical-align:middle; 
+                <output id="TakeImage_Brightness_value1_output" style="vertical-align:middle;
                                 min-width:15px; padding-right:5px; text-align:right; float:left">0</output>
             </td>
         </tr>
@@ -224,7 +224,7 @@
                 <span id="TakeImage_ZoomOffsetX_text">Zoom Offset X</span>
             </td>
             <td  class="camParameter TakeImage_Zoom_parameter">
-                <input required style="clear: both" type="number" id="TakeImage_ZoomOffsetX_value1" value="0" min="0" max="960" 
+                <input required style="clear: both" type="number" id="TakeImage_ZoomOffsetX_value1" value="0" min="0" max="960"
                         oninput="(!validity.rangeOverflow||(value=960)) && (!validity.rangeUnderflow||(value=0));">px
             </td>
             <td style="overflow:hidden">$TOOLTIP_TakeImage_Contrast</td>
@@ -234,7 +234,7 @@
             <td>
                 <input class="camParameter" style="clear: both; width: 80%;vertical-align:middle" type="range" id="TakeImage_Contrast_value1"
                         value=0 min="-2" max="2" onchange="this.nextElementSibling.value = this.value">
-                <output id="TakeImage_Contrast_value1_output" style="vertical-align:middle; 
+                <output id="TakeImage_Contrast_value1_output" style="vertical-align:middle;
                                 min-width:15px; padding-right:5px; text-align:right; float:left">0</output>
             </td>
         </tr>
@@ -244,7 +244,7 @@
                 <span id="TakeImage_ZoomOffsetY_text">Zoom Offset Y</span>
             </td>
             <td class="camParameter TakeImage_Zoom_parameter">
-                <input required style="clear: both" type="number" id="TakeImage_ZoomOffsetY_value1" value="0" min="0" max="720" 
+                <input required style="clear: both" type="number" id="TakeImage_ZoomOffsetY_value1" value="0" min="0" max="720"
                         oninput="(!validity.rangeOverflow||(value=720)) && (!validity.rangeUnderflow||(value=0));">px
             </td>
             <td style="overflow:hidden">$TOOLTIP_TakeImage_Saturation</td>
@@ -254,7 +254,7 @@
             <td>
                 <input class="camParameter" style="clear: both; width: 80%;vertical-align:middle" type="range" id="TakeImage_Saturation_value1"
                         value=0 min="-2" max="2" onchange="this.nextElementSibling.value = this.value">
-                <output id="TakeImage_Saturation_value1_output" style="vertical-align:middle; 
+                <output id="TakeImage_Saturation_value1_output" style="vertical-align:middle;
                                 min-width:15px; padding-right:5px; text-align:right; float:left">0</output>
             </td>
         </tr>
@@ -269,7 +269,7 @@
             <td>
                 <input class="camParameter" style="clear: both; width: 80%;vertical-align:middle" type="range" id="TakeImage_Sharpness_value1"
                         value=0 min="-4" max="3" onchange="onchangeSharpness(this.value);">
-                <output id="TakeImage_Sharpness_value1_output" style="vertical-align:middle; 
+                <output id="TakeImage_Sharpness_value1_output" style="vertical-align:middle;
                         min-width:15px; padding-right:5px; text-align:right; float:left">0</output>
             </td>
         </tr>
@@ -299,7 +299,7 @@
                 <span id="TakeImage_ExposureControlMode_text">Exposure Control</span>
             </td>
             <td class="camParameter">
-				<select id="TakeImage_ExposureControlMode_value1" 
+				<select id="TakeImage_ExposureControlMode_value1"
                         onchange='setEnabled("TakeImage_ExposureControlModeAuto_parameter", this.value > 0 ? true : false);
                                   setEnabled("TakeImage_ExposureControlModeManual_parameter", this.value == 0 ? true : false);'>
                     <option value="0">Manual</option>
@@ -325,10 +325,10 @@
                 <span id="TakeImage_AutoExposureLevel_text">Auto Exposure Level</span>
             </td>
             <td>
-                <input class="camParameter TakeImage_ExposureControlModeAuto_parameter" style="clear: both; width: 80%;vertical-align:middle" 
-                        type="range" id="TakeImage_AutoExposureLevel_value1" value=0 min="-2" max="2" 
+                <input class="camParameter TakeImage_ExposureControlModeAuto_parameter" style="clear: both; width: 80%;vertical-align:middle"
+                        type="range" id="TakeImage_AutoExposureLevel_value1" value=0 min="-2" max="2"
                         onchange="this.nextElementSibling.value = this.value">
-                <output id="TakeImage_AutoExposureLevel_value1_output" style="vertical-align:middle; 
+                <output id="TakeImage_AutoExposureLevel_value1_output" style="vertical-align:middle;
                                 min-width:15px; padding-right:5px; text-align:right; float:left">0</output>
             </td>
         </tr>
@@ -338,8 +338,8 @@
                 <span id="TakeImage_ManualGainValue_text">Manual Gain Value</span>
             </td>
             <td>
-                <input class="camParameter TakeImage_GainControlModeManual_parameter" required style="clear: both" type="number" id="TakeImage_ManualGainValue_value1" 
-                        value="0" min="0" max="5" oninput="(!validity.rangeOverflow||(value=5)) && 
+                <input class="camParameter TakeImage_GainControlModeManual_parameter" required style="clear: both" type="number" id="TakeImage_ManualGainValue_value1"
+                        value="0" min="0" max="5" oninput="(!validity.rangeOverflow||(value=5)) &&
                         (!validity.rangeUnderflow||(value=0));">
             </td>
             <td style="overflow:hidden">$TOOLTIP_TakeImage_ManualExposureValue</td>
@@ -347,35 +347,35 @@
                 <span id="TakeImage_ManualExposureValue_text">Manual Exposure Value</span>
             </td>
             <td>
-                <input class="camParameter TakeImage_ExposureControlModeManual_parameter" required style="clear: both" type="number" id="TakeImage_ManualExposureValue_value1" 
-                        value="300" min="0" max="1200" oninput="(!validity.rangeOverflow||(value=1200)) && 
+                <input class="camParameter TakeImage_ExposureControlModeManual_parameter" required style="clear: both" type="number" id="TakeImage_ManualExposureValue_value1"
+                        value="300" min="0" max="1200" oninput="(!validity.rangeOverflow||(value=1200)) &&
                         (!validity.rangeUnderflow||(value=0));">
             </td>
         </tr>
         <tr>
             <td style="overflow:hidden">$TOOLTIP_Alignment_InitialRotate</td>
-            <td><label for="Alignment_InitialRotate_value1" name="Alignment_InitialRotate_text">Image Rotation</label></td>	  
+            <td><label for="Alignment_InitialRotate_value1" name="Alignment_InitialRotate_text">Image Rotation</label></td>
             <td>
-                <input class="camParameter" required type="number" id="Alignment_InitialRotate_value1" name="Alignment_InitialRotate" 
-                        value="0" min="-360" max="360" onchange="drawRotated()" oninput="(!validity.rangeOverflow||(value=360)) 
+                <input class="camParameter" required type="number" id="Alignment_InitialRotate_value1" name="Alignment_InitialRotate"
+                        value="0" min="-360" max="360" onchange="drawRotated()" oninput="(!validity.rangeOverflow||(value=360))
                         && (!validity.rangeUnderflow||(value=-360)) && (!validity.stepMismatch||(value=parseInt(this.value)));">°
             </td>
-            <td style="overflow:hidden">$TOOLTIP_TakeImage_FlashTime</td>		
+            <td style="overflow:hidden">$TOOLTIP_TakeImage_FlashTime</td>
             <td>
                 <span id="TakeImage_FlashTime_text">Flash Time</span>
             </td>
             <td>
-                <input class="camParameter" required type="number" id="TakeImage_FlashTime_value1" 
+                <input class="camParameter" required type="number" id="TakeImage_FlashTime_value1"
                         value="2.0" min="0.1" step="0.1" oninput="(!validity.rangeUnderflow||(value=0.1));">s
             </td>
         </tr>
         <tr>
             <td style="overflow:hidden">$TOOLTIP_Alignment_InitialRotate</td>
-            <td style="padding:0px 5px 0px 0px"><label for="Alignment_InitialRotate_value1_fine" 
-                    name="Alignment_InitialRotate_text">Image Rotation<br>(Fine-tune)</label></td>	
+            <td style="padding:0px 5px 0px 0px"><label for="Alignment_InitialRotate_value1_fine"
+                    name="Alignment_InitialRotate_text">Image Rotation<br>(Fine-tune)</label></td>
             <td>
-                <input class="camParameter" required type="number" id="Alignment_InitialRotate_value1_fine" name="Alignment_InitialRotate" 
-                        value=0.0 min="-1" max="1" step="0.1" onchange="drawRotated()" oninput="(!validity.rangeOverflow||(value=1)) && 
+                <input class="camParameter" required type="number" id="Alignment_InitialRotate_value1_fine" name="Alignment_InitialRotate"
+                        value=0.0 min="-1" max="1" step="0.1" onchange="drawRotated()" oninput="(!validity.rangeOverflow||(value=1)) &&
                         (!validity.rangeUnderflow||(value=-1)) && (!validity.stepMismatch||(value=parseInt(this.value)));">°
             </td>
             <td style="overflow:hidden">$TOOLTIP_TakeImage_FlashIntensity</td>
@@ -383,8 +383,8 @@
                 <span id="TakeImage_FlashIntensity_text">Flash Intensity</span>
             </td>
             <td>
-                <input class="camParameter" required style="clear: both" type="number" id="TakeImage_FlashIntensity_value1" 
-                        value="0" min="0" max="100" oninput="(!validity.rangeOverflow||(value=100)) && 
+                <input class="camParameter" required style="clear: both" type="number" id="TakeImage_FlashIntensity_value1"
+                        value="0" min="0" max="100" oninput="(!validity.rangeOverflow||(value=100)) &&
                         (!validity.rangeUnderflow||(value=0)) && (!validity.stepMismatch||(value=parseInt(this.value)));">%
             </td>
         </tr>
@@ -399,23 +399,23 @@
             <td style="vertical-align: bottom;"><b>Reference Image</b></td>
             <td><input class="button" type="button" id="take" onclick="doTake(true)" value="Update Image">
             <td>
-                <input style="font-weight:bold;" class="button" type="button" id="savereference" 
+                <input style="font-weight:bold;" class="button" type="button" id="savereference"
                         value="Save And Apply" onclick="SaveReference()">
             </td>
         </tr>
         <tr>
             <td colspan="3"><canvas style="max-width: 100%" id="canvas"></canvas></td>
-        </tr>	
+        </tr>
     </table>
 
 
-<script src="common.js?v=$COMMIT_HASH"></script> 
-<script src="readconfigcommon.js?v=$COMMIT_HASH"></script>  
-<script src="readconfigparam.js?v=$COMMIT_HASH"></script>  
+<script src="common.js?v=$COMMIT_HASH"></script>
+<script src="readconfigcommon.js?v=$COMMIT_HASH"></script>
+<script src="readconfigparam.js?v=$COMMIT_HASH"></script>
 <script>
     let canvas = document.getElementById('canvas'),
         context = canvas.getContext('2d'),
-        imageObj = new Image(),  
+        imageObj = new Image(),
         isActReference = false,
         paramLocal = {},
         initialConfigUrl = "";
@@ -428,8 +428,8 @@
         else if (val == -4) // Automatic
             document.getElementById('TakeImage_Sharpness_value1_output').value = "A";
     }
-    
-    
+
+
     function restoreCamSettings()
     {
         let xhttp = new XMLHttpRequest();
@@ -440,7 +440,7 @@
                 }
                 else {
                     document.getElementById("createreference").disabled = false;
-                    firework.launch("Camera image parameter reset failed (Response status: " + this.status + 
+                    firework.launch("Camera image parameter reset failed (Response status: " + this.status +
                                     "). Repeat action or check logs.", 'danger', 30000);
                     console.error("Camera image parameter reset failed. Response status: " + this.status);
                 }
@@ -451,12 +451,12 @@
         xhttp.open("GET", initialConfigUrl, true);
         xhttp.send();
     }
-    
+
 
     function doTake(release_save = false)
-    { 
+    {
         let url = "";
-        
+
         if (release_save)
             document.getElementById("savereference").disabled = false;
 
@@ -501,11 +501,11 @@
             let zoomOffsetY = document.getElementById("TakeImage_ZoomOffsetY_value1").value;
             if (zoomOffsetX == "") zoomOffsetX = "0";
 
-            url = getDomainname() + "/camera?task=set_parameter&flashtime=" + flashtime + "&flashintensity=" + flashintensity + 
-                    "&brightness=" + brightness + "&contrast=" + contrast + "&saturation=" + saturation + "&sharpness=" + sharpness + 
-                    "&exposurecontrolmode=" + exposureControlMode + "&autoexposurelevel=" + autoExposureLevel + 
-                    "&manualexposurevalue=" + manualExposureValue + "&gaincontrolmode=" + gainControlMode + 
-                    "&manualgainvalue=" + manualGainValue + "&specialeffect=" + specialeffect + "&mirror=" + mirror + "&flip=" + flip + 
+            url = getDomainname() + "/camera?task=set_parameter&flashtime=" + flashtime + "&flashintensity=" + flashintensity +
+                    "&brightness=" + brightness + "&contrast=" + contrast + "&saturation=" + saturation + "&sharpness=" + sharpness +
+                    "&exposurecontrolmode=" + exposureControlMode + "&autoexposurelevel=" + autoExposureLevel +
+                    "&manualexposurevalue=" + manualExposureValue + "&gaincontrolmode=" + gainControlMode +
+                    "&manualgainvalue=" + manualGainValue + "&specialeffect=" + specialeffect + "&mirror=" + mirror + "&flip=" + flip +
                     "&zoommode=" + zoomMode + "&zoomx=" + zoomOffsetX + "&zoomy=" + zoomOffsetY;
         }
         else {
@@ -531,7 +531,7 @@
                 }
                 else {
                     document.getElementById("createreference").disabled = false;
-                    firework.launch("Take reference image parameter setting failed (Response status: " + this.status + 
+                    firework.launch("Take reference image parameter setting failed (Response status: " + this.status +
                                     "). Repeat action or check logs.", 'danger', 30000);
                     console.error("Take reference image parameter setting failed. Response status: " + this.status);
                 }
@@ -549,7 +549,7 @@
         document.getElementById("take").disabled = true;
         if (new_image) {
             let url = getDomainname() + "/img_tmp/raw.jpg?" + Math.floor((Math.random() * 1000000) + 1);
-            loadCanvas(url, true);     
+            loadCanvas(url, true);
             isActReference = false;
         }
         else {
@@ -562,22 +562,22 @@
             // Release additional zoom parameter
             setEnabled("TakeImage_Zoom_parameter", paramLocal["TakeImage"]["ZoomMode"]["value1"] > 0 ? true : false);
             // Release additional exposure control parameter
-            setEnabled("TakeImage_ExposureControlModeAuto_parameter", 
+            setEnabled("TakeImage_ExposureControlModeAuto_parameter",
                 document.getElementById("TakeImage_ExposureControlMode_value1").value > 0 ? true : false);
-		    setEnabled("TakeImage_ExposureControlModeManual_parameter", 
+		    setEnabled("TakeImage_ExposureControlModeManual_parameter",
                 document.getElementById("TakeImage_ExposureControlMode_value1").value == 0 ? true : false);
             // Release additional gain control parameter
-		    setEnabled("TakeImage_GainControlModeManual_parameter", 
+		    setEnabled("TakeImage_GainControlModeManual_parameter",
                 document.getElementById("TakeImage_GainControlMode_value1").value == 0 ? true : false);
-            
+
             doTake();
         }
     }
-    
+
 
     function showReference()
     {
-        let url = getDomainname() + "/fileserver/config/reference.jpg?" + Math.floor((Math.random() * 1000000) + 1);                              
+        let url = getDomainname() + "/fileserver/config/reference.jpg?" + Math.floor((Math.random() * 1000000) + 1);
         loadCanvas(url, false);
         isActReference = true;
 
@@ -594,8 +594,8 @@
     {
         WriteParameter(paramLocal, "TakeImage", "FlashTime");
         WriteParameter(paramLocal, "TakeImage", "FlashIntensity");
-        WriteParameter(paramLocal, "TakeImage", "Brightness", true);		
-        WriteParameter(paramLocal, "TakeImage", "Contrast", true);		
+        WriteParameter(paramLocal, "TakeImage", "Brightness", true);
+        WriteParameter(paramLocal, "TakeImage", "Contrast", true);
         WriteParameter(paramLocal, "TakeImage", "Saturation", true);
         WriteParameter(paramLocal, "TakeImage", "Sharpness", true);
         onchangeSharpness(paramLocal["TakeImage"]["Sharpness"]["value1"]); // -4 -> Auto
@@ -620,10 +620,10 @@
             document.getElementById("Alignment_InitialRotate_value1").value = Math.floor(paramLocal["Alignment"]["InitialRotate"].value1);
         }
 
-        document.getElementById("Alignment_InitialRotate_value1_fine").value = (Number(paramLocal["Alignment"]["InitialRotate"].value1) - 
+        document.getElementById("Alignment_InitialRotate_value1_fine").value = (Number(paramLocal["Alignment"]["InitialRotate"].value1) -
                                                         Number(document.getElementById("Alignment_InitialRotate_value1").value)).toFixed(1);
     }
-    
+
 
     /* Parse parameter out of param structure and preset WebUI fields */
     function WriteParameter(_param, _cat, _name, outval = false)
@@ -654,7 +654,7 @@
         }
         else {
             document.getElementById(_cat+"_"+_name+"_text").style="color:lightgrey;"
-            document.getElementById(_cat+"_"+_name).style="color:lightgrey;"		
+            document.getElementById(_cat+"_"+_name).style="color:lightgrey;"
         }
     }
 
@@ -679,7 +679,7 @@
 
 
     function setEnabled(className, enabled)
-    {       
+    {
         let _color = "rgb(122, 122, 122)";
 		if (enabled) {
 			_color = "black";
@@ -690,7 +690,7 @@
 			if (enabled) {
 				elements[i].classList.remove("disabled");
 				elements[i].disabled = false;
-			} 
+			}
             else {
 				elements[i].classList.add("disabled");
 				elements[i].disabled = true;
@@ -800,7 +800,7 @@
 
             context.drawImage(imageObj,-imageObj.width/2,-imageObj.height/2);
         }
-        
+
         context.restore();
 
         if (_grid)
@@ -887,10 +887,10 @@
         let zw = getCoords(this);
         let x = e.pageX - zw.left;
         let y = e.pageY - zw.top;
-        
+
         context.lineWidth = 1;
         context.strokeStyle = 'rgb(0, 255, 0)'; //"#00FF00";
-        context.beginPath(); 
+        context.beginPath();
         context.moveTo(0,y);
         context.lineTo(canvas.width, y);
         context.moveTo(x, 0);
@@ -906,7 +906,7 @@
 
             ReadParameter(param, "TakeImage", "FlashTime");
             ReadParameter(param, "TakeImage", "FlashIntensity");
-            ReadParameter(param, "TakeImage", "Brightness");		
+            ReadParameter(param, "TakeImage", "Brightness");
             ReadParameter(param, "TakeImage", "Contrast");
             ReadParameter(param, "TakeImage", "Saturation");
             ReadParameter(param, "TakeImage", "Sharpness");
@@ -923,8 +923,8 @@
             ReadParameter(param, "TakeImage", "ZoomOffsetY");
 
             ReadParameter(param, "Alignment", "FlipImageSize");
-            
-            param["Alignment"]["InitialRotate"].value1 = (Number(document.getElementById("Alignment_InitialRotate_value1").value) + 
+
+            param["Alignment"]["InitialRotate"].value1 = (Number(document.getElementById("Alignment_InitialRotate_value1").value) +
                                                             Number(document.getElementById("Alignment_InitialRotate_value1_fine").value)).toFixed(1);
 
             drawRotated(false);
@@ -964,7 +964,7 @@
     function init()
     {
         openDescription();
-        
+
         canvas.addEventListener('mousemove', mouseMove, false);
         loadConfig().then(() => loadConfigData());
     }

--- a/sd-card/html/file_server.html
+++ b/sd-card/html/file_server.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" xml:lang="en"> 
+<html lang="en" xml:lang="en">
 <head>
     <meta charset="UTF-8">
     <title>File Server</title>
@@ -46,23 +46,23 @@
         input[type=file] {
             padding: 5px 0px;
             display: inline-block;
-            font-size: 16px; 
+            font-size: 16px;
         }
 
         input[type=text] {
             padding: 5px 10px;
             display: inline-block;
             border: 1px solid #ccc;
-            font-size: 16px; 
+            font-size: 16px;
         }
 
         .button {
             padding: 4px 10px;
             width: 100px;
-            font-size: 16px;	
+            font-size: 16px;
         }
     </style>
-    
+
     <script src="/jquery-3.6.0.min.js?v=$COMMIT_HASH"></script>
     <link href="/firework.css?v=$COMMIT_HASH" rel="stylesheet">
     <script src="/firework.js?v=$COMMIT_HASH"></script>
@@ -71,7 +71,7 @@
 <body>
     <table style="width:100%; border: 0pt; font-family: arial;">
         <tr>
-            <td style="vertical-align: top;width: 300px;font-size: 1.5em; margin-block-start: 0.0em; 
+            <td style="vertical-align: top;width: 300px;font-size: 1.5em; margin-block-start: 0.0em;
                 margin-block-end: 0.2em;font-weight: bold;padding-left: 10px;">Fileserver
             </td>
             <td>
@@ -83,7 +83,7 @@
                         <td colspan="2">
                             <input id="newfile" type="file" onchange="setpath()" style="width:100%;">
                         </td>
-                    </tr>  
+                    </tr>
                     <tr>
                         <td>
                             <label for="filepath">Destination</label>
@@ -107,7 +107,7 @@
     </table>
 
 
-<script src="/common.js?v=$COMMIT_HASH"></script>            
+<script src="/common.js?v=$COMMIT_HASH"></script>
 <script>
     function setpath() {
         var fileserverpraefix = "/fileserver";
@@ -123,13 +123,13 @@
         var found = zw;
         while (zw >= 0)
         {
-            zw = str.indexOf("/", found+1);  
+            zw = str.indexOf("/", found+1);
             if (zw >= 0)
                 found = zw;
         }
         var res = str.substring(0, found+1);
 
-        window.location.href = res;	
+        window.location.href = res;
     }
 
 
@@ -178,7 +178,7 @@
                     }
                 }
             };
-            
+
             xhttp.timeout = 10000;  // 10 seconds
             xhttp.open("POST", upload_path, true);
             xhttp.send(file);

--- a/sd-card/html/graph.html
+++ b/sd-card/html/graph.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" xml:lang="en"> 
+<html lang="en" xml:lang="en">
 <head>
     <meta charset="UTF-8">
     <title>Data Graph</title>
@@ -20,7 +20,7 @@
             padding: 3px 5px;
             display: inline-block;
             border: 1px solid #ccc;
-            font-size: 16px; 
+            font-size: 16px;
             margin-right: 10px;
             min-width: 100px;
             vertical-align: middle;
@@ -55,12 +55,12 @@
         }
     </style>
 
-    <script src="jquery-3.6.0.min.js?v=$COMMIT_HASH"></script>  
+    <script src="jquery-3.6.0.min.js?v=$COMMIT_HASH"></script>
     <link href="firework.css?v=$COMMIT_HASH" rel="stylesheet">
     <script src="firework.js?v=$COMMIT_HASH"></script>
     <script src='plotly-basic-2.18.2.min.js?v=$COMMIT_HASH'></script>
-    <script src="common.js?v=$COMMIT_HASH"></script> 
-    <script src="readconfigcommon.js?v=$COMMIT_HASH"></script>  
+    <script src="common.js?v=$COMMIT_HASH"></script>
+    <script src="readconfigcommon.js?v=$COMMIT_HASH"></script>
     <script src="readconfigparam.js?v=$COMMIT_HASH"></script>
     <script>
         function addZero(i)
@@ -150,7 +150,7 @@
                     if (firstNonNaNIndex == (traceValue.y.length - 1)) {
                         console.log("No data available for 'value'!");
                     }
-                    else if (firstNonNaNIndex > 0) { // Replace all leading NaN with the first valid value 
+                    else if (firstNonNaNIndex > 0) { // Replace all leading NaN with the first valid value
                         console.log("The first leading values have all just NaN, replacing them with the value of",
                                 traceValue.y[firstNonNaNIndex], "at", traceValue.x[firstNonNaNIndex], "(Index:", firstNonNaNIndex, ")");
                         for(var i = 0; i < firstNonNaNIndex; i++) {
@@ -246,11 +246,11 @@
     <div>
         <input type="checkbox" id="AutoRefreshEnabled" value="1" onchange="AutoRefreshContent();">
         <label for=AutoRefreshEnabled><span id="AutoRefreshEnabled_text" style="color:black;">Auto Refresh</span></label>
-        <input required type="number" style="margin-left: 18px;" name="AutoRefreshTime" id="AutoRefreshTime"  min="1" step="1" value="60" 
+        <input required type="number" style="margin-left: 18px;" name="AutoRefreshTime" id="AutoRefreshTime"  min="1" step="1" value="60"
                 oninput="(!validity.rangeUnderflow||(value=1));" onchange="AutoRefreshContent();"> s
         <output style="margin-left:48px" id="timestamp" >Last Refresh:</output>
     </div>
-    <div style="margin-top:10px;margin-bottom:20px">       
+    <div style="margin-top:10px;margin-bottom:20px">
         <button class="button" onclick="run();">Refresh</button>
         <button class="button" onClick="window.location.href = 'data.html?v=$COMMIT_HASH'">Show Data Viewer</button>
         <button class="button" onClick="window.location.href = getDomainname() + '/fileserver/log/data/'">Show Data Files</button>
@@ -268,14 +268,14 @@
 
         for (var i = list_data.length - 1; i >= 0; --i) {
             var optionDig = document.createElement("option");
-            
+
             optionDig.text = list_data[i].substring(5, list_data[i].lastIndexOf('.'));
             optionDig.value = list_data[i];
             _indexDig.add(optionDig);
         }
     }
 
-  
+
     function parseNumberSequenceName()
     {
         var NumberSequence = getNumberSequences();
@@ -299,17 +299,17 @@
         ParseConfig();
         param = getConfigParameters();
         parseNumberSequenceName();
-        
+
 		document.getElementById("AutoRefreshEnabled").checked = param["WebUI"]["DataGraphAutoRefresh"]["value1"] == "true" ? true : false;
-		document.getElementById("AutoRefreshTime").value = param["WebUI"]["DataGraphAutoRefreshTime"]["value1"];   
-        
+		document.getElementById("AutoRefreshTime").value = param["WebUI"]["DataGraphAutoRefreshTime"]["value1"];
+
         autoRefreshTimeoutHandle = null; // Init auto refresh handle
         AutoRefreshContent();
     }
 
 
 	function AutoRefreshContent()
-	{	   
+	{
         if (document.getElementById("AutoRefreshEnabled").checked == true) { // Activated -> Set timeout
 
 			if (autoRefreshTimeoutHandle) { // Clear actual timeout handle

--- a/sd-card/html/index.html
+++ b/sd-card/html/index.html
@@ -46,7 +46,7 @@
                 el.style.visibility = 'visible';
             });
         }
-        
+
         function getCookie(cname) {
             let name = cname + "=";
             let decodedCookie = decodeURIComponent(document.cookie);
@@ -153,7 +153,7 @@
     //console.log("Loading page: " + getCookie("page"));
     document.getElementById('maincontent').src = getCookie("page");
 
-    
+
     function manual_cycle_start()
     {
         var url = getDomainname() + '/cycle_start';
@@ -183,9 +183,9 @@
                     }
                 }
                 else {
-                    firework.launch("Cycle start request failed (Response status: " + this.status + 
+                    firework.launch("Cycle start request failed (Response status: " + this.status +
                                     "). Repeat action or check logs.", 'danger', 30000);
-                    console.error("Cycle start request failed. Response status: " + this.status);  
+                    console.error("Cycle start request failed. Response status: " + this.status);
                 }
             }
 		};
@@ -217,9 +217,9 @@
 				    firework.launch('Sending HA discovery topics scheduled. The sending will be processed in state "Publish to MQTT"', 'success', 5000);
 			    }
                 else {
-                    firework.launch("HA send discovery topics request failed (Response status: " + this.status + 
+                    firework.launch("HA send discovery topics request failed (Response status: " + this.status +
                                     "). Repeat action or check logs.", 'danger', 30000);
-                    console.error("HA send discovery topics request failed. Response status: " + this.status);  
+                    console.error("HA send discovery topics request failed. Response status: " + this.status);
                 }
             }
 		};
@@ -232,7 +232,7 @@
 
     function start_livestream(streamFlashlight)
     {
-        if (streamPopup) 
+        if (streamPopup)
             streamPopup.close();
 
         if (streamFlashlight)

--- a/sd-card/html/info.html
+++ b/sd-card/html/info.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" xml:lang="en"> 
+<html lang="en" xml:lang="en">
 <head>
 	<meta charset="UTF-8">
 	<title>Info</title>
@@ -73,7 +73,7 @@
 		}
 	</style>
 
-	<script src="common.js?v=$COMMIT_HASH"></script> 
+	<script src="common.js?v=$COMMIT_HASH"></script>
 </head>
 
 <body style="font-family: arial; padding: 0px 10px; width:660px; max-width:660px;">
@@ -117,29 +117,29 @@
 			<col span="1" style="width: 35%;">
 			<col span="1" style="width: 65%;">
 		</colgroup>
-		<tr>			
+		<tr>
 			<h3>Services</h3>
 		</tr>
 		<tr>
-			<td>Data Logging (SD Card) </td>	
+			<td>Data Logging (SD Card) </td>
 			<td class="td-badge">
 				<output class="badge" id="datalogging_sdcard_status"></output>
 			</td>
 		</tr>
 		<tr>
-			<td>MQTT</td>	
+			<td>MQTT</td>
 			<td class="td-badge">
 				<output class="badge" id="mqtt_status"></output>
 			</td>
 		</tr>
 		<tr>
-			<td>InfluxDB v1.x</td>	
+			<td>InfluxDB v1.x</td>
 			<td class="td-badge">
 				<output class="badge" id="influxdbv1_status"></output>
 			</td>
 		</tr>
 		<tr>
-			<td>InfluxDB v2.x</td>	
+			<td>InfluxDB v2.x</td>
 			<td class="td-badge">
 				<output class="badge" id="influxdbv2_status"></output>
 			</td>
@@ -151,7 +151,7 @@
 			<col span="1" style="width: 35%;">
 			<col span="1" style="width: 65%;">
 		</colgroup>
-		<tr>			
+		<tr>
 			<h3>Time</h3>
 		</tr>
 		<tr>
@@ -185,59 +185,59 @@
 			<col span="1" style="width: 35%;">
 			<col span="1" style="width: 65%;">
 		</colgroup>
-		<tr>			
+		<tr>
 			<h3>Network</h3>
 		</tr>
 		<tr>
-			<td>WLAN Status</td>	
+			<td>WLAN Status</td>
 			<td class="td-badge">
 				<output class="badge" id="wlan_status"></output>
 			</td>
 		</tr>
 		<tr>
-			<td>WLAN Name (SSID)</td>	
+			<td>WLAN Name (SSID)</td>
 			<td>
 				<output id="wlan_ssid"></output>
 			</td>
 		</tr>
 		<tr>
-			<td>WLAN Signal (RSSI)</td>	
+			<td>WLAN Signal (RSSI)</td>
 			<td>
 				<output id="wlan_rssi"></output>
 			</td>
 		</tr>
 		<tr>
-			<td>MAC Address</td>	
+			<td>MAC Address</td>
 			<td>
 				<output id="mac_address"></output>
 			</td>
 		</tr>
 		<tr>
-			<td>Network Configuration</td>	
+			<td>Network Configuration</td>
 			<td>
 				<output id="network_config"></output>
 			</td>
 		</tr>
 		<tr>
-			<td>IPv4 Address</td>	
+			<td>IPv4 Address</td>
 			<td>
 				<output id="ipv4_address"></output>
 			</td>
 		</tr>
 		<tr>
-			<td>Netmask Address</td>	
+			<td>Netmask Address</td>
 			<td>
 				<output id="netmask_address"></output>
 			</td>
 		</tr>
 		<tr>
-			<td>Gateway Address</td>	
+			<td>Gateway Address</td>
 			<td>
 				<output id="gateway_address"></output>
 			</td>
 		</tr>
 		<tr>
-			<td>DNS Address</td>	
+			<td>DNS Address</td>
 			<td>
 				<output id="dns_address"></output>
 			</td>
@@ -255,7 +255,7 @@
 			<col span="1" style="width: 35%;">
 			<col span="1" style="width: 65%;">
 		</colgroup>
-		<tr>			
+		<tr>
 			<h3>Device</h3>
 		</tr>
 		<tr>
@@ -301,7 +301,7 @@
 			<col span="1" style="width: 35%;">
 			<col span="1" style="width: 65%;">
 		</colgroup>
-		<tr>			
+		<tr>
 			<h3>Camera</h3>
 		</tr>
 		<tr>
@@ -323,7 +323,7 @@
 			<col span="1" style="width: 35%;">
 			<col span="1" style="width: 65%;">
 		</colgroup>
-		<tr>			
+		<tr>
 			<h3>SD Card</h3>
 		</tr>
 		<tr>
@@ -363,7 +363,7 @@
 			</td>
 		</tr>
 		<tr>
-			<td>Partition Free Space</td>	
+			<td>Partition Free Space</td>
 			<td>
 				<output id="sd_partition_free"></output>
 			</td>
@@ -375,47 +375,47 @@
 			<col span="1" style="width: 35%;">
 			<col span="1" style="width: 65%;">
 		</colgroup>
-		<tr>			
+		<tr>
 			<h3>Memory</h3>
 		</tr>
 		<tr>
-			<td>Total Free (Int + Ext)</td>	
+			<td>Total Free (Int + Ext)</td>
 			<td>
 				<output id="heap_total_free"></output>
 			</td>
 		</tr>
 		<tr>
-			<td>Ext. RAM - Free</td>	
+			<td>Ext. RAM - Free</td>
 			<td>
 				<output id="heap_spiram_free"></output>
 			</td>
 		</tr>
 		<tr>
-			<td>Ext. RAM - Largest Free Block</td>	
+			<td>Ext. RAM - Largest Free Block</td>
 			<td>
 				<output id="heap_spiram_largest_free"></output>
 			</td>
 		</tr>
 		<tr>
-			<td>Ext. RAM - Min Free</td>	
+			<td>Ext. RAM - Min Free</td>
 			<td>
 				<output id="heap_spiram_min_free"></output>
 			</td>
 		</tr>
 		<tr>
-			<td>Int. RAM - Free</td>	
+			<td>Int. RAM - Free</td>
 			<td>
 				<output id="heap_internal_free"></output>
 			</td>
 		</tr>
 		<tr>
-			<td>Int. RAM - Largest Free Block</td>	
+			<td>Int. RAM - Largest Free Block</td>
 			<td>
 				<output id="heap_internal_largest_free"></output>
 			</td>
 		</tr>
 		<tr>
-			<td>Int. RAM - Min Free</td>	
+			<td>Int. RAM - Min Free</td>
 			<td>
 				<output id="heap_internal_min_free"></output>
 			</td>
@@ -478,13 +478,13 @@
 
 
 <script type="text/javascript">
-	function loadInfoData() 
+	function loadInfoData()
 	{
-		url = getDomainname() + '/info';     
+		url = getDomainname() + '/info';
 		var xhttp = new XMLHttpRequest();
 		xhttp.onreadystatechange = function() {
 			if (this.readyState == 4 && this.status == 200) {
-				const _jsonData = JSON.parse(xhttp.responseText);			
+				const _jsonData = JSON.parse(xhttp.responseText);
 				document.getElementById("process_status").value = _jsonData.process_status;
 				if (_jsonData.process_status.substr(0,10) == "Processing")
 					addClassToElement("process_status", "badge-success");
@@ -494,7 +494,7 @@
 				document.getElementById("process_interval").value = _jsonData.process_interval + " Minutes";
 				document.getElementById("process_time").value = _jsonData.process_time + " Seconds";
 				document.getElementById("cycle_counter").value = _jsonData.cycle_counter;
-				
+
 				document.getElementById("datalogging_sdcard_status").value = _jsonData.datalogging_sdcard_status;
 				if (_jsonData.datalogging_sdcard_status == "Enabled")
 					addClassToElement("datalogging_sdcard_status", "badge-success");
@@ -526,7 +526,7 @@
 					document.getElementById("influxdbv1_status").value += " (Unknown Status)"
 					addClassToElement("influxdbv1_status", "badge-error");
 				}
-				
+
 				document.getElementById("influxdbv2_status").value = _jsonData.influxdbv2_status;
 				if (_jsonData.influxdbv2_status.substring(0,7) == "Enabled")
 					addClassToElement("influxdbv2_status", "badge-success");
@@ -551,16 +551,16 @@
 
 				//Input format (ISO): 2023-10-23T14:26:34+0200
 				document.getElementById("device_starttime").value = _jsonData.device_starttime.substr(0,10) + " " +
-																	 _jsonData.device_starttime.substr(11,8) + " (UTC" +	
+																	 _jsonData.device_starttime.substr(11,8) + " (UTC" +
 																	 _jsonData.device_starttime.substr(19,5) + ")";
-				
+
 				//Input format (ISO): 2023-10-23T14:26:34+0200
 				document.getElementById("current_time").value = _jsonData.current_time.substr(0,10) + " " +
-												_jsonData.current_time.substr(11,8) + " (UTC" +	
-												_jsonData.current_time.substr(19,5) + ")";	
+												_jsonData.current_time.substr(11,8) + " (UTC" +
+												_jsonData.current_time.substr(19,5) + ")";
 
 				document.getElementById("device_uptime").value = formatUptime(_jsonData.device_uptime);
-	
+
 				document.getElementById("wlan_status").value = _jsonData.wlan_status;
 				if (_jsonData.wlan_status == "Connected")
 					addClassToElement("wlan_status", "badge-success");
@@ -574,7 +574,7 @@
 				document.getElementById("ipv4_address").value = _jsonData.ipv4_address;
 				document.getElementById("netmask_address").value = _jsonData.netmask_address;
 				document.getElementById("gateway_address").value = _jsonData.gateway_address;
-				document.getElementById("dns_address").value = _jsonData.dns_address;			
+				document.getElementById("dns_address").value = _jsonData.dns_address;
 				document.getElementById("hostname").value =_jsonData.hostname;
 
 				document.getElementById("board_type").value = _jsonData.board_type;
@@ -586,7 +586,7 @@
 
 				document.getElementById("camera_type").value = _jsonData.camera_type;
 				document.getElementById("camera_frequency").value = _jsonData.camera_frequency + "  Mhz";
-				
+
 				document.getElementById("sd_name").value = _jsonData.sd_name;
 				document.getElementById("sd_manufacturer").value = _jsonData.sd_manufacturer;
 				document.getElementById("sd_capacity").value = _jsonData.sd_capacity + " MB";
@@ -605,18 +605,18 @@
 
 				const FirmwareVersionSplit = _jsonData.firmware_version.split('Commit: ');
 				const FirmwareVersionCommit = FirmwareVersionSplit[1].substring(0, 7);
-				const FirmwareVersionString = FirmwareVersionSplit[0] + "Commit: <a href=\"https://github.com/Slider0007/AI-on-the-edge-device/commits/" + 
+				const FirmwareVersionString = FirmwareVersionSplit[0] + "Commit: <a href=\"https://github.com/Slider0007/AI-on-the-edge-device/commits/" +
 										FirmwareVersionCommit + "\" target=\"_blank\">" + FirmwareVersionCommit + "</a>)";
 				document.getElementById("firmware_version").innerHTML = FirmwareVersionString;
-				
+
 				//Input format (ISO): 2023-10-23T14:26:34+0000
 				document.getElementById("build_time").value = _jsonData.build_time.substr(0,10) + " " +
-												 _jsonData.build_time.substr(11,8) + " (UTC" +	
+												 _jsonData.build_time.substr(11,8) + " (UTC" +
 												 _jsonData.build_time.substr(19,5) + ")";
-				
+
 				const HTMLVersionSplit = _jsonData.html_version.split('Commit: ');
 				const HTMLVersionCommit = HTMLVersionSplit[1].substring(0, 7);
-				const HTMLVersionString = HTMLVersionSplit[0] + "Commit: <a href=\"https://github.com/Slider0007/AI-on-the-edge-device/commits/" + 
+				const HTMLVersionString = HTMLVersionSplit[0] + "Commit: <a href=\"https://github.com/Slider0007/AI-on-the-edge-device/commits/" +
 									HTMLVersionCommit + "\" target=\"_blank\">" + HTMLVersionCommit + "</a>)";
 				document.getElementById("html_version").innerHTML = HTMLVersionString;
 				document.getElementById("config_file_version").value = _jsonData.config_file_version;

--- a/sd-card/html/log.html
+++ b/sd-card/html/log.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" xml:lang="en"> 
+<html lang="en" xml:lang="en">
 <head>
     <meta charset="UTF-8">
     <title>Log Viewer</title>
@@ -68,13 +68,13 @@
     </div>
 
 
-<script src="common.js?v=$COMMIT_HASH"></script> 
-<script>  
+<script src="common.js?v=$COMMIT_HASH"></script>
+<script>
     function reload() {
         document.getElementById('log').innerHTML += "<b>Refreshing...</b>";
         window.scrollBy(0,document.body.scrollHeight);
         funcRequest(getDomainname() + '/log');
-    } 
+    }
 
 
     function processLogLine(line, index, arr) {

--- a/sd-card/html/ota_page.html
+++ b/sd-card/html/ota_page.html
@@ -15,14 +15,14 @@
             -webkit-text-size-adjust: 100%;
             text-size-adjust: 100%;
         }
-                
+
         input[type=file] {
             width: 660px;
             padding: 5px 0px;
             display: inline-block;
-            font-size: 16px; 
-        }    
-        
+            font-size: 16px;
+        }
+
         .button {
             padding: 5px 10px;
             width: 205px;
@@ -48,7 +48,7 @@
     <br>
 
     <p><b>Recommended procedure to update the complete device over the air:</b></p>
-    <b>Use update package (<i>*__update__{board type}__*.zip</i>) from 
+    <b>Use update package (<i>*__update__{board type}__*.zip</i>) from
     <a href="https://github.com/Slider0007/AI-on-the-edge-device/releases" target="_blank">github release page</a></b>
     <br>
     Note: Using this, firmware + SD card gets updated, configuration remains unchanged
@@ -81,14 +81,14 @@
 <script>
     var domainname = getDomainname();
     var action_runtime = 0;
-    
+
     /* Max size of an individual file. Make sure this
     * value is same as that set in server_file.c */
     var MAX_FILE_SIZE = 8000*1024;
     var MAX_FILE_SIZE_STR = "8MB";
 
     getBoardType();
-    
+
     function validate_file()
     {
         document.getElementById("start_OTA_button").disabled = true;
@@ -162,7 +162,7 @@
                     document.getElementById("board_type").innerHTML = xhttp.responseText;
                 }
                 else {
-                    firework.launch("Loading board type failed (Response status: " + this.status + 
+                    firework.launch("Loading board type failed (Response status: " + this.status +
                                     "). Repeat action or check logs.", 'danger', 30000);
                     console.error("Loading board type failed. Response status: " + this.status);
                 }
@@ -205,7 +205,7 @@
         var file_name = document.getElementById("file_selector").value;
         filePath = file_name.split(/[\\\/]/).pop();
 
-        /* first delete the old firmware AND empty the /firmware directory*/	
+        /* first delete the old firmware AND empty the /firmware directory*/
         xhttp.onreadystatechange = function() {
             if (xhttp.readyState == 4) {
                 if (xhttp.status == 200) {
@@ -230,7 +230,7 @@
         document.getElementById("status").innerText = "Status: Processing on device...";
 
         var xhttp = new XMLHttpRequest();
-        /* first delete the old firmware */	
+        /* first delete the old firmware */
         xhttp.onreadystatechange = function() {
             if (xhttp.readyState == 4) {
                 if (xhttp.status == 200) {
@@ -240,12 +240,12 @@
                         console.log("Upload completed, the device will now restart and install the update!");
                         document.getElementById("status").innerText = "Status: Installing...";
                         firework.launch('Upload completed, the device will now restart and install the update', 'success', 5000);
-                    
+
                         /* Tell it to reboot */
                         doRebootAfterUpdate();
 
                         action_runtime = 0;
-                        updateTimer = setInterval(function() {                            
+                        updateTimer = setInterval(function() {
                             action_runtime += 1;
                             _("progressBar").value = Math.round(action_runtime);
 
@@ -261,7 +261,7 @@
                                 firework.launch("Reboot takes unusually long. Reload this page or power cycle the device", 'danger', 30000);
                                 clearInterval(updateTimer);
                             }
-                        }, 3000);                           
+                        }, 3000);
                     }
                     else // No reboot required
                     {
@@ -313,7 +313,7 @@
 
     function progressHandler(event)
     {
-        _("loaded_n_total").innerHTML = "Uploaded " + (event.loaded / 1024 / 1024).toFixed(2) + 
+        _("loaded_n_total").innerHTML = "Uploaded " + (event.loaded / 1024 / 1024).toFixed(2) +
                 " MB of " + (event.total / 1024/ 1024).toFixed(2) + " MB";
         var percent = (event.loaded / event.total) * 100;
         _("progressBar").value = Math.round(percent);
@@ -326,7 +326,7 @@
         _("status").innerHTML = "Status: " + event.target.responseText;
         _("progressBar").value = 0; //will clear progress bar after successful upload
         _("loaded_n_total").innerHTML = "";
-    
+
         extract();
     }
 
@@ -348,4 +348,4 @@
 </script>
 
 </body>
-</html> 
+</html>

--- a/sd-card/html/overview.html
+++ b/sd-card/html/overview.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" xml:lang="en"> 
+<html lang="en" xml:lang="en">
 <head>
 	<meta charset="UTF-8">
 	<title>Overview</title>
@@ -50,7 +50,7 @@
 			border: 1px solid red;
 		}
 	</style>
-	
+
 	<script src="jquery-3.6.0.min.js?v=$COMMIT_HASH"></script>
 </head>
 
@@ -71,7 +71,7 @@
 
 						</td>
 						<td style="padding:0px;">
-							<input required type="number" name="AutoRefreshTime" id="AutoRefreshTime" min="1" step="1" value="10" 
+							<input required type="number" name="AutoRefreshTime" id="AutoRefreshTime" min="1" step="1" value="10"
 							oninput="(!validity.rangeUnderflow||(value=2));" onchange="AutoRefreshContent();"> s
 						</td>
 					</tr>
@@ -87,49 +87,49 @@
 		</tr>
 		<tr>
 			<th class="th">Actual Value</th>
-		</tr> 
-		<tr>	
+		</tr>
+		<tr>
 			<td class="tg-2">
 				<div id="value"></div>
-			</td>	
+			</td>
 		</tr>
 		<tr>
 			<th class="th">Fallback Value</th>
-		</tr>	
-		<tr>	
+		</tr>
+		<tr>
 			<td class="tg-2">
 				<div id="fallback"></div>
-			</td>	
+			</td>
 		</tr>
 		<tr>
 			<th class="th">Raw Value</th>
-		</tr>	
-		<tr>	
+		</tr>
+		<tr>
 			<td class="tg-2">
 				<div id="raw"></div>
-			</td>	
+			</td>
 		</tr>
 		<tr>
 			<th class="th">Value Status</th>
-		</tr>	
-		<tr>	
+		</tr>
+		<tr>
 			<td class="tg-2">
 				<div id="status"></div>
-			</td>	
+			</td>
 		</tr>
 		<tr>
 			<th class="th">Process State</th>
-		</tr>	
-		<tr>	
+		</tr>
+		<tr>
 			<td class="tg-3">
 				<div id="statusflow" ></div>
 				<div id="processerror" style="color: rgb(255, 0, 0); font-weight: bold;"></div>
 			</td>
-		</tr>  
+		</tr>
 		<tr>
 			<th class="th">System Info</th>
-		</tr>	
-		<tr>	
+		</tr>
+		<tr>
 			<td>
 				<table>
 					<tr><td style="padding: 0px;">Device Uptime</td><td style="padding: 0px 20px"><output id="device_uptime"></output></td></tr>
@@ -141,7 +141,7 @@
 	</table>
 
 
-<script src="common.js?v=$COMMIT_HASH"></script> 
+<script src="common.js?v=$COMMIT_HASH"></script>
 <script src="readconfigcommon.js?v=$COMMIT_HASH"></script>
 <script src="readconfigparam.js?v=$COMMIT_HASH"></script>
 <script>
@@ -162,7 +162,7 @@
 		var xhttp = new XMLHttpRequest();
 		xhttp.onreadystatechange = function() {
 			if (this.readyState == 4 && this.status == 200) {
-				const _jsonData = JSON.parse(xhttp.responseText);			
+				const _jsonData = JSON.parse(xhttp.responseText);
 				loadValue(_jsonData.actual_value.inline, "value", "border-collapse: collapse; width: 100%");
 				loadValue(_jsonData.fallback_value.inline, "fallback", "border-collapse: collapse; width: 100%");
 				loadValue(_jsonData.raw_value.inline, "raw", "border-collapse: collapse; width: 100%");
@@ -180,7 +180,7 @@
 		xhttp.send();
 	}
 
-	
+
 	function LoadROIImage()
 	{
 		var d = new Date();
@@ -189,7 +189,7 @@
 		var s = addZero(d.getSeconds());
 		$('#timestamp').html(h + ":" + m + ":" + s);
 
-		document.getElementById("img").src = loadImage(domainname + '/img_tmp/alg_roi.jpg?' + Math.floor((Math.random() * 1000000) + 1), 
+		document.getElementById("img").src = loadImage(domainname + '/img_tmp/alg_roi.jpg?' + Math.floor((Math.random() * 1000000) + 1),
 														'img_not_available.png?v=$COMMIT_HASH').src;
 	}
 
@@ -232,7 +232,7 @@
 		}
 		else {
 			for (var j = 0; j < _split.length; ++j) {
-				var _zer = ZerlegeZeile(_split[j], "\t");				
+				var _zer = ZerlegeZeile(_split[j], "\t");
 				if (_div == "status") {
 					if (_zer[1] != null && _zer[1].length > 0) {
 						if (_zer[1].substring(0,3) == "000")
@@ -249,13 +249,13 @@
 							_zer[1] = "";
 					}
 				}
-				
+
 				if (_zer.length == 1)
-					out = out + "<tr><td style=\"width: 22%; padding: 3px 5px; text-align: left; vertical-align:middle; border: 1px solid lightgrey\">" + 
-						_zer[0] + "</td><td style=\"padding: 3px 5px; text-align: left; vertical-align:middle; border: 1px solid lightgrey\"> </td></tr>"; 
+					out = out + "<tr><td style=\"width: 22%; padding: 3px 5px; text-align: left; vertical-align:middle; border: 1px solid lightgrey\">" +
+						_zer[0] + "</td><td style=\"padding: 3px 5px; text-align: left; vertical-align:middle; border: 1px solid lightgrey\"> </td></tr>";
 				else
-					out = out + "<tr><td style=\"width: 22%; padding: 3px 5px; text-align: left; vertical-align:middle; border: 1px solid lightgrey\">" + 
-						_zer[0] + "</td><td style=\"padding: 3px 5px; text-align: left; vertical-align:middle; border: 1px solid lightgrey\" >" + _zer[1] + "</td></tr>"; 
+					out = out + "<tr><td style=\"width: 22%; padding: 3px 5px; text-align: left; vertical-align:middle; border: 1px solid lightgrey\">" +
+						_zer[0] + "</td><td style=\"padding: 3px 5px; text-align: left; vertical-align:middle; border: 1px solid lightgrey\" >" + _zer[1] + "</td></tr>";
 			}
 			out = out + "</table>"
 		}
@@ -286,7 +286,7 @@
 
 
 	function loadWLANRSSI(_value)
-	{		
+	{
 		if (_value >= -55) {
 			$('#wlan_rssi').html("Excellent (" + _value + "dBm)");
 		}
@@ -306,12 +306,12 @@
 
 
 	function ManualRefreshContent()
-	{	
+	{
 		document.getElementById("manual_refresh_img_loading").style.display=""; // Display loading spinner as visual feedback
 
 		LoadProcessData();
 		LoadROIImage();
-		
+
 		setTimeout(function() { // Show loading spinner at least for 200ms
 			document.getElementById("manual_refresh_img_loading").style.display="none";
 		}, 200);
@@ -324,8 +324,8 @@
         param = getConfigParameters();
 
 		document.getElementById("AutoRefreshEnabled").checked = param["WebUI"]["OverviewAutoRefresh"]["value1"] == "true" ? true : false;
-		document.getElementById("AutoRefreshTime").value = param["WebUI"]["OverviewAutoRefreshTime"]["value1"];   
-        
+		document.getElementById("AutoRefreshTime").value = param["WebUI"]["OverviewAutoRefreshTime"]["value1"];
+
         autoRefreshTimeoutHandle = null; // Init auto refresh handle
         AutoRefreshContent();
     }
@@ -333,7 +333,7 @@
 
 
 	function AutoRefreshContent()
-	{	
+	{
 		if (document.getElementById("AutoRefreshEnabled").checked == true) { // Activated -> Set timeout
 
 			if (autoRefreshTimeoutHandle) { // Clear actual timeout handle
@@ -378,7 +378,7 @@
 		loadConfig().then(() => initAutoRefreshContent());
 	}
 
-	
+
 	init();
 
 </script>

--- a/sd-card/html/readconfigcommon.js
+++ b/sd-card/html/readconfigcommon.js
@@ -6,7 +6,7 @@ function reload_config()
      xhttp.onreadystatechange = function() {
           if (this.readyState == 4) {
                if (this.status >= 200 && this.status < 300) {
-                    if (xhttp.responseText.substring(0,3) == "001" || xhttp.responseText.substring(0,3) == "002" || 
+                    if (xhttp.responseText.substring(0,3) == "001" || xhttp.responseText.substring(0,3) == "002" ||
                          xhttp.responseText.substring(0,3) == "003")
                     {
                          firework.launch('Configuration updated and applied', 'success', 2000);
@@ -19,19 +19,19 @@ function reload_config()
                     }
                }
                else {
-                    firework.launch("Configuration update failed (Response status: " + this.status + 
+                    firework.launch("Configuration update failed (Response status: " + this.status +
                                     "). Repeat action or check logs.", 'danger', 30000);
-                    console.error("Configuration update failed. Response status: " + this.status);  
+                    console.error("Configuration update failed. Response status: " + this.status);
                }
           }
      };
-     
+
      xhttp.timeout = 10000;  // 10 seconds
      xhttp.open("GET", url, true);
      xhttp.send();
 }
 
-   
+
 function dataURLtoBlob(dataurl)
 {
      var arr = dataurl.split(','), mime = arr[0].match(/:(.*?);/)[1],
@@ -40,8 +40,8 @@ function dataURLtoBlob(dataurl)
           u8arr[n] = bstr.charCodeAt(n);
      }
      return new Blob([u8arr], {type:mime});
-}	
- 
+}
+
 
 async function FileCopyOnServer(_source, _target, _domainname = "", async = false)
 {
@@ -55,14 +55,14 @@ async function FileCopyOnServer(_source, _target, _domainname = "", async = fals
                          return resolve("Copy file request successful");
                     }
                     if (this.status > 400) {
-                         firework.launch("Copy file request failed (Response status: " + this.status + 
+                         firework.launch("Copy file request failed (Response status: " + this.status +
                                              "). Repeat action or check logs.", 'danger', 30000);
                          console.error("Copy file request failed. Response status: " + this.status);
                          return reject("Copy file request failed");
                     }
                }
           };
-     
+
           if (async)
                xhttp.timeout = 10000;  // 10 seconds
 
@@ -84,7 +84,7 @@ function FileDeleteOnServer(_filename, _domainname = "")
                     okay = true;
                }
                else {
-                    firework.launch("File delete request failed (Response status: " + this.status + 
+                    firework.launch("File delete request failed (Response status: " + this.status +
                                         "). Repeat action or check logs.", 'danger', 30000);
                     console.error("File delete request failed. Response status: " + this.status);
                     okay = false;
@@ -103,18 +103,18 @@ function FileSendContent(_content, _filename, _domainname = "")
 {
      var okay = false;
      var url = _domainname + "/upload" + _filename;
-     
-     var xhttp = new XMLHttpRequest();  
+
+     var xhttp = new XMLHttpRequest();
      xhttp.onreadystatechange = function() {
           if (xhttp.readyState == 4) {
                if (xhttp.status >= 200 && xhttp.status < 300) {
                     okay = true;
-               } 
+               }
                else if (xhttp.status == 0) {
 				firework.launch('File send request failed. Server closed the connection abruptly!', 'danger', 30000);
-               } 
+               }
                else {
-                    firework.launch("File send request failed (Response status: " + this.status + 
+                    firework.launch("File send request failed (Response status: " + this.status +
                                         "). Repeat action or check logs.", 'danger', 30000);
                     console.error("File send request failed. Response status: " + this.status);
                     okay = false;
@@ -125,20 +125,20 @@ function FileSendContent(_content, _filename, _domainname = "")
      xhttp.open("POST", url, false);
      xhttp.send(_content);
 
-     return okay;        
+     return okay;
 }
 
 
 function SaveCanvasToImage(_canvas, _filename, _delete = true, _domainname = "")
 {
      var JPEG_QUALITY=0.8;
-     var dataUrl = _canvas.toDataURL('image/jpeg', JPEG_QUALITY);	
+     var dataUrl = _canvas.toDataURL('image/jpeg', JPEG_QUALITY);
      var rtn = dataURLtoBlob(dataUrl);
 
      if (_delete) {
           FileDeleteOnServer(_filename, _domainname);
      }
-	
+
      FileSendContent(rtn, _filename, _domainname);
 }
 
@@ -155,11 +155,11 @@ function SaveConfigToServer(_domainname)
      for (var i = 0; i < config_split.length; ++i)
      {
           _config_gesamt = _config_gesamt + config_split[i] + "\n";
-     } 
+     }
 
      // Save to temporary file and then promote to config.ini on firmware level (server_file.cpp)
      // -> Reduce data loss risk (e.g. network connection got interrupted during data transfer)
-     FileSendContent(_config_gesamt, "/config/config.tmp", _domainname);       
+     FileSendContent(_config_gesamt, "/config/config.tmp", _domainname);
 }
 
 
@@ -168,7 +168,7 @@ function loadImage(url, altUrl)
 {
     var timer;
     function clearTimer() {
-        if (timer) {                
+        if (timer) {
             clearTimeout(timer);
             timer = null;
         }
@@ -191,7 +191,7 @@ function loadImage(url, altUrl)
         clearTimer();
     };
     img.src = url;
-    timer = setTimeout(function(theImg) { 
+    timer = setTimeout(function(theImg) {
         return function() {
             handleFail.call(theImg);
         };
@@ -206,16 +206,16 @@ function ZerlegeZeile(input, delimiter = " =\t\r")
 //          delimiter = " =,\t";
 
 
-     /* The input can have multiple formats: 
+     /* The input can have multiple formats:
           *  - key = value
           *  - key = value1 value2 value3 ...
           *  - key value1 value2 value3 ...
-          *  
+          *
           * Examples:
           *  - ImageSize = VGA
-          *  - IO0 = input disabled 10 false false 
+          *  - IO0 = input disabled 10 false false
           *  - main.dig1 28 144 55 100 false
-          * 
+          *
           * This causes issues eg. if a password key has a whitespace or equal sign in its value.
           * As a workaround and to not break any legacy usage, we enforce to only use the
           * equal sign, if the key is "password"
@@ -243,7 +243,7 @@ function ZerlegeZeile(input, delimiter = " =\t\r")
 
      return Output;
 
-}    
+}
 
 
 function findDelimiterPos(input, delimiter)
@@ -270,14 +270,14 @@ function findDelimiterPos(input, delimiter)
      return pos;
 }
 
-     
+
 
 function trim(istring, adddelimiter)
 {
      while ((istring.length > 0) && (adddelimiter.indexOf(istring[0]) >= 0)) {
           istring = istring.substr(1, istring.length-1);
      }
-     
+
      while ((istring.length > 0) && (adddelimiter.indexOf(istring[istring.length-1]) >= 0)) {
           istring = istring.substr(0, istring.length-1);
      }

--- a/sd-card/html/readconfigparam.js
+++ b/sd-card/html/readconfigparam.js
@@ -10,7 +10,7 @@ let pinConfig = {};      // Board pin configuration
 async function getDataFileList()
 {
     return new Promise(function (resolve, reject) {
-        var url = getDomainname() + '/editflow?task=data';     
+        var url = getDomainname() + '/editflow?task=data';
 
         var xhttp = new XMLHttpRequest();
         xhttp.onreadystatechange = function() {
@@ -23,7 +23,7 @@ async function getDataFileList()
                         return resolve(datalist);
                     }
                     else {
-                        firework.launch("Data files request failed (Response status: " + this.status + 
+                        firework.launch("Data files request failed (Response status: " + this.status +
                                 "). Repeat action or check logs.", 'danger', 30000);
                         console.error("Data files request failed. Response status: " + this.status);
                         return reject("Data files request failed");
@@ -54,7 +54,7 @@ async function fetchTFLITEList()
                         return resolve(tflite_list);
                 }
                 else {
-                        firework.launch("TFLite files request failed (Response status: " + this.status + 
+                        firework.launch("TFLite files request failed (Response status: " + this.status +
                                 "). Repeat action or check logs.", 'danger', 30000);
                         console.error("TFLite files request failed. Response status: " + this.status);
                         return reject("TFLite files request failed");
@@ -82,7 +82,7 @@ function loadPinConfig()
                          return resolve(pinConfig);
                     }
                     else {
-                         firework.launch("Loading GPIO pin config failed (Response status: " + this.status + 
+                         firework.launch("Loading GPIO pin config failed (Response status: " + this.status +
                                         "). Repeat action or check logs.", 'danger', 30000);
                          console.error("Loading GPIO pin config failed. Response status: " + this.status);
                          return reject("Loading GPIO pin config failed");
@@ -110,7 +110,7 @@ async function loadConfigIni()
                          return resolve(config_gesamt);
                     }
                     else {
-                         firework.launch("Loading config.ini failed (Response status: " + this.status + 
+                         firework.launch("Loading config.ini failed (Response status: " + this.status +
                                         "). Repeat action or check logs.", 'danger', 30000);
                          console.error("Loading config.ini failed. Response status: " + this.status);
                          return reject("Loading config.ini failed");
@@ -144,14 +144,14 @@ function ParseConfig()
      var aktline = 0;
 
      var catname = "ConfigFile";
-     category[catname] = new Object(); 
+     category[catname] = new Object();
      category[catname]["enabled"] = true;
      category[catname]["found"] = true;
      param[catname] = new Object();
      ParamAddSingleValueWithPreset(param, catname, "Version", true, "0");
 
      var catname = "TakeImage";
-     category[catname] = new Object(); 
+     category[catname] = new Object();
      category[catname]["enabled"] = true;
      category[catname]["found"] = true;
      param[catname] = new Object();
@@ -177,32 +177,32 @@ function ParseConfig()
      ParamAddSingleValueWithPreset(param, catname, "ZoomMode", true, "0");
      ParamAddSingleValueWithPreset(param, catname, "ZoomOffsetX", true, "0");
      ParamAddSingleValueWithPreset(param, catname, "ZoomOffsetY", true, "0");
-     ParamAddSingleValueWithPreset(param, catname, "Demo", true, "false");    
+     ParamAddSingleValueWithPreset(param, catname, "Demo", true, "false");
 
      var catname = "Alignment";
-     category[catname] = new Object(); 
+     category[catname] = new Object();
      category[catname]["enabled"] = true;
      category[catname]["found"] = true;
      param[catname] = new Object();
      ParamAddSingleValueWithPreset(param, catname, "AlignmentAlgo", true, "Default");
      ParamAddSingleValueWithPreset(param, catname, "SearchFieldX", true, "20");
-     ParamAddSingleValueWithPreset(param, catname, "SearchFieldY", true, "20");     
+     ParamAddSingleValueWithPreset(param, catname, "SearchFieldY", true, "20");
      ParamAddSingleValueWithPreset(param, catname, "InitialRotate", true, "0.0");
      ParamAddSingleValueWithPreset(param, catname, "FlipImageSize", true, "false");
      ParamAddSingleValueWithPreset(param, catname, "SaveDebugInfo", true, "false");
 
      var catname = "Digits";
-     category[catname] = new Object(); 
+     category[catname] = new Object();
      category[catname]["enabled"] = false;
      category[catname]["found"] = true;
      param[catname] = new Object();
      ParamAddModelWithPreset(param, catname, "Model", true);
-     ParamAddSingleValueWithPreset(param, catname, "CNNGoodThreshold", true, "0.0"); 
+     ParamAddSingleValueWithPreset(param, catname, "CNNGoodThreshold", true, "0.0");
      ParamAddSingleValueWithPreset(param, catname, "ROIImagesLocation", false, "/log/digit");
      ParamAddSingleValueWithPreset(param, catname, "ROIImagesRetention", false, "5");
 
      var catname = "Analog";
-     category[catname] = new Object(); 
+     category[catname] = new Object();
      category[catname]["enabled"] = false;
      category[catname]["found"] = true;
      param[catname] = new Object();
@@ -211,7 +211,7 @@ function ParseConfig()
      ParamAddSingleValueWithPreset(param, catname, "ROIImagesRetention", false, "5");
 
      var catname = "PostProcessing";
-     category[catname] = new Object(); 
+     category[catname] = new Object();
      category[catname]["enabled"] = true;
      category[catname]["found"] = true;
      param[catname] = new Object();
@@ -228,7 +228,7 @@ function ParseConfig()
      ParamAddSingleValueWithPreset(param, catname, "SaveDebugInfo", true, "false");
 
      var catname = "MQTT";
-     category[catname] = new Object(); 
+     category[catname] = new Object();
      category[catname]["enabled"] = false;
      category[catname]["found"] = true;
      param[catname] = new Object();
@@ -250,7 +250,7 @@ function ParseConfig()
      ParamAddSingleValueWithPreset(param, catname, "HAMeterType", true, "water_m3");
 
      var catname = "InfluxDB";
-     category[catname] = new Object(); 
+     category[catname] = new Object();
      category[catname]["enabled"] = false;
      category[catname]["found"] = true;
      param[catname] = new Object();
@@ -266,7 +266,7 @@ function ParseConfig()
      ParamAddValue(param, catname, "Field", 1, true, "undefined");
 
      var catname = "InfluxDBv2";
-     category[catname] = new Object(); 
+     category[catname] = new Object();
      category[catname]["enabled"] = false;
      category[catname]["found"] = true;
      param[catname] = new Object();
@@ -282,31 +282,31 @@ function ParseConfig()
      ParamAddValue(param, catname, "Field", 1, true, "undefined");
 
      var catname = "GPIO";
-     category[catname] = new Object(); 
+     category[catname] = new Object();
      category[catname]["enabled"] = false;
      category[catname]["found"] = true;
      param[catname] = new Object();
-     ParamAddGpioWithPreset(param, catname, [null, null, /^[0-9]*$/, null, null, null, 
+     ParamAddGpioWithPreset(param, catname, [null, null, /^[0-9]*$/, null, null, null,
                               /^[0-9]*$/, /^[0-9]*$/, /^[0-9]*$/, /^[a-zA-Z0-9_-]*$/]);
 
      var catname = "AutoTimer";
-     category[catname] = new Object(); 
+     category[catname] = new Object();
      category[catname]["enabled"] = true;
      category[catname]["found"] = true;
      param[catname] = new Object();
      ParamAddSingleValueWithPreset(param, catname, "AutoStart", true, "true");
-     ParamAddSingleValueWithPreset(param, catname, "Interval", true, "5.0");     
+     ParamAddSingleValueWithPreset(param, catname, "Interval", true, "5.0");
 
      var catname = "DataLogging";
-     category[catname] = new Object(); 
+     category[catname] = new Object();
      category[catname]["enabled"] = true;
      category[catname]["found"] = true;
      param[catname] = new Object();
      ParamAddSingleValueWithPreset(param, catname, "DataLogActive", true, "true");
-     ParamAddSingleValueWithPreset(param, catname, "DataFilesRetention", true, "5");     
+     ParamAddSingleValueWithPreset(param, catname, "DataFilesRetention", true, "5");
 
      var catname = "Debug";
-     category[catname] = new Object(); 
+     category[catname] = new Object();
      category[catname]["enabled"] = true;
      category[catname]["found"] = true;
      param[catname] = new Object();
@@ -315,19 +315,19 @@ function ParseConfig()
      ParamAddSingleValueWithPreset(param, catname, "DebugFilesRetention", true, "5");
 
      var catname = "System";
-     category[catname] = new Object(); 
+     category[catname] = new Object();
      category[catname]["enabled"] = true;
      category[catname]["found"] = false;
      param[catname] = new Object();
-     ParamAddSingleValueWithPreset(param, catname, "TimeServer", true, "pool.ntp.org");   
+     ParamAddSingleValueWithPreset(param, catname, "TimeServer", true, "pool.ntp.org");
      ParamAddSingleValueWithPreset(param, catname, "TimeZone", true, "CET-1CEST,M3.5.0,M10.5.0/3");
-     ParamAddSingleValueWithPreset(param, catname, "Hostname", true, "watermeter");   
-     ParamAddSingleValueWithPreset(param, catname, "RSSIThreshold", false, "-75");   
+     ParamAddSingleValueWithPreset(param, catname, "Hostname", true, "watermeter");
+     ParamAddSingleValueWithPreset(param, catname, "RSSIThreshold", false, "-75");
      ParamAddSingleValueWithPreset(param, catname, "CPUFrequency", true, "160");
      ParamAddSingleValueWithPreset(param, catname, "SetupMode", true, "true");
 
      var catname = "WebUI";
-     category[catname] = new Object(); 
+     category[catname] = new Object();
      category[catname]["enabled"] = true;
      category[catname]["found"] = true;
      param[catname] = new Object();
@@ -335,7 +335,7 @@ function ParseConfig()
      ParamAddSingleValueWithPreset(param, catname, "OverviewAutoRefreshTime", true, "10");
      ParamAddSingleValueWithPreset(param, catname, "DataGraphAutoRefresh", true, "false");
      ParamAddSingleValueWithPreset(param, catname, "DataGraphAutoRefreshTime", true, "60");
-     
+
 
      while (aktline < config_split.length) {
           for (var cat in category) {
@@ -347,7 +347,7 @@ function ParseConfig()
                zw = cat.toUpperCase();
                zw1 = "[" + zw + "]";
                zw2 = ";[" + zw + "]";
-               
+
                if ((config_split[aktline].trim().toUpperCase() == zw1) || (config_split[aktline].trim().toUpperCase() == zw2)) {
                     if (config_split[aktline].trim().toUpperCase() == zw1) {
                          category[cat]["enabled"] = true;
@@ -358,7 +358,7 @@ function ParseConfig()
                     continue;
                }
           }
-          
+
           aktline++;
      }
 
@@ -388,31 +388,31 @@ function ParseConfigReduced() {
      var aktline = 0;
 
      param = new Object();
-     category = new Object(); 
+     category = new Object();
 
      var catname = "TakeImage";
-     category[catname] = new Object(); 
+     category[catname] = new Object();
      category[catname]["enabled"] = true;
      category[catname]["found"] = true;
      param[catname] = new Object();
      ParamAddSingleValueWithPreset(param, catname, "ImageSize", true, "VGA");
 
      var catname = "Alignment";
-     category[catname] = new Object(); 
+     category[catname] = new Object();
      category[catname]["enabled"] = true;
      category[catname]["found"] = true;
      param[catname] = new Object();
      ParamAddSingleValueWithPreset(param, catname, "FlipImageSize", true, "false");
 
      var catname = "MQTT";
-     category[catname] = new Object(); 
+     category[catname] = new Object();
      category[catname]["enabled"] = false;
      category[catname]["found"] = true;
      param[catname] = new Object();
      ParamAddSingleValueWithPreset(param, catname, "HomeassistantDiscovery", true, "false");
 
      var catname = "WebUI";
-     category[catname] = new Object(); 
+     category[catname] = new Object();
      category[catname]["enabled"] = true;
      category[catname]["found"] = false;
      param[catname] = new Object();
@@ -428,7 +428,7 @@ function ParseConfigReduced() {
                     aktline++;
                     continue;
                }
-               
+
                zw = cat.toUpperCase();
                zw1 = "[" + zw + "]";
                zw2 = ";[" + zw + "]";
@@ -450,10 +450,10 @@ function ParseConfigReduced() {
 
 function ParamAddValue(param, _cat, _param, _anzParam = 1, _isNUMBER = false, _defaultValue = "", _checkRegExList = null)
 {
-     param[_cat][_param] = new Object(); 
+     param[_cat][_param] = new Object();
      param[_cat][_param]["found"] = false;
      param[_cat][_param]["enabled"] = false;
-     param[_cat][_param]["line"] = -1; 
+     param[_cat][_param]["line"] = -1;
      param[_cat][_param]["anzParam"] = _anzParam;
      param[_cat][_param]["defaultValue"] = _defaultValue;   // Parameter only used for numbers sequences
      param[_cat][_param]["Numbers"] = _isNUMBER;
@@ -469,7 +469,7 @@ function ParamAddSingleValueWithPreset(param, _cat, _param, _enabled, _value)
           param[_cat][_param]["found"] = true;
           param[_cat][_param]["enabled"] = _enabled;
           param[_cat][_param]["value1"] = _value;
-          param[_cat][_param]["line"] = -1; 
+          param[_cat][_param]["line"] = -1;
           param[_cat][_param]["anzParam"] = 1;
           param[_cat][_param]["defaultValue"] = "";   // Parameter only used for numbers sequences
           param[_cat][_param]["Numbers"] = false;
@@ -485,7 +485,7 @@ function ParamAddModelWithPreset(param, _cat, _param, _enabled)
           param[_cat][_param] = new Object();
           param[_cat][_param]["found"] = true;
           param[_cat][_param]["enabled"] = _enabled;
-          param[_cat][_param]["line"] = -1; 
+          param[_cat][_param]["line"] = -1;
           param[_cat][_param]["anzParam"] = 1;
           param[_cat][_param]["defaultValue"] = "";   // Parameter only used for number sequences
           param[_cat][_param]["Numbers"] = false;
@@ -495,7 +495,7 @@ function ParamAddModelWithPreset(param, _cat, _param, _enabled)
                filter = "/dig";
           else if (_cat == "Analog")
                filter = "/ana";
-          
+
 
           for (var i = 0; i < tflite_list.length; ++i) {
                if (tflite_list[i].includes(filter)) {
@@ -529,7 +529,7 @@ function ParamAddGpioWithPreset(param, _cat, _checkRegExList = null)
                param[_cat][_name] = new Object();
                param[_cat][_name]["found"] = true;
                param[_cat][_name]["enabled"] = false;
-               param[_cat][_name]["line"] = -1; 
+               param[_cat][_name]["line"] = -1;
                param[_cat][_name]["anzParam"] = 13;
                param[_cat][_name]["value1"] = "input-pullup";
                param[_cat][_name]["value2"] = "cyclic-polling";
@@ -544,7 +544,7 @@ function ParamAddGpioWithPreset(param, _cat, _checkRegExList = null)
                param[_cat][_name]["value11"] = "255";
                param[_cat][_name]["value12"] = "100";
                param[_cat][_name]["value13"] = "";
-               param[_cat][_name].checkRegExList = _checkRegExList;   
+               param[_cat][_name].checkRegExList = _checkRegExList;
           }
      }
 }
@@ -572,8 +572,8 @@ function ParamResetGpioValuesToDefault(param, _cat, _name)
 function ParseConfigParamAll(_aktline, _catname){
      ++_aktline;
 
-     while ((_aktline < config_split.length) 
-            && !(config_split[_aktline][0] == "[") 
+     while ((_aktline < config_split.length)
+            && !(config_split[_aktline][0] == "[")
             && !((config_split[_aktline][0] == ";") && (config_split[_aktline][1] == "["))) {
           var _input = config_split[_aktline];
           let [isCom, input] = isCommented(_input);
@@ -593,8 +593,8 @@ function ParseConfigParamAll(_aktline, _catname){
           }
 
           ++_aktline;
-     }    
-     return _aktline; 
+     }
+     return _aktline;
 }
 
 function ParamExtractValue(_param, _linesplit, _catname, _paramname, _aktline, _iscom, _anzvalue = 1){
@@ -635,7 +635,7 @@ function ParamExtractValueAll(_param, _linesplit, _catname, _aktline, _iscom){
                     abc[_catname][paramname] = new Object;
                     abc[_catname][paramname]["found"] = true;
                     abc[_catname][paramname]["enabled"] = !_iscom;
-     
+
                     for (var j = 1; j <= _param[_catname][paramname]["anzParam"]; ++j) {
                          abc[_catname][paramname]["value"+j] = _linesplit[j];
                     }
@@ -699,8 +699,8 @@ function WriteConfigININew()
                     {
                          text = NUMBERS[_num]["name"] + "." + name;
 
-                         var text = text + " =" 
-                         
+                         var text = text + " ="
+
                          for (var j = 1; j <= param[cat][name]["anzParam"]; ++j) {
                               if (!(typeof NUMBERS[_num][cat][name]["value"+j] == 'undefined'))
                                    text = text + " " + NUMBERS[_num][cat][name]["value"+j];
@@ -713,8 +713,8 @@ function WriteConfigININew()
                }
                else
                {
-                    var text = name + " =" 
-                    
+                    var text = name + " ="
+
                     for (var j = 1; j <= param[cat][name]["anzParam"]; ++j) {
                          if (!(typeof param[cat][name]["value"+j] == 'undefined'))
                               text = text + " " + param[cat][name]["value"+j];
@@ -788,7 +788,7 @@ function isCommented(input)
                input = input.substr(1, input.length-1);
           };
           return [isComment, input];
-     }    
+     }
 
 
 function getConfigCategory() {
@@ -856,7 +856,7 @@ function getNUMBERS(_name, _type, _create = true)
                          _ret[_cat][_param] = new Object();
                          _ret[_cat][_param]["found"] = false;
                          _ret[_cat][_param]["enabled"] = false;
-                         _ret[_cat][_param]["anzParam"] = param[_cat][_param]["anzParam"]; 
+                         _ret[_cat][_param]["anzParam"] = param[_cat][_param]["anzParam"];
 
                     }
 
@@ -888,11 +888,11 @@ function getNumberSequences(){
 
 function CreateNumberSequence(_sequence_name)
 {
-     if ((_sequence_name.indexOf(".") >= 0) || (_sequence_name.indexOf(",") >= 0) || 
+     if ((_sequence_name.indexOf(".") >= 0) || (_sequence_name.indexOf(",") >= 0) ||
      (_sequence_name.indexOf(" ") >= 0) || (_sequence_name.indexOf("\"") >= 0)) {
           return "Number sequence name must not contain , . \" or a space";
      }
-     
+
      found = false;
      for (i = 0; i < NUMBERS.length; ++i) {
           if (NUMBERS[i]["name"] == _sequence_name)
@@ -928,17 +928,17 @@ function CreateNumberSequence(_sequence_name)
                          _ret[_cat][_param]["value1"] = param[_cat][_param]["defaultValue"];
 
                     }
-                    _ret[_cat][_param]["anzParam"] = param[_cat][_param]["anzParam"]; 
+                    _ret[_cat][_param]["anzParam"] = param[_cat][_param]["anzParam"];
 
                }
 
-     NUMBERS.push(_ret);               
+     NUMBERS.push(_ret);
      return "";
 }
 
 
 function RenameNumberSequence(_sequence_name_old, _sequence_name_new){
-     if ((_sequence_name_new.indexOf(".") >= 0) || (_sequence_name_new.indexOf(",") >= 0) || 
+     if ((_sequence_name_new.indexOf(".") >= 0) || (_sequence_name_new.indexOf(",") >= 0) ||
          (_sequence_name_new.indexOf(" ") >= 0) || (_sequence_name_new.indexOf("\"") >= 0))
      {
           return "Number sequence name must not contain , . \" or a space";
@@ -957,7 +957,7 @@ function RenameNumberSequence(_sequence_name_old, _sequence_name_new){
           return "Number sequence name is already existing, please choose another name";
 
      NUMBERS[index]["name"] = _sequence_name_new;
-     
+
      return "";
 }
 
@@ -965,7 +965,7 @@ function RenameNumberSequence(_sequence_name_old, _sequence_name_new){
 function DeleteNumberSequence(_sequence_name){
      if (NUMBERS.length == 1)
           return "One number sequence is mandatory. Therefore this cannot be deleted"
-     
+
 
      index = -1;
      for (i = 0; i < NUMBERS.length; ++i) {
@@ -990,7 +990,7 @@ function getROIInfo(_typeROI, _number){
      if (index != -1)
           return NUMBERS[index][_typeROI];
      else
-          return "";     
+          return "";
 }
 
 
@@ -1029,8 +1029,8 @@ function CreateROI(_sequence_name, _type, _pos, _roinew, _x, _y, _dx, _dy, _CCW)
 
 function RenameROI(_sequence_name, _type, _roi_name_old, _roi_name_new){
      if ((_roi_name_new.includes("=")) || (_roi_name_new.includes(".")) || (_roi_name_new.includes(":")) ||
-         (_roi_name_new.includes(",")) || (_roi_name_new.includes(";")) || (_roi_name_new.includes(" ")) || 
-         (_roi_name_new.includes("\""))) 
+         (_roi_name_new.includes(",")) || (_roi_name_new.includes(";")) || (_roi_name_new.includes(" ")) ||
+         (_roi_name_new.includes("\"")))
      {
           return "ROI name must not contain . : , ; = \" or space";
      }
@@ -1043,7 +1043,7 @@ function RenameROI(_sequence_name, _type, _roi_name_old, _roi_name_new){
                _indexnumber = j;
 
      if (_indexnumber == -1)
-          return "Number sequence not existing. ROI cannot be renamed"  
+          return "Number sequence not existing. ROI cannot be renamed"
 
      for (i = 0; i < NUMBERS[_indexnumber][_type].length; ++i) {
           if (NUMBERS[_indexnumber][_type][i]["name"] == _roi_name_old)
@@ -1056,6 +1056,6 @@ function RenameROI(_sequence_name, _type, _roi_name_old, _roi_name_new){
           return "ROI name is already existing";
 
      NUMBERS[_indexnumber][_type][index]["name"] = _roi_name_new;
-     
+
      return "";
 }

--- a/sd-card/html/reboot_page.html
+++ b/sd-card/html/reboot_page.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" xml:lang="en"> 
+<html lang="en" xml:lang="en">
 <head>
 	<meta charset="UTF-8">
 	<title>Reboot</title>
@@ -19,7 +19,7 @@
 		.button {
 			padding: 5px 10px;
 			width: 205px;
-			font-size: 16px;	
+			font-size: 16px;
 		}
 
 		table {
@@ -53,7 +53,7 @@
 		<span><b>The device is usually rebooted in 20 to 40 seconds<br>and then getting redirected to the overview page.</b></span>
 	</div>
 
-<script src="common.js?v=$COMMIT_HASH"></script> 
+<script src="common.js?v=$COMMIT_HASH"></script>
 <script>
 	function doReboot()
 	{
@@ -100,7 +100,7 @@
 
 					clearInterval(dotInterval);
 					clearInterval(checkInterval);
-					
+
 					document.getElementById("rebootRequest").style.display = "";
 					document.getElementById("rebootChecker").style.display = "none";
 				}

--- a/sd-card/html/set_fallbackvalue.html
+++ b/sd-card/html/set_fallbackvalue.html
@@ -32,7 +32,7 @@
             padding: 3px 5px;
             display: inline-block;
             border: 1px solid #ccc;
-            font-size: 16px; 
+            font-size: 16px;
         }
 
         .invalid-input {
@@ -47,7 +47,7 @@
             padding: 3px 5px;
             display: inline-block;
             border: 1px solid #ccc;
-            font-size: 16px; 
+            font-size: 16px;
             margin-right: 10px;
             min-width: 100px;
             vertical-align: middle;
@@ -56,7 +56,7 @@
         .button {
             padding: 5px 10px;
             width: 205px;
-            font-size: 16px;	
+            font-size: 16px;
         }
 
         table {
@@ -86,16 +86,16 @@
             Set the "Fallback Value" for consistency checks and substitution for N positions in number sequence.
         </p>
         <p>
-            The Fallback Value is the last successful valid reading of any processing cycle. The result of the the 
+            The Fallback Value is the last successful valid reading of any processing cycle. The result of the the
             actual processing cycle, as long it's a vaild result, will be promoted to the new "Fallback Value". If
             the result is not usable (e.g. rate negative, rate too high) the "Fallback Value" will not be updated.
-            If activated in configuration, the "Fallback Value" will be used in the following processing cycle to 
-            identify negtive rates and too high rates (MaxRateValue / MaxRateType) as well as for the "Check Digit 
+            If activated in configuration, the "Fallback Value" will be used in the following processing cycle to
+            identify negtive rates and too high rates (MaxRateValue / MaxRateType) as well as for the "Check Digit
             Increase Consistency" (configuration paramter, only for dig-class11 models) and for possible substitution
-            of any N positions in the "Raw Value" reading (only valid for dig-class11 models and dig-cont models). 
+            of any N positions in the "Raw Value" reading (only valid for dig-class11 models and dig-cont models).
         </p>
         <p>
-            The field to enter new "Fallback Value" is prefilled with actual "Raw Value" because it's the most likely 
+            The field to enter new "Fallback Value" is prefilled with actual "Raw Value" because it's the most likely
             use case. Nevertheless every other positive value can be set as new "Fallback Value".
         </p>
     </details>
@@ -132,22 +132,22 @@
             <td>
                 <input required type="number" id="myInput" name="myInput" min="0" oninput="(!validity.rangeUnderflow||(value=0));">
                 <button class="button" type="button" onclick="setFallbackValue()">Update Value</button>
-                <p style="padding-left: 5px;">NOTE: The current "Raw Value" is prefilled as 
+                <p style="padding-left: 5px;">NOTE: The current "Raw Value" is prefilled as
                     <br>the suggested new "Fallback Value"</p>
             </td>
-        </tr>	
+        </tr>
         <tr>
             <td id="result_text">"Fallback Value" updated to</td>
             <td>
                 <div id="result" style="padding-left:5px;"></div>
             </td>
-        </tr>	 
+        </tr>
     </table>
 
 
-<script src="common.js?v=$COMMIT_HASH"></script> 
-<script src="readconfigcommon.js?v=$COMMIT_HASH"></script>  
-<script src="readconfigparam.js?v=$COMMIT_HASH"></script>  
+<script src="common.js?v=$COMMIT_HASH"></script>
+<script src="readconfigcommon.js?v=$COMMIT_HASH"></script>
+<script src="readconfigparam.js?v=$COMMIT_HASH"></script>
 <script>
     var domainname = getDomainname();
 
@@ -157,25 +157,25 @@
         firework.launch('Update \"Fallback Value\" ...', 'success', 2000, true);
         var inputVal = document.getElementById("myInput").value;
         var sel = document.getElementById("Numbers_value1");
-        var _number = sel.options[sel.selectedIndex].text;  
+        var _number = sel.options[sel.selectedIndex].text;
         inputVal = inputVal.replace(",", ".");
-        url = domainname + "/set_fallbackvalue?sequence=" + _number + "&value=" + inputVal     
+        url = domainname + "/set_fallbackvalue?sequence=" + _number + "&value=" + inputVal
 
         var xhttp = new XMLHttpRequest();
         xhttp.onreadystatechange = function() {
             if (this.readyState == 4) {
-                if (this.status >= 200 && this.status < 300) {       
+                if (this.status >= 200 && this.status < 300) {
                     document.getElementById("result").innerHTML=xhttp.responseText;
                     firework.launch('New \"Fallback Value\" set', 'success', 2000, true);
                 }
                 else if (this.status == 403) {
                     firework.launch("Setting new value rejected. Process not (yet) initialized. Repeat action or check logs.", 'warning', 5000);
-                    console.error("Setting new value rejected. Process not (yet) initialized. Response status: " + this.status);  
+                    console.error("Setting new value rejected. Process not (yet) initialized. Response status: " + this.status);
                 }
                 else {
-                    firework.launch("Setting new value failed (Response status: " + this.status + 
+                    firework.launch("Setting new value failed (Response status: " + this.status +
                                     "). Repeat action or check logs.", 'danger', 30000);
-                    console.error("Setting new value failed. Response status: " + this.status);  
+                    console.error("Setting new value failed. Response status: " + this.status);
                 }
             }
         };
@@ -201,12 +201,12 @@
                 }
                 else if (this.status == 403) {
                     firework.launch("Sequence name request rejected. Process not (yet) initialized. Repeat action or check logs.", 'warning', 5000);
-                    console.error("Sequence name request rejected. Process not (yet) initialized. Response status: " + this.status);  
+                    console.error("Sequence name request rejected. Process not (yet) initialized. Response status: " + this.status);
                 }
                 else {
-                    firework.launch("Sequence name request failed (Response status: " + this.status + 
+                    firework.launch("Sequence name request failed (Response status: " + this.status +
                                     "). Repeat action or check logs.", 'danger', 30000);
-                    console.error("Sequence name request failed. Response status: " + this.status);  
+                    console.error("Sequence name request failed. Response status: " + this.status);
                 }
             }
         }
@@ -236,12 +236,12 @@
                 }
                 else if (this.status == 403) {
                     firework.launch("Raw value request rejected. Process not (yet) initialized. Repeat action or check logs.", 'warning', 5000);
-                    console.error("Raw value request rejected. Process not (yet) initialized. Response status: " + this.status);  
+                    console.error("Raw value request rejected. Process not (yet) initialized. Response status: " + this.status);
                 }
                 else {
-                    firework.launch("Raw value request failed (Response status: " + this.status + 
+                    firework.launch("Raw value request failed (Response status: " + this.status +
                                     "). Repeat action or check logs.", 'danger', 30000);
-                    console.error("Raw value request failed. Response status: " + this.status);  
+                    console.error("Raw value request failed. Response status: " + this.status);
                 }
             }
         }
@@ -274,7 +274,7 @@
             var option = document.createElement("option");
             option.text = NumberSequence[i]["name"];
             option.value = i;
-            _index.add(option); 
+            _index.add(option);
         }
 
         loadFallbackValue(domainname);
@@ -286,8 +286,8 @@
         ParseConfig();
         parseNumberSequenceName();
     }
-    
-    
+
+
     function init()
     {
         loadConfig().then(() => loadConfigData());

--- a/sd-card/html/setup.html
+++ b/sd-card/html/setup.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" xml:lang="en"> 
+<html lang="en" xml:lang="en">
 <head>
     <meta charset="UTF-8">
     <title>AI on the edge</title>
@@ -12,11 +12,11 @@
         p {font-size: 1em;}
 
         body, html {
-            width: 100%; 
-            height: 100%; 
+            width: 100%;
+            height: 100%;
             min-height: 800px;
-            margin: 0px 0px 0px 2px; 
-            padding: 0; 
+            margin: 0px 0px 0px 2px;
+            padding: 0;
             font-family: arial;
             width: -moz-fit-content;
             width: fit-content;
@@ -54,10 +54,10 @@
         }
 
         .main {
-            display: flex; 
-            width: 100%; 
-            height: 100%; 
-            flex-direction: column; 
+            display: flex;
+            width: 100%;
+            height: 100%;
+            flex-direction: column;
             overflow: hidden;
         }
     </style>
@@ -108,19 +108,19 @@
     </div>
 
 
-<script src="common.js?v=$COMMIT_HASH"></script> 
+<script src="common.js?v=$COMMIT_HASH"></script>
 <script>
     var aktstep = 0;
     var setupCompleted = false;
     document.getElementById('stream').style.display = "none";   // Make sure that stream iframe is always hidden
     document.getElementById("progressBar").value = 0;
 
-    
+
     function clickStart()
     {
         aktstep = 0;
         setupCompleted = false;
-        document.getElementById('stream').src = "";     
+        document.getElementById('stream').src = "";
         document.getElementById('stream').style.display = "none";   // Make sure that stream iframe is always hidden
         LoadStep();
     }
@@ -130,7 +130,7 @@
     {
         setupCompleted = false;
         aktstep = 7;
-        document.getElementById('stream').src = "";     
+        document.getElementById('stream').src = "";
         document.getElementById('stream').style.display = "none";   // Make sure that stream iframe is always hidden
         LoadStep();
     }
@@ -142,7 +142,7 @@
         if (aktstep > 7) {
             aktstep = 7;
         }
-        document.getElementById('stream').src = "";     
+        document.getElementById('stream').src = "";
         document.getElementById('stream').style.display = "none";   // Make sure that stream iframe is always hidden
         LoadStep();
     }
@@ -154,7 +154,7 @@
         if (aktstep < 0) {
             aktstep = 0;
         }
-        document.getElementById('stream').src = "";     
+        document.getElementById('stream').src = "";
         document.getElementById('stream').style.display = "none";   // Make sure that stream iframe is always hidden
         LoadStep();
    }
@@ -187,7 +187,7 @@
             document.getElementById('explaincontent').style="height:155px;"
             document.getElementById('explaincontent').scrolling="yes"
             document.getElementById('explaincontent').src = 'setup_explain_1.html?v=$COMMIT_HASH';
-            
+
             document.getElementById("restart").disabled = false;
             document.getElementById("previous").disabled = false;
             document.getElementById("next").disabled = false;
@@ -294,7 +294,7 @@
 
             document.getElementById("progressBar").value = 6;
             setupCompleted = true;
-            break; 
+            break;
 
         case 7: // Setup completed / aborted
             document.getElementById('h_iframe').style="height:660px;"
@@ -304,7 +304,7 @@
             }
             else {
                 document.getElementById('maincontent').src = 'setup_explain_7_abort.html?v=$COMMIT_HASH';
-                document.getElementById("previous").disabled = true; 
+                document.getElementById("previous").disabled = true;
             }
 
             document.getElementById('h_iframe_explain').style.display = "none";
@@ -319,7 +319,7 @@
    }
 
 
-   function loadRSSI() 
+   function loadRSSI()
    {
 		var url = getDomainname() + '/info?type=wlan_rssi';
 
@@ -327,7 +327,7 @@
 		xhttp.onreadystatechange = function() {
 			if (this.readyState == 4 && this.status == 200) {
 				var _rsp = xhttp.responseText;
-				
+
 				if (_rsp >= -55) {
 					document.getElementById('rssi').value = ("WLAN Signal: Excellent (" + _rsp + "dBm)");
 				}
@@ -348,7 +348,7 @@
 
         xhttp.timeout = 10000;  // 10 seconds
 		xhttp.open("GET", url, true);
-		xhttp.send();		
+		xhttp.send();
 	}
 
 

--- a/sd-card/html/setup_explain_0.html
+++ b/sd-card/html/setup_explain_0.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" xml:lang="en"> 
+<html lang="en" xml:lang="en">
 <head>
     <meta charset="UTF-8">
     <title>AI on the edge</title>
@@ -25,7 +25,7 @@
 
     <p><img src="flow_overview.jpg" alt="" width="680" height="auto"></p>
     <p>
-        This is the first time you started the device after the initial installation. You have been automatically routed to the <b>initial setup procedure</b>. 
+        This is the first time you started the device after the initial installation. You have been automatically routed to the <b>initial setup procedure</b>.
         With the prodecure the basic setup of your device within seven steps will be performed. After completion of all steps the setup mode will be completed
         and the device restarts automatically to the regular web interface.<br>
         Note: All settings of the initial setup will be also accessible using regular web interface.

--- a/sd-card/html/setup_explain_1.html
+++ b/sd-card/html/setup_explain_1.html
@@ -1,9 +1,9 @@
 <!DOCTYPE html>
-<html lang="en" xml:lang="en"> 
+<html lang="en" xml:lang="en">
 <head>
     <meta charset="UTF-8">
     <title>AI on the edge</title>
-    
+
     <style>
         h1 {font-size: 1.8em;}
         h2 {font-size: 1.5em; margin-block-start: 0.0em; margin-block-end: 0.2em;}
@@ -22,11 +22,11 @@
 <body style="font-family: arial">
 
     <h4>Step 1 / 7: Adjust Focus And Verify Flashlight</h4>
-        Firstly you have find a proper mounting position and potentially have to adjust the focus of the camera lens to get a sharp and crisp image. 
+        Firstly you have find a proper mounting position and potentially have to adjust the focus of the camera lens to get a sharp and crisp image.
         This <b>live stream with flashlight on</b> could be helpful for this task. More details about adjusting the camera lens can be found here:
         <a href=https://jomjol.github.io/AI-on-the-edge-device-docs/Reference-Image/#focus target=_blank>Focus Adjustment</a><br>
-        Additionally it should be verfied that the flashlight is not creating any distrubing reflection in the processing relevant areas. 
-        Beside using the built-in internal flash LED it's also possible to attach additional external LEDs to the device to have more possiblities 
+        Additionally it should be verfied that the flashlight is not creating any distrubing reflection in the processing relevant areas.
+        Beside using the built-in internal flash LED it's also possible to attach additional external LEDs to the device to have more possiblities
         to get proper light condition. Please read the documentation if you'd like to use extenal LEDs:
         <a href=https://jomjol.github.io/AI-on-the-edge-device-docs/External-LED/ target=_blank>Installation Of External LEDs</a>
     <p>

--- a/sd-card/html/setup_explain_2.html
+++ b/sd-card/html/setup_explain_2.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" xml:lang="en"> 
+<html lang="en" xml:lang="en">
 <head>
     <meta charset="UTF-8">
     <title>AI on the edge</title>

--- a/sd-card/html/setup_explain_3.html
+++ b/sd-card/html/setup_explain_3.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" xml:lang="en"> 
+<html lang="en" xml:lang="en">
 <head>
     <meta charset="UTF-8">
     <title>AI on the edge</title>

--- a/sd-card/html/setup_explain_4.html
+++ b/sd-card/html/setup_explain_4.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" xml:lang="en"> 
+<html lang="en" xml:lang="en">
 <head>
     <meta charset="UTF-8">
     <title>AI on the edge</title>

--- a/sd-card/html/setup_explain_5.html
+++ b/sd-card/html/setup_explain_5.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" xml:lang="en"> 
+<html lang="en" xml:lang="en">
 <head>
     <meta charset="UTF-8">
     <title>AI on the edge</title>

--- a/sd-card/html/setup_explain_6.html
+++ b/sd-card/html/setup_explain_6.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" xml:lang="en"> 
+<html lang="en" xml:lang="en">
 <head>
     <meta charset="UTF-8">
     <title>AI on the edge</title>

--- a/sd-card/html/setup_explain_7.html
+++ b/sd-card/html/setup_explain_7.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" xml:lang="en"> 
+<html lang="en" xml:lang="en">
 <head>
     <meta charset="UTF-8">
     <title>AI on the edge</title>
@@ -19,7 +19,7 @@
         .button {
             padding: 5px 10px;
             width: 205px;
-            font-size: 16px;	
+            font-size: 16px;
         }
     </style>
 
@@ -36,7 +36,7 @@
         Congratulations! You have completed the initial setup and you are now ready to switch to the regular web interface!
     </p>
     <p>
-        Once you push the button below, the setup mode will be completed and the device will be automatically switch to 
+        Once you push the button below, the setup mode will be completed and the device will be automatically switch to
         regular web interface. If configuration is error free, the device will automatically start with first processing.
         It will take some time until you get the first reading.
     </p>
@@ -44,22 +44,22 @@
         <button class="button" onclick="completeSetup()">Complete Setup</button>
     </p>
 
-<script src="common.js?v=$COMMIT_HASH"></script> 
-<script src="readconfigparam.js?v=$COMMIT_HASH"></script> 
-<script src="readconfigcommon.js?v=$COMMIT_HASH"></script> 
+<script src="common.js?v=$COMMIT_HASH"></script>
+<script src="readconfigparam.js?v=$COMMIT_HASH"></script>
+<script src="readconfigcommon.js?v=$COMMIT_HASH"></script>
 
 <script>
 
     function reboot()
     {
-        ParseConfig();	
+        ParseConfig();
         param = getConfigParameters();
 
         param["System"]["SetupMode"]["enabled"] = true;
         param["System"]["SetupMode"]["value1"] = "false";
 
         WriteConfigININew();
-        SaveConfigToServer(getDomainname());  
+        SaveConfigToServer(getDomainname());
 
         firework.launch('Setup completed', 'success', 5000);
         setTimeout(function() {

--- a/sd-card/html/setup_explain_7_abort.html
+++ b/sd-card/html/setup_explain_7_abort.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" xml:lang="en"> 
+<html lang="en" xml:lang="en">
 <head>
     <meta charset="UTF-8">
     <title>AI on the edge</title>
@@ -19,7 +19,7 @@
         .button {
             padding: 5px 10px;
             width: 205px;
-            font-size: 16px;	
+            font-size: 16px;
         }
     </style>
 
@@ -33,7 +33,7 @@
     <h4>Initial setup aborted!</h4>
 
     <p>You have <b>aborted</b> the initial setup!</p>
-    <p>Once you push the button below, the setup mode will be ended and the device will be automatically switch to regular web interface. 
+    <p>Once you push the button below, the setup mode will be ended and the device will be automatically switch to regular web interface.
        Please be aware: The configuration of the device is not or only parly adapted to your needs! <br><br>
        Configuration can still be adapted / completed using regular web interface.
     </p>
@@ -42,15 +42,15 @@
         <button class="button" onclick="abortSetup()">Abort Setup</button>
     </p>
 
-<script src="common.js?v=$COMMIT_HASH"></script> 
-<script src="readconfigparam.js?v=$COMMIT_HASH"></script> 
-<script src="readconfigcommon.js?v=$COMMIT_HASH"></script> 
+<script src="common.js?v=$COMMIT_HASH"></script>
+<script src="readconfigparam.js?v=$COMMIT_HASH"></script>
+<script src="readconfigcommon.js?v=$COMMIT_HASH"></script>
 
 <script>
 
     function reboot()
     {
-        ParseConfig();	
+        ParseConfig();
         param = getConfigParameters();
         param["System"]["SetupMode"]["enabled"] = true;
         param["System"]["SetupMode"]["value1"] = "false";
@@ -70,10 +70,10 @@
             parent.location.href = stringota;
             parent.location.assign(stringota);
             parent.location.replace(stringota);
-        }, 7000);    
+        }, 7000);
     }
 
-    
+
     function abortSetup()
     {
         if (confirm("Do you want to abort the setup mode and switch to regular web interface?"))

--- a/sd-card/html/style.css
+++ b/sd-card/html/style.css
@@ -3,8 +3,8 @@ body, html {
     min-width: 690px;
     height: 100vh;
     min-height: 100vh;
-    margin: 0px 0px 0px 2px; 
-    padding: 0; 
+    margin: 0px 0px 0px 2px;
+    padding: 0;
     font-family: arial;
     font-size: 100%;
     -webkit-text-size-adjust: 100%;
@@ -16,8 +16,8 @@ body, html {
     max-width: 689px;
     height: 150vh;
     min-height: 100vh;
-    margin: 0px 0px 0px 2px; 
-    padding: 0; 
+    margin: 0px 0px 0px 2px;
+    padding: 0;
     font-family: arial;
     font-size: 100%;
     -webkit-text-size-adjust: 100%;
@@ -26,9 +26,9 @@ body, html {
 }
 
 .main {
-    display: flex; 
-    width: 100%; 
-    height: 100%; 
+    display: flex;
+    width: 100%;
+    height: 100%;
     flex-direction: column;
     overflow: hidden;
     font-family: arial;
@@ -36,21 +36,21 @@ body, html {
 
 .iframe {
     flex: 1 1 auto;
-    margin: 5px 0px 8px 0px; 
-    padding: 0; 
+    margin: 5px 0px 8px 0px;
+    padding: 0;
     border: 0px solid #333; /* black */
     font-family: arial;
 }
 
 h1 {
-    font-size: 1.8em; 
+    font-size: 1.8em;
     margin-block-end: 0.2em;
 }
 
 h2 {
     font-size: 1.5em;
     margin-block-start: 0.0em;
-    margin-block-end: 0.2em; 
+    margin-block-end: 0.2em;
 }
 
 h3 {
@@ -197,9 +197,9 @@ p {
   transform: rotate(-45deg);
   position: absolute;
   right: 10px;
-  top: 20px;     
-  width:0px; 
-  height:0px; 
+  top: 20px;
+  width:0px;
+  height:0px;
 }
 
 .down {

--- a/sd-card/html/timezones.html
+++ b/sd-card/html/timezones.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" xml:lang="en"> 
+<html lang="en" xml:lang="en">
 <head>
     <meta charset="UTF-8">
     <title>Timezones</title>
@@ -544,7 +544,7 @@
                 } else {
                     tr[i].style.display = "none";
                 }
-            }       
+            }
         }
     }
 
@@ -552,4 +552,3 @@
 
 </body>
 </html>
-    

--- a/sd-card/html/wlan_config.html
+++ b/sd-card/html/wlan_config.html
@@ -1,6 +1,6 @@
 <html lang="en" xml:lang="en">
 <head>
-    <meta charset="UTF-8"> 
+    <meta charset="UTF-8">
     <title>WLAN config</title>
 
     <script src="jquery-3.6.0.min.js?v=$COMMIT_HASH"></script>
@@ -50,13 +50,13 @@
         }
 
         var upload_path = "/upload/firmware/" + filePath; xhttp.open("POST", upload_path, true); xhttp.send(file);}
-    
-    
+
+
     function extract() {
         document.getElementById("status").innerText = "Status: Processing on device (takes up to 3 minutes)...";
-    
+
         var xhttp = new XMLHttpRequest();
-        /* first delete the old firmware */	
+        /* first delete the old firmware */
         xhttp.onreadystatechange = function() {
             if (xhttp.readyState == 4) {
                 stopProgressTimer();
@@ -65,7 +65,7 @@
                     document.getElementById("doUpdate").disabled = true;
                     document.getElementById("newfile").disabled = false;
                     document.cookie = "page=overview.html?v=$COMMIT_HASH;path=/;SameSite=Lax"; // Make sure after the reboot we go to the overview page
-    
+
                     if (xhttp.responseText.startsWith("reboot"))
                     {
                         doRebootAfterUpdate();
@@ -83,35 +83,35 @@
                 }
             }
         };
-    
+
         startProgressTimer("Extraction");
-    
-    
+
+
         var nameneu = document.getElementById("newfile").value;
         filePath = nameneu.split(/[\\\/]/).pop();
         var _toDo = domainname + "/ota?task=update&file=" + filePath;
         xhttp.open("GET", _toDo, true);
         xhttp.send();
     }
-    
-    
-    function startProgressTimer(step) {     
+
+
+    function startProgressTimer(step) {
         console.log(step + "...");
         document.getElementById('progress').innerHTML = "(0s)";
-        action_runtime = 0;    
+        action_runtime = 0;
         progressTimerHandle = setInterval(function() {
             action_runtime += 1;
-            console.log("Progress: " + action_runtime + "s");  
+            console.log("Progress: " + action_runtime + "s");
             document.getElementById('progress').innerHTML = "(" + action_runtime + "s)";
         }, 1000);
     }
-    
-    
-    function stopProgressTimer() {            
+
+
+    function stopProgressTimer() {
         clearInterval(progressTimerHandle);
         document.getElementById('progress').innerHTML = "";
     }
-  
+
 </script>
 
 </body>

--- a/tools/docs-generator/generate-api-docs-localbuild.py
+++ b/tools/docs-generator/generate-api-docs-localbuild.py
@@ -11,7 +11,7 @@ scriptName = "generate-api-docs-localbuild.py"
 if len(sys.argv) > 1:
     scriptPath = sys.argv[1] + "/tools/docs-generator/"
     rootPath = sys.argv[1]
-    
+
 else:
     scriptPath = sys.argv[0].split(scriptName,1)[0]
     if scriptPath[0] == ".":
@@ -44,7 +44,7 @@ def prepareRestApiMarkdown(markdownFile):
             markdownFileContent = markdownFileContent.replace("_OVERVIEW.md", "#overview-rest-api")
         elif (ReplaceLinkName == "xxx_migration_notes"):
             markdownFileContent = markdownFileContent.replace("xxx_migration_notes.md", "#migration-notes")
-        
+
         # Replace all links with local links
         markdownFileContent = markdownFileContent.replace(replaceLink, "#rest-api-endpoint-" + ReplaceLinkName)
 
@@ -54,7 +54,7 @@ def prepareRestApiMarkdown(markdownFile):
     # Update image paths
     if "./img/" in markdownFileContent:
         markdownFileContent = markdownFileContent.replace("./img/", "/")
-    
+
     return markdownFileContent
 
 
@@ -65,7 +65,7 @@ def prepareMqttApiMarkdown(markdownFile):
 
     linkPosEnd = markdownFileContent.find(".md)")
     while (linkPosEnd >= 0):
-        
+
         # Find markdown local links
         replaceLink = markdownFileContent[markdownFileContent.rfind("(", 0, linkPosEnd)+1:linkPosEnd+3]
         ReplaceLinkName = replaceLink.split("\\")[-1].replace(".md", "")
@@ -75,7 +75,7 @@ def prepareMqttApiMarkdown(markdownFile):
             markdownFileContent = markdownFileContent.replace("_OVERVIEW.md", "#overview-mqtt-api")
         elif (ReplaceLinkName == "xxx_migration_notes"):
             markdownFileContent = markdownFileContent.replace("xxx_migration_notes.md", "#migration-notes")
-        
+
         # Replace all links with local links
         markdownFileContent = markdownFileContent.replace(replaceLink, "#mqtt-api-" + ReplaceLinkName)
 

--- a/tools/docs-generator/generate-api-docs.py
+++ b/tools/docs-generator/generate-api-docs.py
@@ -29,7 +29,7 @@ def prepareRestApiMarkdown(markdownFile):
             markdownFileContent = markdownFileContent.replace("_OVERVIEW.md", "#overview-rest-api")
         elif (ReplaceLinkName == "xxx_migration_notes"):
             markdownFileContent = markdownFileContent.replace("xxx_migration_notes.md", "#migration-notes")
-        
+
         # Replace all links with local links
         markdownFileContent = markdownFileContent.replace(replaceLink, "#rest-api-endpoint-" + ReplaceLinkName)
 
@@ -39,7 +39,7 @@ def prepareRestApiMarkdown(markdownFile):
     # Update image paths
     if "./img/" in markdownFileContent:
         markdownFileContent = markdownFileContent.replace("./img/", "/")
-    
+
     return markdownFileContent
 
 
@@ -50,7 +50,7 @@ def prepareMqttApiMarkdown(markdownFile):
 
     linkPosEnd = markdownFileContent.find(".md)")
     while (linkPosEnd >= 0):
-        
+
         # Find markdown local links
         replaceLink = markdownFileContent[markdownFileContent.rfind("(", 0, linkPosEnd)+1:linkPosEnd+3]
         ReplaceLinkName = replaceLink.split("\\")[-1].replace(".md", "")
@@ -60,7 +60,7 @@ def prepareMqttApiMarkdown(markdownFile):
             markdownFileContent = markdownFileContent.replace("_OVERVIEW.md", "#overview-mqtt-api")
         elif (ReplaceLinkName == "xxx_migration_notes"):
             markdownFileContent = markdownFileContent.replace("xxx_migration_notes.md", "#migration-notes")
-        
+
         # Replace all links with local links
         markdownFileContent = markdownFileContent.replace(replaceLink, "#mqtt-api-" + ReplaceLinkName)
 
@@ -98,7 +98,7 @@ for folder in folders:
         elif (folder == "MQTT"):
             markdownMqttApi += prepareMqttApiMarkdown(file) # Merge files
             markdownMqttApi += "\n\n---\n" # Add a divider line
-    
+
     # Copy in API doc linked images to HTMl folder
     if os.path.exists(docsAPIRootFolder + "/" + folder + "/img"):
         files = sorted(filter(os.path.isfile, glob.glob(docsAPIRootFolder + "/" + folder + '/img/*')))

--- a/tools/parameter-tooltip-generator/generate-param-doc-tooltips-localbuild.py
+++ b/tools/parameter-tooltip-generator/generate-param-doc-tooltips-localbuild.py
@@ -12,7 +12,7 @@ scriptName = "generate-param-doc-tooltips-localbuild.py"
 if len(sys.argv) > 1:
     scriptPath = sys.argv[1] + "/tools/parameter-tooltip-generator/"
     rootPath = sys.argv[1]
-    
+
 else:
     scriptPath = sys.argv[0].split(scriptName,1)[0]
     if scriptPath[0] == ".":
@@ -77,7 +77,7 @@ def generateHtmlTooltip(section, parameter, markdownFile):
         referenceImagePageContent = referenceImagePageHandle.read()
 
     # print("replacing $TOOLTIP_" + section + "_" + parameter + " with the tooltip content...")
-    referenceImagePageContent = referenceImagePageContent.replace("<td style=\"overflow:hidden\">$TOOLTIP_" + section + "_" + parameter + "</td>", 
+    referenceImagePageContent = referenceImagePageContent.replace("<td style=\"overflow:hidden\">$TOOLTIP_" + section + "_" + parameter + "</td>",
                                                                   "<td>" + htmlTooltip + "</td>")
 
     with open(docsMainFolder + "/" + referenceImagePage, 'w') as referenceImagePageHandle:
@@ -90,14 +90,14 @@ print(scriptName + ": Generate tooltips")
 Generate a HTML tooltip for each markdown page
 """
 for folder in folders:
-    folder = folder.split("\\")[-1]  
+    folder = folder.split("\\")[-1]
 
     files = sorted(filter(os.path.isfile, glob.glob(parameterDocsFolder + "/" + folder + '/*')))
 
     if folder == "img":
         for file in files:
             shutil.copy2(file, docsMainFolder + "/")
-    
+
     else:
         for file in files:
             if not ".md" in file: # Skip non-markdown files

--- a/tools/parameter-tooltip-generator/generate-param-doc-tooltips.py
+++ b/tools/parameter-tooltip-generator/generate-param-doc-tooltips.py
@@ -60,7 +60,7 @@ def generateHtmlTooltip(section, parameter, markdownFile):
         referenceImagePageContent = referenceImagePageHandle.read()
 
     # print("replacing $TOOLTIP_" + section + "_" + parameter + " with the tooltip content...")
-    referenceImagePageContent = referenceImagePageContent.replace("<td style=\"overflow:hidden\">$TOOLTIP_" + section + "_" + parameter + "</td>", 
+    referenceImagePageContent = referenceImagePageContent.replace("<td style=\"overflow:hidden\">$TOOLTIP_" + section + "_" + parameter + "</td>",
                                                                   "<td>" + htmlTooltip + "</td>")
 
     with open(docsMainFolder + "/" + referenceImagePage, 'w') as referenceImagePageHandle:


### PR DESCRIPTION
Remove trailing whitespaces from all source code files to have cleaner code

---

To remove them automatically (excluding markdown files .md), add this to VSCode settings.json:
```
    "files.trimTrailingWhitespace": true,
    "[markdown]": {
        "files.trimTrailingWhitespace": false
    }
```