### PR TITLE
(webui): Clear fallback value result after switching sequence

### DIFF
--- a/sd-card/html/edit_fallbackvalue.html
+++ b/sd-card/html/edit_fallbackvalue.html
@@ -264,7 +264,7 @@
         xhttp_rawvalue.send();
 
         // Reset result
-        document.getElementById("result").innerHTML = "";
+        document.getElementById("result").value = "";
     }
 
 


### PR DESCRIPTION
Bug introduced with [#165](https://github.com/Slider0007/AI-on-the-edge-device/pull/165)