### PR TITLE
feat(home assistant discovery): Add discovery topics for GPIO pins

### DIFF
--- a/code/components/gpio_ctrl/gpioControl.h
+++ b/code/components/gpio_ctrl/gpioControl.h
@@ -39,7 +39,6 @@ class GpioHandler
     ledc_timer_t getFreeTimer(int _frequency);
 
     gpio_num_t resolveSparePinNr(uint8_t _sparePinNr);
-    gpio_pin_mode_t resolvePinMode(std::string input);
     std::string getPinModeDecription(gpio_pin_mode_t _mode);
     gpio_int_type_t resolveIntType(std::string input);
     std::string getPinInterruptDecription(gpio_int_type_t _type);
@@ -59,6 +58,8 @@ class GpioHandler
 
     void gpioPinInterrupt(GpioResult *gpioResult);
     void gpioInputStatePolling();
+
+    gpio_pin_mode_t resolvePinMode(std::string input);
 
     void registerGpioUri();
     esp_err_t handleHttpRequest(httpd_req_t *req);

--- a/code/components/mqtt_ctrl/server_mqtt.cpp
+++ b/code/components/mqtt_ctrl/server_mqtt.cpp
@@ -17,6 +17,7 @@
 #include "time_sntp.h"
 #include "helper.h"
 #include "system.h"
+#include "gpioControl.h"
 
 static const char *TAG = "SERVER_MQTT";
 
@@ -502,7 +503,7 @@ bool mqttServer_publishHADiscovery(int _qos)
     for (const auto &sequence : *sequenceData) {
         HADiscoveryData = {};
         HADiscoveryData = {
-            .sequenceName = sequence->sequenceName,
+            .structureName = sequence->sequenceName,
             .isTopicJSONNotation = true,
             .topic = "/process/data/" + std::to_string(sequence->sequenceId) + "/json",
             .topicName = "actual_value",
@@ -514,24 +515,26 @@ bool mqttServer_publishHADiscovery(int _qos)
         };
         publishOK &= publishHADiscoveryTopic(&HADiscoveryData, _qos);
 
-        HADiscoveryData = {};
-        HADiscoveryData = {
-            .sequenceName = sequence->sequenceName,
-            .isTopicJSONNotation = true,
-            .topic = "/process/data/" + std::to_string(sequence->sequenceId) + "/json",
-            .topicName = "fallback_value",
-            .friendlyName = "Fallback Value",
-            .icon = "gauge",
-            .unit = valueUnit,
-            .deviceClass = meterType,
-            .stateClass = "measurement",
-            .entityCategory = "diagnostic"
-        };
-        publishOK &= publishHADiscoveryTopic(&HADiscoveryData, _qos);
+        if (sequence->paramPostProc->useFallbackValue) {
+            HADiscoveryData = {};
+            HADiscoveryData = {
+                .structureName = sequence->sequenceName,
+                .isTopicJSONNotation = true,
+                .topic = "/process/data/" + std::to_string(sequence->sequenceId) + "/json",
+                .topicName = "fallback_value",
+                .friendlyName = "Fallback Value",
+                .icon = "gauge",
+                .unit = valueUnit,
+                .deviceClass = meterType,
+                .stateClass = "measurement",
+                .entityCategory = "diagnostic"
+            };
+            publishOK &= publishHADiscoveryTopic(&HADiscoveryData, _qos);
+        }
 
         HADiscoveryData = {};
         HADiscoveryData = {
-            .sequenceName = sequence->sequenceName,
+            .structureName = sequence->sequenceName,
             .isTopicJSONNotation = true,
             .topic = "/process/data/" + std::to_string(sequence->sequenceId) + "/json",
             .topicName = "raw_value",
@@ -546,7 +549,7 @@ bool mqttServer_publishHADiscovery(int _qos)
 
         HADiscoveryData = {};
         HADiscoveryData = {
-            .sequenceName = sequence->sequenceName,
+            .structureName = sequence->sequenceName,
             .isTopicJSONNotation = true,
             .topic = "/process/data/" + std::to_string(sequence->sequenceId) + "/json",
             .topicName = "value_status",
@@ -558,7 +561,7 @@ bool mqttServer_publishHADiscovery(int _qos)
 
         HADiscoveryData = {};
         HADiscoveryData = {
-            .sequenceName = sequence->sequenceName,
+            .structureName = sequence->sequenceName,
             .isTopicJSONNotation = true,
             .topic = "/process/data/" + std::to_string(sequence->sequenceId) + "/json",
             .topicName = "rate_per_time_unit",
@@ -572,7 +575,7 @@ bool mqttServer_publishHADiscovery(int _qos)
 
         HADiscoveryData = {};
         HADiscoveryData = {
-            .sequenceName = sequence->sequenceName,
+            .structureName = sequence->sequenceName,
             .isTopicJSONNotation = true,
             .topic = "/process/data/" + std::to_string(sequence->sequenceId) + "/json",
             .topicName = "rate_per_interval",
@@ -586,7 +589,7 @@ bool mqttServer_publishHADiscovery(int _qos)
 
         HADiscoveryData = {};
         HADiscoveryData = {
-            .sequenceName = sequence->sequenceName,
+            .structureName = sequence->sequenceName,
             .isTopicJSONNotation = true,
             .topic = "/process/data/" + std::to_string(sequence->sequenceId) + "/json",
             .topicName = "timestamp_processed",
@@ -604,10 +607,42 @@ bool mqttServer_publishHADiscovery(int _qos)
         .topicName = "cycle_start",
         .friendlyName = "Manual Cycle Start",
         .icon = "timer-play-outline",
-        .deviceClass = "update",
-        .entityCategory = "config"
     };
     publishOK &= publishHADiscoveryTopic(&HADiscoveryData, _qos);
+
+    // Publish GPIO state topic
+    for (const auto &gpioPin : ConfigClass::getInstance()->get()->sectionGpio.gpioPin) {
+        if (!gpioPin.pinEnabled || !gpioPin.exposeToMqtt) { // Skip if disabled or not exposed to MQTT
+            continue;
+        }
+
+        std::string gpioName = gpioPin.pinName.empty() ? "gpio" + std::to_string(gpioPin.gpioNumber) : gpioPin.pinName;
+        gpio_pin_mode_t pinMode = gpio_handler_get()->resolvePinMode(toLower(gpioPin.pinMode));
+
+        HADiscoveryData = {};
+        HADiscoveryData = {
+            .structureName = gpioName,
+            .isTopicJSONNotation = true,
+            .topic = "/device/gpio/" + gpioName + "/state",
+            .topicName = "state",
+            .friendlyName = "State",
+            .entityCategory = "diagnostic"
+        };
+        publishOK &= publishHADiscoveryTopic(&HADiscoveryData, _qos);
+
+        if (pinMode == GPIO_PIN_MODE_OUTPUT_PWM) {
+            HADiscoveryData = {};
+            HADiscoveryData = {
+                .structureName = gpioName,
+                .isTopicJSONNotation = true,
+                .topic = "/device/gpio/" + gpioName + "/state",
+                .topicName = "pwm_duty",
+                .friendlyName = "PWM Duty",
+                .entityCategory = "diagnostic"
+            };
+            publishOK &= publishHADiscoveryTopic(&HADiscoveryData, _qos);
+        }
+    }
 
     if (!publishOK) {
         LogFile.writeToFile(ESP_LOG_ERROR, TAG, "Failed to publish HA discovery");
@@ -629,25 +664,32 @@ static bool publishHADiscoveryTopic(const strHADiscoveryData *_data, const int _
     // Add name prefix for number sequences to make ID and friendly names unique
     std::string topicNameID = _data->topicName;
     std::string friendlyName = _data->friendlyName;
-    if (!_data->sequenceName.empty()) {
-        topicNameID = _data->sequenceName + "_" + _data->topicName;
-        friendlyName = _data->sequenceName + ": " + _data->friendlyName;
+    if (!_data->structureName.empty()) {
+        topicNameID = _data->structureName + "_" + _data->topicName;
+        friendlyName = _data->structureName + ": " + _data->friendlyName;
     }
 
-    // Define configuration topic
-    std::string configurationTopic;
-    if (_data->deviceClass == "problem" && _data->topicName == "process_error") { // Special case: process_error -> configure as binary sensor
+    // Define configuration topic (default component: sensor)
+    std::string configurationTopic = cfgDataPtr->homeAssistant.discoveryPrefix  + "/sensor/" + nodeID + "/" + topicNameID + "/config";
+
+    if (_data->topicName == "process_error") { // Special case: Process error
         configurationTopic = cfgDataPtr->homeAssistant.discoveryPrefix + "/binary_sensor/" + nodeID + "/" + topicNameID + "/config";
     }
-    else if (_data->topic == "/process/ctrl/cycle_start") { // Special case: cyle_start command -> configure as button
+    else if (_data->topicName == "cycle_start") { // Special case: Cycle start
         configurationTopic = cfgDataPtr->homeAssistant.discoveryPrefix  + "/button/" + nodeID + "/" + topicNameID + "/config";
     }
-    else {
-        configurationTopic = cfgDataPtr->homeAssistant.discoveryPrefix  + "/sensor/" + nodeID + "/" + topicNameID + "/config";
+    else if (_data->topic.contains("/gpio/")) { // Special case: GPIO
+        if (_data->topicName == "state") { // State
+            configurationTopic = cfgDataPtr->homeAssistant.discoveryPrefix + "/binary_sensor/" + nodeID + "/" + topicNameID + "/config";
+        }
+        else { // PWM duty
+            configurationTopic = cfgDataPtr->homeAssistant.discoveryPrefix  + "/sensor/" + nodeID + "/" + topicNameID + "/config";
+        }
     }
 
     // Define payload for configuration topic
     // See https://www.home-assistant.io/docs/mqtt/discovery/
+    // Abbreviations: https://www.home-assistant.io/integrations/mqtt/#supported-abbreviations-in-mqtt-discovery-messages
     std::string payload =
         "{\"~\":\"" + cfgDataPtr->mainTopic + "\","  +
         "\"uniq_id\":\"" + nodeID + "_" + topicNameID + "\"," +
@@ -657,43 +699,60 @@ static bool publishHADiscoveryTopic(const strHADiscoveryData *_data, const int _
     if (!_data->icon.empty())
         payload += "\"ic\":\"mdi:" + _data->icon + "\",";
 
-    if (_data->topic == "/process/ctrl/cycle_start") { // Special case: cyle_start command
+    // Define command or status topic
+    if (_data->topicName == "cycle_start") { // Special case: cyle_start command
         payload += "\"cmd_t\":\"~" + _data->topic + "\","; // Add command topic
         payload += "\"pl_prs\":\"1\",";
+    }
+    else if (_data->topic.contains("/gpio/")) { // Special case: GPIO
+        payload += "\"stat_t\":\"~" + _data->topic + "\","; // Add status topic
+
+        if (_data->topicName == "state") { // GPIO state
+            payload += "\"pl_on\":\"1\","; // payload "ON"
+            payload += "\"pl_off\":\"0\","; // payload "OFF"
+        }
     }
     else {
         payload += "\"stat_t\":\"~" + _data->topic + "\","; // Add status topic
     }
 
-    // Add status topic template for JSON notation or process error binary topic
-    if (_data->isTopicJSONNotation)
+    // Define value template
+    if (_data->isTopicJSONNotation) {
         payload += "\"val_tpl\":\"{{value_json." + _data->topicName + "}}\",";
+    }
     // Signal a problem only if multiple process errors (-2) or process deviation (2) in row occured
-    else if (_data->deviceClass == "problem" && _data->topicName == "process_error") // Special binary sensor
+    else if (_data->topicName == "process_error") { // Special case: process error
         payload += "\"val_tpl\":\"{{ 'ON' if '-2' in value or '2' in value else 'OFF'}}\",";
+    }
 
+    // Set QOS to "At least once" (QoS 1)
     payload += "\"qos\":\"1\",";
 
-    if (!_data->unit.empty())
+    if (!_data->unit.empty()) {
         payload += "\"unit_of_meas\":\"" + _data->unit + "\",";
+    }
 
-    if (!_data->deviceClass.empty())
+    if (!_data->deviceClass.empty()) {
         payload += "\"dev_cla\":\"" + _data->deviceClass + "\",";
+    }
 
-    if (!_data->stateClass.empty())
+    if (!_data->stateClass.empty()) {
         payload += "\"stat_cla\":\"" + _data->stateClass + "\",";
+    }
 
-    if (!_data->entityCategory.empty())
+    if (!_data->entityCategory.empty()) {
         payload += "\"ent_cat\":\"" + _data->entityCategory + "\",";
+    }
 
-    payload +=
-        "\"avty_t\":\"~" + std::string(MQTT_STATUS_TOPIC) + "\""; // Use default values for available: "online" / not available: "offline"
+    // Define availability topic
+    payload += "\"avty_t\":\"~" + std::string(MQTT_STATUS_TOPIC) + "\"";
 
     // Publish complete general device info only once
     if (publishHADiscoveryTopicDeviceInfo) {
         std::string firmwareVersion = std::string(libfive_git_version());
-        if (firmwareVersion == "" || firmwareVersion == "N/A")
+        if (firmwareVersion == "" || firmwareVersion == "N/A") {
             firmwareVersion = std::string(libfive_git_branch()) + " (" + std::string(libfive_git_revision()) + ")";
+        }
 
         payload += std::string(", \"dev\": {")  +
             "\"ids\":[\"" + nodeID + "\"],"  +
@@ -705,7 +764,7 @@ static bool publishHADiscoveryTopic(const strHADiscoveryData *_data, const int _
     }
     else { // Publish device reference only to group data together
         payload += std::string(", \"dev\": {")  +
-            "\"ids\":[\"" + nodeID + "\"]}";
+                                 "\"ids\":[\"" + nodeID + "\"]}";
     }
 
     payload += "}";

--- a/code/components/mqtt_ctrl/server_mqtt.h
+++ b/code/components/mqtt_ctrl/server_mqtt.h
@@ -9,7 +9,7 @@
 
 
 struct strHADiscoveryData {
-    std::string sequenceName = "";
+    std::string structureName = "";
     bool isTopicJSONNotation = false;
     std::string topic = "";
     std::string topicName = "";


### PR DESCRIPTION
### Add discovery topics for GPIO pins
- Discovery topics are only published for enabled pins and with enabled `Expose To MQTT`
- Visualization:
  - `{GPIO name} : State` : `Off` / `On`
    e.g.
    ![image](https://github.com/user-attachments/assets/3d1e1f60-1ed7-4f4e-ab56-9afe6003016e)
  - `{GPIO name} : PWM Duty` : `{Value}` (only for GPIO mode: `Output PWM`)

### Further small corrections:
- Publish discovery topic for `Fallback Value` only if fallback evaluation is activated
- Visualize `Manual Start Trigger` button in control section instead of configuration section

---
### Usage statistics

Before (based on ESP32):
RAM:   [=         ]  14.3% (used 46972 bytes from 327680 bytes)
Flash: [========= ]  87.8% (used 1708193 bytes from 1945600 bytes)

After:
RAM:   [=         ]  14.3% (used 46972 bytes from 327680 bytes)
Flash: [========= ]  87.9% (used 1709417 bytes from 1945600 bytes)