### PR TITLE
fix(home assistant discovery): Set correct device class for 'rate_per_time_unit'

### DIFF
--- a/code/components/mqtt_ctrl/server_mqtt.cpp
+++ b/code/components/mqtt_ctrl/server_mqtt.cpp
@@ -565,6 +565,7 @@ bool mqttServer_publishHADiscovery(int _qos)
             .friendlyName = "Rate",
             .icon = "swap-vertical",
             .unit = rateUnit,
+            .deviceClass = meterType == "energy" ? "power" : "volume_flow_rate",
             .stateClass = "measurement"
         };
         publishOK &= publishHADiscoveryTopic(&HADiscoveryData, _qos);
@@ -578,7 +579,8 @@ bool mqttServer_publishHADiscovery(int _qos)
             .friendlyName = "Rate / Interval",
             .icon = "arrow-expand-vertical",
             .unit = valueUnit != "" ? valueUnit + "/" + to_stringWithPrecision(processingInterval, 1) + "min" : "",
-            .stateClass = "measurement"
+            .stateClass = "measurement",
+            .entityCategory = "diagnostic"
         };
         publishOK &= publishHADiscoveryTopic(&HADiscoveryData, _qos);
 


### PR DESCRIPTION
Home Assistant Discovery:
1. Set correct device class for `rate_per_time_unit` to allow unit conversion change in HA 
 --> issue described here: #3333

Device class is dependend on meter type:
- Energy meter: device class = `power`
- Gas / water meter: device class = `volume_flow_rate`

Cherry-picked from #3332. Thanks to caco3 for the fix.


Note: Additional inconistencies were fixed in #229 and #234

---
3. Move `rate_per_interval` to diagnostic category
