### PR TITLE
fix(demo mode): Deinit demo mode when main init is aborted

### DIFF
--- a/code/components/camera_ctrl/ClassControlCamera.cpp
+++ b/code/components/camera_ctrl/ClassControlCamera.cpp
@@ -1142,14 +1142,12 @@ bool ClassControlCamera::loadNextDemoImage(camera_fb_t *_fb)
 /* Free only user allocated memory without deinit of cam driver */
 void ClassControlCamera::freeDemoMemoryOnly()
 {
-    demoFiles.clear();
-    std::vector<std::string>().swap(demoFiles); // Ensure that memory allocated by vector gets freed
+    disableDemoMode();
 }
 
 
 ClassControlCamera::~ClassControlCamera()
 {
+    disableDemoMode();
     deinitCam();
-    demoFiles.clear();
-    std::vector<std::string>().swap(demoFiles); // Ensure that memory allocated by vector gets freed
 }

--- a/code/components/mainprocess_ctrl/ClassFlowTakeImage.cpp
+++ b/code/components/mainprocess_ctrl/ClassFlowTakeImage.cpp
@@ -172,4 +172,5 @@ time_t ClassFlowTakeImage::getTimeImageTaken()
 ClassFlowTakeImage::~ClassFlowTakeImage()
 {
     delete rawImage;
+    cameraCtrl.freeDemoMemoryOnly();
 }


### PR DESCRIPTION
Taking an image e.g. for creating a reference image (only in condition: main init aborted + demo mode active) results in a division by zero execption because demo mode is not deactivated properly (accessing non-initialized ressources) --> Deinit demo mode properly