### PR TITLE
fix(load fallbackvalue): Avoid conversion exception if string is invalid

### DIFF
--- a/code/components/mainprocess_ctrl/ClassFlowPostProcessing.cpp
+++ b/code/components/mainprocess_ctrl/ClassFlowPostProcessing.cpp
@@ -844,7 +844,8 @@ bool ClassFlowPostProcessing::loadFallbackValue(void)
                 // Fallback value valid
                 else {
                     sequence->isFallbackValueValid = true;
-                    sequence->fallbackValue = stod(std::string(cValue));
+                    char *pEnd = NULL;
+                    sequence->fallbackValue = strtod(cValue, &pEnd);
                     sequence->sFallbackValue = to_stringWithPrecision(sequence->fallbackValue, sequence->decimalPlaceCount + 1); // Keep one digit more
                     LogFile.writeToFile(ESP_LOG_INFO, TAG, sequence->sequenceName + ": Fallback value valid | Time: " + std::string(cTime));
                 }


### PR DESCRIPTION
`std::stod` function for string to double conversion of fallbackvalue throws exception if invalid string is detected. --> Not catchable with disabled C++ exception handling

Switch to alternative `strtod` function to avoid exception and ensure a return value (0) a any case.