### PR TITLE
fix(camera): Skip first 10 images after camera init

### DIFF
--- a/code/components/camera_ctrl/ClassControlCamera.cpp
+++ b/code/components/camera_ctrl/ClassControlCamera.cpp
@@ -79,20 +79,16 @@ ClassControlCamera::ClassControlCamera()
     cameraInitSuccessful = false;
 
     demoMode = false;
-
-#ifdef GPIO_FLASHLIGHT_DEFAULT_USE_PWM
-    ledcInitFlashlightDefault();
-#endif // GPIO_FLASHLIGHT_DEFAULT_USE_PWM
 }
 
 
 esp_err_t ClassControlCamera::initCam()
 {
+    LogFile.writeToFile(ESP_LOG_INFO, TAG, "Init camera");
+
     if (cameraInitSuccessful) {
         deinitCam(); // De-init in case it was already initialized
     }
-
-    vTaskDelay(pdMS_TO_TICKS(100));
 
     // Init camera
     esp_err_t err = esp_camera_init(&cameraConfig);
@@ -124,6 +120,19 @@ esp_err_t ClassControlCamera::initCam()
     sensorFrameSizeWidth = resolution[camera_sensor[paramCameraInternal.cameraModel].max_size].width;
     sensorFrameSizeHeight = resolution[camera_sensor[paramCameraInternal.cameraModel].max_size].height;
 
+    // Set camera and flashlight config
+    setCameraParameter(&paramCameraInternal);
+    setFlashlightParameter(&paramFlashlightInternal);
+
+    // Skip first frames to allow camera auto routines (AWB, AGC, ...) to adapt to actual environment
+    // Note: Handle it for all camera models, but especially OV2640 has quite slow auto routines
+    skipFrames(10);
+
+    LogFile.writeToFile(ESP_LOG_INFO, TAG, "Init camera successful");
+
+    // Print camera info
+    printCamInfo();
+
     return ESP_OK;
 }
 
@@ -132,18 +141,45 @@ esp_err_t ClassControlCamera::deinitCam()
 {
     cameraInitSuccessful = false;
     esp_camera_deinit(); // De-init in case it was already initialized (returns ESP_FAIL if deinit is already done)
-    powerResetCamera();
+    powerCycle();
 
     return ESP_OK;
 }
 
 
-void ClassControlCamera::powerResetCamera()
+void ClassControlCamera::skipFrames(uint8_t n)
 {
-#if PWDN_GPIO_NUM == -1 // Use reset only if pin is available
-    LogFile.writeToFile(ESP_LOG_DEBUG, TAG, "No power down pin availbale to reset camera");
+    LogFile.writeToFile(ESP_LOG_INFO, TAG, "Skip camera frames");
+
+    setStatusLed(true);
+    setFlashlight(true);
+
+    camera_fb_t *fb = NULL;
+    for (uint8_t i = 0; i < n; ++i) {
+        vTaskDelay(pdMS_TO_TICKS(100));
+        fb = esp_camera_fb_get();
+        esp_camera_fb_return(fb);
+    }
+
+    setFlashlight(false);
+    setStatusLed(false);
+}
+
+
+void ClassControlCamera::powerCycle()
+{
+#if PWDN_GPIO_NUM == -1 // Power down pin not wired
+    LogFile.writeToFile(ESP_LOG_DEBUG, TAG, "Power down pin not wired. Resetting by software");
+
+    sensor_t *s = esp_camera_sensor_get();
+    if (s == NULL) {
+        return;
+    }
+    s->reset(s); // Software reset
+    vTaskDelay(pdMS_TO_TICKS(100));
 #else
-    LogFile.writeToFile(ESP_LOG_DEBUG, TAG, "Resetting camera by power down");
+    LogFile.writeToFile(ESP_LOG_DEBUG, TAG, "Resetting by power cycle");
+
     gpio_config_t conf;
     conf.intr_type = GPIO_INTR_DISABLE;
     conf.pin_bit_mask = 1LL << PWDN_GPIO_NUM;
@@ -152,26 +188,11 @@ void ClassControlCamera::powerResetCamera()
     conf.pull_up_en = GPIO_PULLUP_DISABLE;
     gpio_config(&conf);
 
-    // Be careful, logic is inverted compared to reset pin
-    gpio_set_level(PWDN_GPIO_NUM, 1);
-    vTaskDelay(pdMS_TO_TICKS(1000));
-    gpio_set_level(PWDN_GPIO_NUM, 0);
-    vTaskDelay(pdMS_TO_TICKS(1000));
+    gpio_set_level(PWDN_GPIO_NUM, 1); // Power down (low active)
+    vTaskDelay(pdMS_TO_TICKS(100));
+    gpio_set_level(PWDN_GPIO_NUM, 0); // Power up (low active)
+    vTaskDelay(pdMS_TO_TICKS(100));
 #endif // PWDN_GPIO_NUM == -1
-}
-
-
-bool ClassControlCamera::testCamera(void)
-{
-    bool retval;
-    camera_fb_t *fb = esp_camera_fb_get();
-    if (fb == NULL) {
-        LogFile.writeToFile(ESP_LOG_ERROR, TAG, "Camera framebuffer check failed");
-        return false;
-    }
-
-    esp_camera_fb_return(fb);
-    return true;
 }
 
 
@@ -230,6 +251,7 @@ esp_err_t ClassControlCamera::setCameraParameter(const CfgData::SectionTakeImage
                          paramCameraInternal.sharpness, paramCameraInternal.exposureControlMode, paramCameraInternal.autoExposureLevel,
                          paramCameraInternal.manualExposureValue, paramCameraInternal.gainControlMode, paramCameraInternal.manualGainValue,
                          paramCameraInternal.specialEffect, paramCameraInternal.mirrorImage, paramCameraInternal.flipImage);
+    vTaskDelay(pdMS_TO_TICKS(100));
 
     return ESP_OK;
 }
@@ -919,6 +941,19 @@ esp_err_t ClassControlCamera::captureToStream(httpd_req_t *_req, bool _flashligh
     LogFile.writeToFile(ESP_LOG_INFO, TAG, "Live stream stopped");
 
     return res;
+}
+
+
+void ClassControlCamera::initFlashlight(void)
+{
+#ifdef GPIO_FLASHLIGHT_DEFAULT_USE_PWM
+    ledcInitFlashlightDefault();
+#elif defined(GPIO_FLASHLIGHT_DEFAULT_USE_SMARTLED)
+    if (!gpio_handler_get()->gpioHandlerIsEnabled()) {
+        gpio_handler_init();
+    }
+#endif
+    cameraCtrl.setFlashlight(false);
 }
 
 

--- a/code/components/camera_ctrl/ClassControlCamera.cpp
+++ b/code/components/camera_ctrl/ClassControlCamera.cpp
@@ -948,8 +948,15 @@ void ClassControlCamera::initFlashlight(void)
 {
 #ifdef GPIO_FLASHLIGHT_DEFAULT_USE_PWM
     ledcInitFlashlightDefault();
+
+    // Init GPIO handler to handle flashlight
+    if (ConfigClass::getInstance()->get()->sectionGpio.customizationEnabled) {
+        if (!(gpio_handler_get() != NULL && gpio_handler_get()->gpioHandlerIsEnabled())) {
+            gpio_handler_init();
+        }
+    }
 #elif defined(GPIO_FLASHLIGHT_DEFAULT_USE_SMARTLED)
-    if (!gpio_handler_get()->gpioHandlerIsEnabled()) {
+    if (!(gpio_handler_get() != NULL && gpio_handler_get()->gpioHandlerIsEnabled())) {
         gpio_handler_init();
     }
 #endif

--- a/code/components/camera_ctrl/ClassControlCamera.h
+++ b/code/components/camera_ctrl/ClassControlCamera.h
@@ -35,11 +35,12 @@ class ClassControlCamera
   public:
     ClassControlCamera();
     ~ClassControlCamera();
-    void powerResetCamera();
     esp_err_t initCam();
     esp_err_t deinitCam();
 
-    bool testCamera(void);
+    void skipFrames(uint8_t n = 10);
+    void powerCycle();
+
     void printCamInfo(void);
     void printCamConfig(void);
 
@@ -65,6 +66,7 @@ class ClassControlCamera
     esp_err_t captureToHTTP(httpd_req_t *_req);
     esp_err_t captureToStream(httpd_req_t *_req, bool _flashlightOn);
 
+    void initFlashlight(void);
 #ifdef GPIO_FLASHLIGHT_DEFAULT_USE_PWM
     void ledcInitFlashlightDefault(void);
 #endif // GPIO_FLASHLIGHT_DEFAULT_USE_PWM

--- a/code/components/gpio_ctrl/gpioControl.cpp
+++ b/code/components/gpio_ctrl/gpioControl.cpp
@@ -29,11 +29,9 @@ static GpioHandler *gpioHandler = NULL;
 QueueHandle_t gpio_queue_handle = NULL;
 
 
-GpioHandler::GpioHandler(httpd_handle_t _httpServer)
+GpioHandler::GpioHandler()
 {
-    httpServer = _httpServer;
-
-    registerGpioUri();
+    // No action
 }
 
 
@@ -249,7 +247,7 @@ esp_err_t GpioHandler::loadParameter()
         for (int i = 0; i < GPIO_SPARE_PIN_COUNT; ++i) {
             if (strcmp(gpio_spare_usage[i], FLASHLIGHT_SMARTLED) == 0) {
                 GpioPin *gpioPin = new GpioPin((gpio_num_t)gpio_spare[i], ("gpio" + std::to_string((int)gpio_spare[i])).c_str(),
-                                               GPIO_PIN_MODE_FLASHLIGHT_SMARTLED, GPIO_INTR_DISABLE, 200, 5000, false, false, "",
+                                               GPIO_PIN_MODE_FLASHLIGHT_SMARTLED, GPIO_INTR_DISABLE, 200, 5000, false, false, false, "",
                                                GPIO_FLASHLIGHT_DEFAULT_SMARTLED_TYPE, GPIO_FLASHLIGHT_DEFAULT_SMARTLED_QUANTITY,
                                                Rgb{255, 255, 255}, 100);
                 (*gpioMap)[(gpio_num_t)gpio_spare[i]] = gpioPin;
@@ -799,7 +797,7 @@ esp_err_t GpioHandler::handleHttpRequest(httpd_req_t *req)
 }
 
 
-void GpioHandler::registerGpioUri()
+void GpioHandler::registerGpioUri(httpd_handle_t server)
 {
     ESP_LOGI(TAG, "Registering URI handlers");
 
@@ -809,16 +807,16 @@ void GpioHandler::registerGpioUri()
     camuri.uri = "/gpio";
     camuri.handler = HTTP_AUTH_BASIC(callHandleHttpRequest);
     camuri.user_ctx = (void *)this;
-    httpd_register_uri_handler(httpServer, &camuri);
+    httpd_register_uri_handler(server, &camuri);
 }
 
 
 // GPIO handler interface
 // ***********************************
-void createGpioHandler(httpd_handle_t _server)
+void createGpioHandler(void)
 {
     if (gpioHandler == NULL) {
-        gpioHandler = new GpioHandler(_server);
+        gpioHandler = new GpioHandler();
     }
 }
 

--- a/code/components/gpio_ctrl/gpioControl.h
+++ b/code/components/gpio_ctrl/gpioControl.h
@@ -7,6 +7,7 @@
 #include <hal/gpio_types.h>
 #include <esp_http_server.h>
 #include <map>
+#include <esp_rom_gpio.h>
 #include <driver/gpio.h>
 #include <driver/ledc.h>
 
@@ -47,7 +48,7 @@ class GpioHandler
 #endif // ENABLE_MQTT
 
   public:
-    GpioHandler(httpd_handle_t _httpServer);
+    GpioHandler();
     ~GpioHandler();
     bool init();
     void deinit();
@@ -60,13 +61,13 @@ class GpioHandler
 
     gpio_pin_mode_t resolvePinMode(std::string input);
 
-    void registerGpioUri();
+    void registerGpioUri(httpd_handle_t server);
     esp_err_t handleHttpRequest(httpd_req_t *req);
 };
 
 esp_err_t callHandleHttpRequest(httpd_req_t *req);
 
-void createGpioHandler(httpd_handle_t server);
+void createGpioHandler();
 bool gpio_handler_init();
 void gpio_handler_deinit();
 void gpio_handler_destroy();

--- a/code/components/mainprocess_ctrl/MainFlowControl.cpp
+++ b/code/components/mainprocess_ctrl/MainFlowControl.cpp
@@ -48,28 +48,30 @@ bool doInit(void)
 {
     bool bRetVal = true;
 
-    // Deinit GPIO handler
-    gpio_handler_deinit();
-
     // Deinit main flow components before init all ressources again
     // ********************************************
     flowctrl.deinitFlow();
+
     // heap_caps_dump(MALLOC_CAP_INTERNAL);
     // heap_caps_dump(MALLOC_CAP_SPIRAM);
 
-    // Init cam if init not yet done.
-    // Make sure this is called between deinit and init of flow components (avoid SPIRAM fragmentation)
+    // Init GPIO handler
+    // Note: GPIO has to be initialized before MQTT (topic subscription)
+    // ********************************************
+    gpio_handler_deinit();
+    if (!gpio_handler_init()) {
+        bRetVal = false;
+    }
+
+    // Init camera
+    // Note: Make sure this is called between deinit and init
+    // of flow components (avoid SPIRAM fragmentation)
     // ********************************************
     if (!cameraCtrl.getCameraInitSuccessful()) {
-        cameraCtrl.powerResetCamera();
-        esp_err_t camStatus = cameraCtrl.initCam();
-
-        if (camStatus != ESP_OK) { // Camera init failed
+        cameraCtrl.powerCycle();
+        if (cameraCtrl.initCam() != ESP_OK) { // Camera init failed
             return false;
         }
-
-        LogFile.writeToFile(ESP_LOG_INFO, TAG, "Init camera successful");
-        cameraCtrl.printCamInfo();
     }
 
     // Init main flow components
@@ -77,14 +79,6 @@ bool doInit(void)
     if (!flowctrl.initFlow()) {
         flowctrl.deinitFlow();
         return false;
-    }
-
-    // Init GPIO handler
-    // Note: It has to be initialized before MQTT (topic subscription)
-    // and after flow init (MQTT main topic parameter)
-    // ********************************************
-    if (!gpio_handler_init()) {
-        bRetVal = false;
     }
 
     // Init MQTT service

--- a/code/main/main.cpp
+++ b/code/main/main.cpp
@@ -86,6 +86,12 @@ extern "C" void app_main(void)
         return; // Stop here, SD card is needed for proper operation
     }
 
+    // Init SOC temperature sensor (if supported by hardware)
+    // ********************************************
+#ifdef SOC_TEMP_SENSOR_SUPPORTED
+    initSOCTemperatureSensor();
+#endif // SOC_TEMP_SENSOR_SUPPORTED
+
     // SD card: Create log directories (if not already existing)
     // ********************************************
     LogFile.createLogDirectories(); // mandatory for logging + image saving
@@ -254,8 +260,7 @@ extern "C" void app_main(void)
                 setSystemStatusFlag(SYSTEM_STATUS_HEAP_TOO_SMALL);
                 setStatusLed(PSRAM_INIT, 3, true);
             }
-            else { // HEAP size OK --> continue to camera init
-                // Set SPIRAM memory category
+            else { // HEAP size OK --> Set SPIRAM memory category
                 size_t SPIRAMFree = getESPHeapSizeSPIRAMFree();
                 if (SPIRAMFree >= 32000000) {
                     setSPIRAMCategory(SPIRAMCategory_32MB);
@@ -269,36 +274,29 @@ extern "C" void app_main(void)
                 else {
                     setSPIRAMCategory(SPIRAMCategory_4MB);
                 }
-
-                // Init camera
-                // ********************************************
-                esp_err_t camStatus = cameraCtrl.initCam();
-                cameraCtrl.setFlashlight(false);
-
-                // Check camera init
-                // ********************************************
-                if (camStatus != ESP_OK) { // Camera init failed, try to reinit during flow init (MainFlowControl.cpp -> doInit())
-                    setStatusLed(CAM_INIT, 1, false);
-                }
-                else { // ESP_OK -> Camera init OK
-                    LogFile.writeToFile(ESP_LOG_INFO, TAG, "Init camera successful");
-                    cameraCtrl.printCamInfo();
-                }
             }
         }
     }
 
-    // Init SOC temperature sensor (if supported by hardware)
+    // Create GPIO handler
+    // Note: GPIO handler interface has to be created before flashlight init
     // ********************************************
-#ifdef SOC_TEMP_SENSOR_SUPPORTED
-    initSOCTemperatureSensor();
-#endif // SOC_TEMP_SENSOR_SUPPORTED
+    createGpioHandler();
 
-    // Print Device info
+    // Init camera + flashlight
+    // Note: Basic flashlight init has to be performed before camera init
+    // ********************************************
+    cameraCtrl.initFlashlight();
+
+    if (cameraCtrl.initCam() != ESP_OK) { // Camera init failed, try to reinit during flow init (MainFlowControl.cpp -> doInit())
+        setStatusLed(CAM_INIT, 1, false);
+    }
+
+    // Show device info
     // ********************************************
     printDeviceInfo();
 
-    // Print SD-Card info
+    // Show SD card info
     // ********************************************
     LogFile.writeToFile(ESP_LOG_INFO, TAG,
                         "SD card info: Name: " + getSDCardName() + ", Capacity: " + std::to_string(getSDCardCapacity()) +
@@ -307,7 +305,6 @@ extern "C" void app_main(void)
 
     // Start webserver + register URI handler
     // ********************************************
-    ESP_LOGD(TAG, "starting servers");
     server = startWebserver();
     registerConfigFileUri(server);
     registerWlanUri(server);
@@ -319,7 +316,7 @@ extern "C" void app_main(void)
     registerMqttUri(server);
 #endif // ENABLE_MQTT
     registerOpenmetricsUri(server);
-    createGpioHandler(server);
+    gpio_handler_get()->registerGpioUri(server);
     registerWebserverUri(server, "/sdcard");
 
     // Check basic device init status
@@ -329,8 +326,8 @@ extern "C" void app_main(void)
         createMainFlowTask(); // Create main task
     }
     // Critical error(s) occured which do not allow to continue with regular boot sequence.
-    // Provding only a reduced web interface for diagnostic purpose. Reduced web interface and interlock: server_main.cpp ->
-    // hello_main_handler()
+    // Provding only a reduced web interface for diagnostic purpose. Reduced web interface and interlock: webserver.cpp ->
+    // handler_main()
     else {
         LogFile.writeToFile(ESP_LOG_ERROR, TAG, "Basic device initialization failed");
     }


### PR DESCRIPTION
Reduce probability of tinted images after power on (especially with OV2640 camera) by discarding the first 10 images after camera initialization. It solves the issue not fully (depends on environment condition / lighting), but it might make it a little better at least.

Some references:
https://github.com/espressif/esp32-camera/issues/314
https://github.com/espressif/esp32-camera/issues/383

---
### Usage stats:

Before (based on ESP32):
RAM:   [=         ]  14.4% (used 47116 bytes from 327680 bytes)
Flash: [========= ]  88.1% (used 1713293 bytes from 1945600 bytes)

After
RAM:   [=         ]  14.4% (used 47116 bytes from 327680 bytes)
Flash: [========= ]  88.1% (used 1713525 bytes from 1945600 bytes)