### PR TITLE
chore(influxdb tls + mqtt tls): Use built-in certification bundle for server verification

### DIFF
--- a/code/components/influxdb_ctrl/interface_influxdbv1.cpp
+++ b/code/components/influxdb_ctrl/interface_influxdbv1.cpp
@@ -132,7 +132,7 @@ esp_err_t influxDBv1Publish(const std::string &_measurement, const std::string &
             httpConfig.skip_cert_common_name_check = true;    // Skip any validation of server certificate CN field
         }
         else {
-            LogFile.writeToFile(ESP_LOG_DEBUG, TAG, "CA Certificate empty, use certification bundle for server verfication");
+            LogFile.writeToFile(ESP_LOG_DEBUG, TAG, "CA Certificate empty, use certification bundle for server verification");
             httpConfig.crt_bundle_attach = esp_crt_bundle_attach;
         }
 

--- a/code/components/influxdb_ctrl/interface_influxdbv1.cpp
+++ b/code/components/influxdb_ctrl/interface_influxdbv1.cpp
@@ -6,6 +6,7 @@
 #include <time.h>
 
 #include <esp_http_client.h>
+#include <esp_crt_bundle.h>
 #include <esp_log.h>
 
 #include "ClassLogFile.h"
@@ -107,42 +108,42 @@ bool influxDBv1Init(const CfgData::SectionInfluxDBv1 *_cfgDataPtr)
 
 esp_err_t influxDBv1Publish(const std::string &_measurement, const std::string &_fieldkey1, const std::string &_fieldvalue1, const std::string &_timestamp)
 {
-    char* response_buffer = (char*) calloc_psram_heap(std::string(TAG) + "->response_buffer", 1,
-                            sizeof(char) * MAX_HTTP_OUTPUT_BUFFER, MALLOC_CAP_8BIT | MALLOC_CAP_SPIRAM);
-
-    esp_http_client_config_t http_config = {
-       .user_agent = "ESP32 Meter reader",
+    esp_http_client_config_t httpConfig = {
+       .user_agent = "AI-on-the-Edge Device",
        .method = HTTP_METHOD_POST,
        .event_handler = http_event_handler,
-       .buffer_size = MAX_HTTP_OUTPUT_BUFFER,
-       .user_data = response_buffer
+       .buffer_size = MAX_HTTP_OUTPUT_BUFFER
     };
 
     if (cfgDataPtr->authMode == AUTH_BASIC) {
-        http_config.auth_type = HTTP_AUTH_TYPE_BASIC;
-        http_config.username = cfgDataPtr->username.c_str();
-        http_config.password = cfgDataPtr->password.c_str();
+        httpConfig.auth_type = HTTP_AUTH_TYPE_BASIC;
+        httpConfig.username = cfgDataPtr->username.c_str();
+        httpConfig.password = cfgDataPtr->password.c_str();
     }
     else if (cfgDataPtr->authMode == AUTH_TLS) {
-        http_config.auth_type = HTTP_AUTH_TYPE_BASIC;
-        http_config.username = cfgDataPtr->username.c_str();
-        http_config.password = cfgDataPtr->password.c_str();
-        http_config.transport_type = HTTP_TRANSPORT_OVER_SSL;
+        httpConfig.auth_type = HTTP_AUTH_TYPE_BASIC;
+        httpConfig.username = cfgDataPtr->username.c_str();
+        httpConfig.password = cfgDataPtr->password.c_str();
+        httpConfig.transport_type = HTTP_TRANSPORT_OVER_SSL;
 
         if (!TLSCACert.empty()) {
-            http_config.cert_pem = TLSCACert.c_str();
-            http_config.cert_len = TLSCACert.length() + 1;
-            http_config.skip_cert_common_name_check = true;    // Skip any validation of server certificate CN field
+            httpConfig.cert_pem = TLSCACert.c_str();
+            httpConfig.cert_len = TLSCACert.length() + 1;
+            httpConfig.skip_cert_common_name_check = true;    // Skip any validation of server certificate CN field
+        }
+        else {
+            LogFile.writeToFile(ESP_LOG_DEBUG, TAG, "CA Certificate empty, use certification bundle for server verfication");
+            httpConfig.crt_bundle_attach = esp_crt_bundle_attach;
         }
 
         if (!TLSClientCert.empty()) {
-            http_config.client_cert_pem = TLSClientCert.c_str();
-            http_config.client_cert_len = TLSClientCert.length() + 1;
+            httpConfig.client_cert_pem = TLSClientCert.c_str();
+            httpConfig.client_cert_len = TLSClientCert.length() + 1;
         }
 
         if (!TLSClientKey.empty()) {
-            http_config.client_key_pem = TLSClientKey.c_str();
-            http_config.client_key_len = TLSClientKey.length() + 1;
+            httpConfig.client_key_pem = TLSClientKey.c_str();
+            httpConfig.client_key_len = TLSClientKey.length() + 1;
         }
     }
 
@@ -177,22 +178,27 @@ esp_err_t influxDBv1Publish(const std::string &_measurement, const std::string &
     // use the default retention policy of the database
     std::string apiURI = cfgDataPtr->uri + "/write?db=" + cfgDataPtr->database;
     apiURI.shrink_to_fit();
-    http_config.url = apiURI.c_str();
+    httpConfig.url = apiURI.c_str();
     LogFile.writeToFile(ESP_LOG_DEBUG, TAG, "URI: " + apiURI);
 
-    esp_http_client_handle_t http_client = esp_http_client_init(&http_config);
+    esp_http_client_handle_t httpClient = esp_http_client_init(&httpConfig);
+    if (httpClient == NULL) {
+        LogFile.writeToFile(ESP_LOG_ERROR, TAG, "HTTP client: Initialization failed");
+        return ESP_FAIL;
+    }
+
     LogFile.writeToFile(ESP_LOG_DEBUG, TAG, "HTTP client: Initialized");
 
-    esp_http_client_set_header(http_client, "Content-Type", "text/plain");
+    esp_http_client_set_header(httpClient, "Content-Type", "text/plain");
     //LogFile.writeToFile(ESP_LOG_DEBUG, TAG, "Header setting done");
 
-    ESP_ERROR_CHECK(esp_http_client_set_post_field(http_client, payload.c_str(), payload.length()));
+    ESP_ERROR_CHECK(esp_http_client_set_post_field(httpClient, payload.c_str(), payload.length()));
     //LogFile.writeToFile(ESP_LOG_DEBUG, TAG, "Payload post completed");
 
-    retVal = ESP_ERROR_CHECK_WITHOUT_ABORT(esp_http_client_perform(http_client));
+    retVal = ESP_ERROR_CHECK_WITHOUT_ABORT(esp_http_client_perform(httpClient));
 
     if (retVal == ESP_OK) {
-        int status_code = esp_http_client_get_status_code(http_client);
+        int status_code = esp_http_client_get_status_code(httpClient);
         if (status_code < 300) {
             LogFile.writeToFile(ESP_LOG_DEBUG, TAG, "Writing data successful. HTTP response status: " + std::to_string(status_code));
         }
@@ -204,9 +210,7 @@ esp_err_t influxDBv1Publish(const std::string &_measurement, const std::string &
     else {
         LogFile.writeToFile(ESP_LOG_ERROR, TAG, "HTTP client: Request failed. Error: " + intToHexString(retVal));
     }
-    esp_http_client_cleanup(http_client);
-    free_psram_heap(std::string(TAG) + "->response_buffer", response_buffer);
-
+    esp_http_client_cleanup(httpClient);
     return retVal;
 }
 

--- a/code/components/influxdb_ctrl/interface_influxdbv2.cpp
+++ b/code/components/influxdb_ctrl/interface_influxdbv2.cpp
@@ -122,7 +122,7 @@ esp_err_t influxDBv2Publish(const std::string &_measurement, const std::string &
             httpConfig.skip_cert_common_name_check = true;    // Skip any validation of server certificate CN field
         }
         else {
-            LogFile.writeToFile(ESP_LOG_DEBUG, TAG, "CA Certificate empty, use certification bundle for server verfication");
+            LogFile.writeToFile(ESP_LOG_DEBUG, TAG, "CA Certificate empty, use certification bundle for server verification");
             httpConfig.crt_bundle_attach = esp_crt_bundle_attach;
         }
 

--- a/code/components/influxdb_ctrl/interface_influxdbv2.cpp
+++ b/code/components/influxdb_ctrl/interface_influxdbv2.cpp
@@ -6,6 +6,7 @@
 #include <time.h>
 
 #include <esp_http_client.h>
+#include <esp_crt_bundle.h>
 #include <esp_log.h>
 
 #include "ClassLogFile.h"
@@ -107,32 +108,32 @@ bool influxDBv2Init(const CfgData::SectionInfluxDBv2 *_cfgDataPtr)
 
 esp_err_t influxDBv2Publish(const std::string &_measurement, const std::string &_fieldkey1, const std::string &_fieldvalue1, const std::string &_timestamp)
 {
-    char* response_buffer = (char*) calloc_psram_heap(std::string(TAG) + "->response_buffer", 1,
-                            sizeof(char) * MAX_HTTP_OUTPUT_BUFFER, MALLOC_CAP_8BIT | MALLOC_CAP_SPIRAM);
-
-    esp_http_client_config_t http_config = {
-       .user_agent = "ESP32 Meter reader",
+    esp_http_client_config_t httpConfig = {
+       .user_agent = "AI-on-the-Edge Device",
        .method = HTTP_METHOD_POST,
        .event_handler = http_event_handler,
-       .buffer_size = MAX_HTTP_OUTPUT_BUFFER,
-       .user_data = response_buffer
+       .buffer_size = MAX_HTTP_OUTPUT_BUFFER
     };
 
     if (cfgDataPtr->authMode == AUTH_TLS) {
         if (!TLSCACert.empty()) {
-            http_config.cert_pem = TLSCACert.c_str();
-            http_config.cert_len = TLSCACert.length() + 1;
-            http_config.skip_cert_common_name_check = true;    // Skip any validation of server certificate CN field
+            httpConfig.cert_pem = TLSCACert.c_str();
+            httpConfig.cert_len = TLSCACert.length() + 1;
+            httpConfig.skip_cert_common_name_check = true;    // Skip any validation of server certificate CN field
+        }
+        else {
+            LogFile.writeToFile(ESP_LOG_DEBUG, TAG, "CA Certificate empty, use certification bundle for server verfication");
+            httpConfig.crt_bundle_attach = esp_crt_bundle_attach;
         }
 
         if (!TLSClientCert.empty()) {
-            http_config.client_cert_pem = TLSClientCert.c_str();
-            http_config.client_cert_len = TLSClientCert.length() + 1;
+            httpConfig.client_cert_pem = TLSClientCert.c_str();
+            httpConfig.client_cert_len = TLSClientCert.length() + 1;
         }
 
         if (!TLSClientKey.empty()) {
-            http_config.client_key_pem = TLSClientKey.c_str();
-            http_config.client_key_len = TLSClientKey.length() + 1;
+            httpConfig.client_key_pem = TLSClientKey.c_str();
+            httpConfig.client_key_len = TLSClientKey.length() + 1;
         }
     }
 
@@ -166,25 +167,30 @@ esp_err_t influxDBv2Publish(const std::string &_measurement, const std::string &
 
     std::string apiURI = cfgDataPtr->uri + "/api/v2/write?org=" + cfgDataPtr->organization + "&bucket=" + cfgDataPtr->bucket;
     apiURI.shrink_to_fit();
-    http_config.url = apiURI.c_str();
+    httpConfig.url = apiURI.c_str();
     LogFile.writeToFile(ESP_LOG_DEBUG, TAG, "URI: " + apiURI);
 
-    esp_http_client_handle_t http_client = esp_http_client_init(&http_config);
+    esp_http_client_handle_t httpClient = esp_http_client_init(&httpConfig);
+    if (httpClient == NULL) {
+        LogFile.writeToFile(ESP_LOG_ERROR, TAG, "HTTP client: Initialization failed");
+        return ESP_FAIL;
+    }
+
     LogFile.writeToFile(ESP_LOG_DEBUG, TAG, "HTTP client: Initialized");
 
-    esp_http_client_set_header(http_client, "Content-Type", "text/plain");
+    esp_http_client_set_header(httpClient, "Content-Type", "text/plain");
     std::string authString = "Token " + cfgDataPtr->token;
     //LogFile.writeToFile(ESP_LOG_DEBUG, TAG, "Tokenheader: %s\n", _zw.c_str());
-    esp_http_client_set_header(http_client, "Authorization", authString.c_str());
+    esp_http_client_set_header(httpClient, "Authorization", authString.c_str());
     //LogFile.writeToFile(ESP_LOG_DEBUG, TAG, "Header setting done");
 
-    ESP_ERROR_CHECK(esp_http_client_set_post_field(http_client, payload.c_str(), payload.length()));
+    ESP_ERROR_CHECK(esp_http_client_set_post_field(httpClient, payload.c_str(), payload.length()));
     //LogFile.writeToFile(ESP_LOG_DEBUG, TAG, "Payload post completed");
 
-    retVal = ESP_ERROR_CHECK_WITHOUT_ABORT(esp_http_client_perform(http_client));
+    retVal = ESP_ERROR_CHECK_WITHOUT_ABORT(esp_http_client_perform(httpClient));
 
     if (retVal == ESP_OK) {
-        int status_code = esp_http_client_get_status_code(http_client);
+        int status_code = esp_http_client_get_status_code(httpClient);
         if (status_code < 300) {
             LogFile.writeToFile(ESP_LOG_DEBUG, TAG, "Writing data successful. HTTP response status: " + std::to_string(status_code));
         }
@@ -196,9 +202,7 @@ esp_err_t influxDBv2Publish(const std::string &_measurement, const std::string &
     else {
         LogFile.writeToFile(ESP_LOG_ERROR, TAG, "HTTP client: Request failed. Error: " + intToHexString(retVal));
     }
-    esp_http_client_cleanup(http_client);
-    free_psram_heap(std::string(TAG) + "->response_buffer", response_buffer);
-
+    esp_http_client_cleanup(httpClient);
     return retVal;
 }
 

--- a/code/components/mainprocess_ctrl/ClassFlowInfluxDBv1.cpp
+++ b/code/components/mainprocess_ctrl/ClassFlowInfluxDBv1.cpp
@@ -20,7 +20,6 @@ static const char* TAG = "INFLUXDBV1";
 ClassFlowInfluxDBv1::ClassFlowInfluxDBv1()
 {
     presetFlowStateHandler(true);
-    flowpostprocessing = NULL;
     InfluxDBenable = false;
 }
 
@@ -104,12 +103,6 @@ void ClassFlowInfluxDBv1::doPostProcessEventHandling()
 {
     // Post cycle process handling can be included here. Function is called after processing cycle is completed
 
-}
-
-
-bool ClassFlowInfluxDBv1::isInfluxDBEnabled(void)
-{
-    return InfluxDBenable;
 }
 
 

--- a/code/components/mainprocess_ctrl/ClassFlowInfluxDBv1.h
+++ b/code/components/mainprocess_ctrl/ClassFlowInfluxDBv1.h
@@ -1,8 +1,8 @@
 #include "../../include/defines.h"
 #ifdef ENABLE_INFLUXDB
 
-#ifndef CLASSFINFLUXDBV1_H
-#define CLASSFINFLUXDBV1_H
+#ifndef CLASSFLOWINFLUXDBV1_H
+#define CLASSFLOWINFLUXDBV1_H
 
 #include <string>
 
@@ -16,7 +16,6 @@ class ClassFlowInfluxDBv1 : public ClassFlow
   protected:
     const CfgData::SectionInfluxDBv1 *cfgDataPtr = NULL;
     bool InfluxDBenable;
-    ClassFlowPostProcessing *flowpostprocessing;
 
   public:
     ClassFlowInfluxDBv1();
@@ -25,10 +24,9 @@ class ClassFlowInfluxDBv1 : public ClassFlow
     bool loadParameter();
     bool doFlow(std::string time);
     void doPostProcessEventHandling();
-    bool isInfluxDBEnabled();
 
     std::string name() { return "ClassFlowInfluxDBv1"; };
 };
 
-    #endif // CLASSFINFLUXDBV1_H
+    #endif // CLASSFLOWINFLUXDBV1_H
 #endif     // ENABLE_INFLUXDB

--- a/code/components/mainprocess_ctrl/ClassFlowInfluxDBv2.cpp
+++ b/code/components/mainprocess_ctrl/ClassFlowInfluxDBv2.cpp
@@ -20,7 +20,6 @@ static const char* TAG = "INFLUXDBV2";
 ClassFlowInfluxDBv2::ClassFlowInfluxDBv2()
 {
     presetFlowStateHandler(true);
-    flowpostprocessing = NULL;
     InfluxDBenable = false;
 }
 
@@ -104,12 +103,6 @@ void ClassFlowInfluxDBv2::doPostProcessEventHandling()
 {
     // Post cycle process handling can be included here. Function is called after processing cycle is completed
 
-}
-
-
-bool ClassFlowInfluxDBv2::isInfluxDBEnabled(void)
-{
-    return InfluxDBenable;
 }
 
 

--- a/code/components/mainprocess_ctrl/ClassFlowInfluxDBv2.h
+++ b/code/components/mainprocess_ctrl/ClassFlowInfluxDBv2.h
@@ -1,8 +1,8 @@
 #include "../../include/defines.h"
 #ifdef ENABLE_INFLUXDB
 
-#ifndef CLASSFINFLUXDBv2_H
-#define CLASSFINFLUXDBv2_H
+#ifndef CLASSFLOWINFLUXDBv2_H
+#define CLASSFLOWINFLUXDBv2_H
 
 #include <string>
 
@@ -16,7 +16,6 @@ class ClassFlowInfluxDBv2 : public ClassFlow
   protected:
     const CfgData::SectionInfluxDBv2 *cfgDataPtr = NULL;
     bool InfluxDBenable;
-    ClassFlowPostProcessing *flowpostprocessing;
 
   public:
     ClassFlowInfluxDBv2();
@@ -25,10 +24,9 @@ class ClassFlowInfluxDBv2 : public ClassFlow
     bool loadParameter();
     bool doFlow(std::string time);
     void doPostProcessEventHandling();
-    bool isInfluxDBEnabled();
 
     std::string name() { return "ClassFlowInfluxDBv2"; };
 };
 
-    #endif // CLASSFINFLUXDBv2_H
+    #endif // CLASSFLOWINFLUXDBv2_H
 #endif     // ENABLE_INFLUXDB

--- a/docs/Configuration/Parameter/InfluxDBv1/AuthMode.md
+++ b/docs/Configuration/Parameter/InfluxDBv1/AuthMode.md
@@ -9,14 +9,14 @@
 
 ## Description
 
-Select authentication mode for InfluxDB authentication.
+Select authentication mode for InfluxDB authentication / security.
 
 
 | Input Option               | Description
 |:---                        |:---
 | `None`                     | No authentication, anonymous
 | `Basic`                    | Authenticate with username and password
-| `TLS`                      | Authenticate with username, password and TLS certificates
+| `TLS`                      | Authenticate with username, password and/or secure with TLS certificates
 
 
 !!! Note

--- a/docs/Configuration/Parameter/InfluxDBv1/TLS_CACert.md
+++ b/docs/Configuration/Parameter/InfluxDBv1/TLS_CACert.md
@@ -8,25 +8,23 @@
 
 ## Description
 
-CA (Certificate Authority) certificate file (file name with extention, file placed in /config/certs).
-
-
+Select CA (Certificate Authority) certificate file.<br>
 The CA certificate is used for TLS handshake of InfluxDB authentification. The CA certificate is 
-used by the client to validate the broker is who it claims to be.
+used by the client to validate the server is who it claims to be.
 
 
 !!! Note
-The certificate file needs to be copied to SD card folder `/config/certs`.<br>
+    The certificate file needs to be copied to SD card folder `/config/certs`.<br>
     Supported formats:<br>
     - `PEM` (Base64-ASCII-coding, File extentions: `.pem, .crt, .cer`)<br>
     - `DER` (Binary coding, File extention: `.der, .cer`)<br>
     Only unencrypted and not password protected files are supported.
 
+
+!!! Tip
+    If no custom certificate file is selected, built-in certificate bundle is used by default. 
+    The bundle comes with a full list of root certificates from Mozilla's NSS root certificate store. 
+
     
 !!! Warning
     Certificate CN field (common name) check is disabled by default (hard-coded).
-
-
-!!! Note
-    Using TLS for InfluxDB, adaptions of InfluxDB `URI` parameter needs to be done, as well. Please ensure 
-    protocol `https://` is configured, e.g. `https://IP-ADDRESS:8086`

--- a/docs/Configuration/Parameter/InfluxDBv1/TLS_ClientCert.md
+++ b/docs/Configuration/Parameter/InfluxDBv1/TLS_ClientCert.md
@@ -8,11 +8,12 @@
 
 ## Description
 
-Client certificate file for mutual authentication (file name with extention, file placed in /config/certs). 
+Select client certificate file<br>. 
 Keep it empty if mutual authentication is not required. If configured, `Client Key` needs to be provided, too.
 
 The client certificate is used for TLS handshake of InfluxDB mutual authentification. The client certificate and 
-related client private key is used by the MQTT client to prove its identity to the MQTT broker (server).
+related client private key is used by the HTTP client to prove its identity to the InfluxDB server.
+
 
 !!! Note
 The certificate file needs to be copied to SD card folder `/config/certs`.<br>
@@ -20,8 +21,3 @@ The certificate file needs to be copied to SD card folder `/config/certs`.<br>
     - `PEM` (Base64-ASCII-coding, File extentions: `.pem, .crt, .cer`)<br>
     - `DER` (Binary coding, File extention: `.der, .cer`)<br>
     Only unencrypted and not password protected files are supported.
-
-
-!!! Note
-    Using TLS for InfluxDB, adaptions of InfluxDB `URI` parameter needs to be done, as well.  Please ensure 
-    protocol `https://` is configured, e.g. `https://IP-ADDRESS:8086`

--- a/docs/Configuration/Parameter/InfluxDBv1/TLS_ClientKey.md
+++ b/docs/Configuration/Parameter/InfluxDBv1/TLS_ClientKey.md
@@ -8,13 +8,12 @@
 
 ## Description
 
-Client private key file (file name with extention, file placed in /config/certs)<br>
+Select client private key file.<br>
+Keep it empty if mutual authentication is not required. If configured, `Client Certificate` needs to be configured, too.
 
-Client private key file for mutual authentication (absolute path in relation to sd card root folder). 
-If configured, `Client Certificate` needs to be configured, too.
-
-The client private key is used for TLS handshake of InfluxDB authentification. The client certificate and 
+The client private key is used for TLS handshake of InfluxDB mutual authentification. The client certificate and 
 related client private key is used by the HTTP client to prove its identity to the InfluxDB server.
+
 
 !!! Note
 The certificate file needs to be copied to SD card folder `/config/certs`.<br>
@@ -22,9 +21,3 @@ The certificate file needs to be copied to SD card folder `/config/certs`.<br>
     - `PEM` (Base64-ASCII-coding, File extentions: `.pem, .crt, .cer, .key`)<br>
     - `DER` (Binary coding, File extention: `.der, .cer`)<br>
     Only unencrypted and not password protected files are supported.
-
-
-
-!!! Note
-    Using TLS for InfluxDB, adaptions of InfluxDB `URI` parameter needs to be done, as well.  Please ensure 
-    protocol `https://` is configured, e.g. `https://IP-ADDRESS:8086`

--- a/docs/Configuration/Parameter/InfluxDBv1/Uri.md
+++ b/docs/Configuration/Parameter/InfluxDBv1/Uri.md
@@ -8,5 +8,6 @@
 
 ## Description
 
-URI of the HTTP interface to InfluxDB, without trailing slash, 
-e.g. `http://192.168.1.x:8086`.
+URI of the HTTP interface to InfluxDB, without trailing slash<br>
+- Connection unencrypted: e.g. `http://192.168.1.x:8086`<br>
+- Connection using TLS encryption: e.g. `https://192.168.1.x:8086`<br>

--- a/docs/Configuration/Parameter/InfluxDBv2/AuthMode.md
+++ b/docs/Configuration/Parameter/InfluxDBv2/AuthMode.md
@@ -9,13 +9,13 @@
 
 ## Description
 
-Select authentication mode for InfluxDB authentication.
+Select authentication mode for InfluxDB authentication / security.
 
 
 | Input Option               | Description
 |:---                        |:---
 | `Token`                    | Authenticate with token
-| `TLS`                      | Authenticate with token and TLS certificates
+| `TLS`                      | Authenticate with token and secure with TLS certificates
 
 
 !!! Note

--- a/docs/Configuration/Parameter/InfluxDBv2/TLS_CACert.md
+++ b/docs/Configuration/Parameter/InfluxDBv2/TLS_CACert.md
@@ -8,25 +8,23 @@
 
 ## Description
 
-CA (Certificate Authority) certificate file (file name with extention, file placed in /config/certs).
-
-
+Select CA (Certificate Authority) certificate file.<br>
 The CA certificate is used for TLS handshake of InfluxDB authentification. The CA certificate is 
-used by the client to validate the broker is who it claims to be.
+used by the client to validate the server is who it claims to be.
 
 
 !!! Note
-The certificate file needs to be copied to SD card folder `/config/certs`.<br>
+    The certificate file needs to be copied to SD card folder `/config/certs`.<br>
     Supported formats:<br>
     - `PEM` (Base64-ASCII-coding, File extentions: `.pem, .crt, .cer`)<br>
     - `DER` (Binary coding, File extention: `.der, .cer`)<br>
     Only unencrypted and not password protected files are supported.
 
+
+!!! Tip
+    If no custom certificate file is selected, built-in certificate bundle is used by default. 
+    The bundle comes with a full list of root certificates from Mozilla's NSS root certificate store. 
+
     
 !!! Warning
     Certificate CN field (common name) check is disabled by default (hard-coded).
-
-
-!!! Note
-    Using TLS for InfluxDB, adaptions of InfluxDB `URI` parameter needs to be done, as well. Please ensure 
-    protocol `https://` is configured, e.g. `https://IP-ADDRESS:8086`

--- a/docs/Configuration/Parameter/InfluxDBv2/TLS_ClientCert.md
+++ b/docs/Configuration/Parameter/InfluxDBv2/TLS_ClientCert.md
@@ -8,11 +8,12 @@
 
 ## Description
 
-Client certificate file for mutual authentication (file name with extention, file placed in /config/certs). 
+Select client certificate file<br>. 
 Keep it empty if mutual authentication is not required. If configured, `Client Key` needs to be provided, too.
 
 The client certificate is used for TLS handshake of InfluxDB mutual authentification. The client certificate and 
 related client private key is used by the HTTP client to prove its identity to the InfluxDB server.
+
 
 !!! Note
 The certificate file needs to be copied to SD card folder `/config/certs`.<br>
@@ -20,8 +21,3 @@ The certificate file needs to be copied to SD card folder `/config/certs`.<br>
     - `PEM` (Base64-ASCII-coding, File extentions: `.pem, .crt, .cer`)<br>
     - `DER` (Binary coding, File extention: `.der, .cer`)<br>
     Only unencrypted and not password protected files are supported.
-
-
-!!! Note
-    Using TLS for InfluxDB, adaptions of InfluxDB `URI` parameter needs to be done, as well.  Please ensure 
-    protocol `https://` is configured, e.g. `https://IP-ADDRESS:8086`

--- a/docs/Configuration/Parameter/InfluxDBv2/TLS_ClientKey.md
+++ b/docs/Configuration/Parameter/InfluxDBv2/TLS_ClientKey.md
@@ -8,13 +8,12 @@
 
 ## Description
 
-Client private key file (file name with extention, file placed in /config/certs)<br>
+Select client private key file.<br>
+Keep it empty if mutual authentication is not required. If configured, `Client Certificate` needs to be configured, too.
 
-Client private key file for mutual authentication (absolute path in relation to sd card root folder). 
-If configured, `Client Certificate` needs to be configured, too.
-
-The client private key is used for TLS handshake of InfluxDB authentification. The client certificate and 
+The client private key is used for TLS handshake of InfluxDB mutual authentification. The client certificate and 
 related client private key is used by the HTTP client to prove its identity to the InfluxDB server.
+
 
 !!! Note
 The certificate file needs to be copied to SD card folder `/config/certs`.<br>
@@ -22,8 +21,3 @@ The certificate file needs to be copied to SD card folder `/config/certs`.<br>
     - `PEM` (Base64-ASCII-coding, File extentions: `.pem, .crt, .cer, .key`)<br>
     - `DER` (Binary coding, File extention: `.der, .cer`)<br>
     Only unencrypted and not password protected files are supported.
-
-
-!!! Note
-    Using TLS for InfluxDB, adaptions of InfluxDB `URI` parameter needs to be done, as well.  Please ensure 
-    protocol `https://` is configured, e.g. `https://IP-ADDRESS:8086`

--- a/docs/Configuration/Parameter/InfluxDBv2/Uri.md
+++ b/docs/Configuration/Parameter/InfluxDBv2/Uri.md
@@ -8,5 +8,6 @@
 
 ## Description
 
-URI of the HTTP interface to InfluxDB, without trailing slash, 
-e.g. `http://192.168.1.x:8086`.
+URI of the HTTP interface to InfluxDB, without trailing slash<br>
+- Connection unencrypted: e.g. `http://192.168.1.x:8086`<br>
+- Connection using TLS encryption: e.g. `https://192.168.1.x:8086`<br>

--- a/docs/Configuration/Parameter/MQTT/AuthMode.md
+++ b/docs/Configuration/Parameter/MQTT/AuthMode.md
@@ -9,14 +9,14 @@
 
 ## Description
 
-Select authentication mode for InfluxDB authentication.
+Select authentication mode for MQTT broker authentication / security.
 
 
 | Input Option               | Description
 |:---                        |:---
 | `None`                     | No authentication, anonymous
 | `Basic`                    | Authenticate with username and password
-| `TLS`                      | Authenticate with username, password and TLS certificates
+| `TLS`                      | Authenticate with username, password and/or secure with TLS certificates
 
 
 !!! Note

--- a/docs/Configuration/Parameter/MQTT/Enabled.md
+++ b/docs/Configuration/Parameter/MQTT/Enabled.md
@@ -14,3 +14,8 @@ Enable or disable MQTT client service.
 
 !!! Note
     Only MQTT version 3.1.x is supported up to now.
+
+
+!!! Tip
+    More detailed information can be found in MQTT API description located in
+    repository `docs` folder or is also accessible in `WebUI > System > Documentation`.

--- a/docs/Configuration/Parameter/MQTT/TLS_CACert.md
+++ b/docs/Configuration/Parameter/MQTT/TLS_CACert.md
@@ -8,25 +8,24 @@
 
 ## Description
 
-CA (Certificate Authority) certificate file (file name with extention, file placed in /config/certs).
-
-
+Select CA (Certificate Authority) certificate file.<br>
 The CA certificate is used for TLS handshake of MQTT broker authentification. The CA certificate is 
 used by the client to validate the broker is who it claims to be.
 
 
 !!! Note
-The certificate file needs to be copied to SD card folder `/config/certs`.<br>
+    The certificate file needs to be copied to SD card folder `/config/certs`.<br>
     Supported formats:<br>
     - `PEM` (Base64-ASCII-coding, File extentions: `.pem, .crt, .cer`)<br>
     - `DER` (Binary coding, File extention: `.der, .cer`)<br>
     Only unencrypted and not password protected files are supported.
 
+
+!!! Tip
+    If no custom certificate file is selected, built-in certificate bundle is used by default. 
+    The bundle comes with a full list of root certificates from Mozilla's NSS root certificate store. 
+
     
 !!! Warning
     Certificate CN field (common name) check is disabled by default (hard-coded).
 
-
-!!! Note
-    Using TLS for MQTT, adaptions of MQTT `URI` parameter needs to be done, as well.  Please ensure suitable MQTT
-    TLS protocol `mqtts://` and proper MQTT TLS port selection. e.g. `mqtts://IP-ADDRESS:8883`

--- a/docs/Configuration/Parameter/MQTT/TLS_ClientCert.md
+++ b/docs/Configuration/Parameter/MQTT/TLS_ClientCert.md
@@ -8,20 +8,16 @@
 
 ## Description
 
-Client certificate file for mutual authentication (file name with extention, file placed in /config/certs). 
+Select client certificate file.<br>
 Keep it empty if mutual authentication is not required. If configured, `Client Key` needs to be provided, too.
 
 The client certificate is used for TLS handshake of MQTT broker mutual authentification. The client certificate and 
 related client private key is used by the MQTT client to prove its identity to the MQTT broker (server).
 
+
 !!! Note
-The certificate file needs to be copied to SD card folder `/config/certs`.<br>
+    The certificate file needs to be copied to SD card folder `/config/certs`.<br>
     Supported formats:<br>
     - `PEM` (Base64-ASCII-coding, File extentions: `.pem, .crt, .cer`)<br>
     - `DER` (Binary coding, File extention: `.der, .cer`)<br>
     Only unencrypted and not password protected files are supported.
-
-
-!!! Note
-    Using TLS for MQTT, adaptions of MQTT `URI` parameter needs to be done, as well.  Please ensure suitable MQTT
-    TLS protocol `mqtts://` and proper MQTT TLS port selection. e.g. `mqtts://IP-ADDRESS:8883`

--- a/docs/Configuration/Parameter/MQTT/TLS_ClientKey.md
+++ b/docs/Configuration/Parameter/MQTT/TLS_ClientKey.md
@@ -8,22 +8,16 @@
 
 ## Description
 
-Client private key file (file name with extention, file placed in /config/certs)<br>
+Select client private key file.<br>
+Keep it empty if mutual authentication is not required. If configured, `Client Certificate` needs to be configured, too.
 
-Client private key file for mutual authentication (absolute path in relation to sd card root folder). 
-If configured, `Client Certificate` needs to be configured, too.
-
-The client private key is used for TLS handshake of MQTT broker authentification. The client certificate and 
+The client private key is used for TLS handshake of MQTT broker mutual authentification. The client certificate and 
 related client private key is used by the MQTT client to prove its identity to the MQTT broker (server).
 
+
 !!! Note
-The certificate file needs to be copied to SD card folder `/config/certs`.<br>
+    The certificate file needs to be copied to SD card folder `/config/certs`.<br>
     Supported formats:<br>
     - `PEM` (Base64-ASCII-coding, File extentions: `.pem, .crt, .cer, .key`)<br>
     - `DER` (Binary coding, File extention: `.der, .cer`)<br>
     Only unencrypted and not password protected files are supported.
-
-
-!!! Note
-    Using TLS for MQTT, adaptions of MQTT `URI` parameter needs to be done, as well.  Please ensure suitable MQTT
-    TLS protocol `mqtts://` and proper MQTT TLS port selection. e.g. `mqtts://IP-ADDRESS:8883`


### PR DESCRIPTION
If TLS is enabled, but no user-provided CA certificate is selected, use [built-in certification bundle](https://docs.espressif.com/projects/esp-idf/en/v5.3.1/esp32/api-reference/protocols/esp_crt_bundle.html) for server verification (default) for the following services:
- MQTT
- InfluxDBv1
- InfluxDBv2

Benefits:
- The bundle comes with the complete list of root certificates from [Mozilla's NSS root certificate store](https://curl.se/docs/caextract.html). Most commonly used root certificates are covered out of the box.

Drawback:
- Increased flash size (ca. 66kB)
  - If needed, could be reduced by using only common certificates (to be modified in sdkconfig.defaults)
  - At creation time of this PR, flash memory is still suffcient

---
Usage before based on ESP32:
RAM:   [=         ]  13.8% (used 45096 bytes from 327680 bytes)
Flash: [========  ]  82.2% (used 1599697 bytes from 1945600 bytes)

Usage after:
RAM:   [=         ]  13.9% (used 45520 bytes from 327680 bytes)
Flash: [========= ]  85.6% (used 1665457 bytes from 1945600 bytes)