### PR TITLE
fix(camera): Prevent against concurrent access to camera ressource

### DIFF
--- a/code/components/camera_ctrl/ClassControlCamera.cpp
+++ b/code/components/camera_ctrl/ClassControlCamera.cpp
@@ -73,6 +73,7 @@ static camera_config_t cameraConfig = {
 
 ClassControlCamera::ClassControlCamera()
 {
+    camMutex = xSemaphoreCreateMutex();
     outputFrameSizeWidth = CAMERA_OUTPUT_WINDOW_SIZE_WIDTH;
     outputFrameSizeHeight = CAMERA_OUTPUT_WINDOW_SIZE_HEIGHT;
 
@@ -151,18 +152,22 @@ void ClassControlCamera::skipFrames(uint8_t n)
 {
     LogFile.writeToFile(ESP_LOG_INFO, TAG, "Skip camera frames");
 
-    setStatusLed(true);
-    setFlashlight(true);
+    if (xSemaphoreTake(camMutex, portMAX_DELAY) == pdTRUE) {
+        setStatusLed(true);
+        setFlashlight(true);
 
-    camera_fb_t *fb = NULL;
-    for (uint8_t i = 0; i < n; ++i) {
-        vTaskDelay(pdMS_TO_TICKS(100));
-        fb = esp_camera_fb_get();
-        esp_camera_fb_return(fb);
+        camera_fb_t *fb = NULL;
+        for (uint8_t i = 0; i < n; ++i) {
+            vTaskDelay(pdMS_TO_TICKS(100));
+            fb = esp_camera_fb_get();
+            esp_camera_fb_return(fb);
+        }
+
+        setFlashlight(false);
+        setStatusLed(false);
+
+        xSemaphoreGive(camMutex);
     }
-
-    setFlashlight(false);
-    setStatusLed(false);
 }
 
 
@@ -578,7 +583,7 @@ camera_model_t ClassControlCamera::getCamModel(void)
 {
     sensor_t *s = esp_camera_sensor_get();
     if (s == NULL) {
-        LogFile.writeToFile(ESP_LOG_ERROR, TAG, "getCamType: Failed to get control structure");
+        LogFile.writeToFile(ESP_LOG_ERROR, TAG, "getCamModel: Failed to get control structure");
         return CAMERA_NONE;
     }
     camera_sensor_info_t *info = esp_camera_sensor_get_info(&s->id);
@@ -647,19 +652,28 @@ esp_err_t ClassControlCamera::captureToBasisImage(CImageBasis *_Image)
         return ESP_FAIL;
     }
 
-    if (paramFlashlightInternal.flashTime > 0) { // Switch on for defined time if a flashTime is set
-        setStatusLed(true);
-        setFlashlight(true);
-        vTaskDelay(paramFlashlightInternal.flashTime / portTICK_PERIOD_MS);
+    camera_fb_t *fb = NULL;
+    if (xSemaphoreTake(camMutex, portMAX_DELAY) == pdTRUE) {
+        if (paramFlashlightInternal.flashTime > 0) { // Switch on for defined time if a flashTime is set
+            setStatusLed(true);
+            setFlashlight(true);
+            vTaskDelay(pdMS_TO_TICKS(paramFlashlightInternal.flashTime));
+        }
+
+        fb = esp_camera_fb_get();
+        esp_camera_fb_return(fb);
+        fb = esp_camera_fb_get();
+
+        if (paramFlashlightInternal.flashTime > 0) { // Switch off if flashlight was on
+            setStatusLed(false);
+            setFlashlight(false);
+        }
+
+        xSemaphoreGive(camMutex);
     }
-
-    camera_fb_t *fb = esp_camera_fb_get();
-    esp_camera_fb_return(fb);
-    fb = esp_camera_fb_get();
-
-    if (paramFlashlightInternal.flashTime > 0) { // Switch off if flashlight was on
-        setStatusLed(false);
-        setFlashlight(false);
+    else {
+        LogFile.writeToFile(ESP_LOG_ERROR, TAG, "captureToBasisImage: Failed to get camera mutex");
+        return ESP_FAIL;
     }
 
     if (fb == NULL) {
@@ -698,7 +712,8 @@ esp_err_t ClassControlCamera::captureToBasisImage(CImageBasis *_Image)
 }
 
 
-esp_err_t ClassControlCamera::captureToFile(std::string _nm)
+esp_err_t ClassControlCamera::captureToFile(std::string _nm, CfgData::SectionTakeImage::Camera *paramCameraTemp,
+                                            CfgData::SectionTakeImage::Flashlight *paramFlashlightTemp)
 {
     if (!cameraInitSuccessful) {
         return ESP_FAIL;
@@ -707,19 +722,44 @@ esp_err_t ClassControlCamera::captureToFile(std::string _nm)
     esp_err_t retVal = ESP_OK;
     std::string ftype;
 
-    if (paramFlashlightInternal.flashTime > 0) { // Switch on for defined time if a flashTime is set
-        setStatusLed(true);
-        setFlashlight(true);
-        vTaskDelay(paramFlashlightInternal.flashTime / portTICK_PERIOD_MS);
+    camera_fb_t *fb = NULL;
+    if (xSemaphoreTake(camMutex, portMAX_DELAY) == pdTRUE) {
+        // Load temporary config
+        if (paramCameraTemp != NULL) {
+            setCameraParameter(paramCameraTemp);
+        }
+        if (paramFlashlightTemp != NULL) {
+            setFlashlightParameter(paramFlashlightTemp);
+        }
+
+        if (paramFlashlightInternal.flashTime > 0) { // Switch on for defined time if a flashTime is set
+            setStatusLed(true);
+            setFlashlight(true);
+            vTaskDelay(pdMS_TO_TICKS(paramFlashlightInternal.flashTime));
+        }
+
+        fb = esp_camera_fb_get();
+        esp_camera_fb_return(fb);
+        fb = esp_camera_fb_get();
+
+        if (paramFlashlightInternal.flashTime > 0) { // Switch off if flashlight was on
+            setStatusLed(false);
+            setFlashlight(false);
+        }
+
+        // Restore persistent config
+        if (paramCameraTemp != NULL) {
+            setCameraParameter(&ConfigClass::getInstance()->get()->sectionTakeImage.camera);
+        }
+        if (paramFlashlightTemp != NULL) {
+            setFlashlightParameter(&ConfigClass::getInstance()->get()->sectionTakeImage.flashlight);
+        }
+
+        xSemaphoreGive(camMutex);
     }
-
-    camera_fb_t *fb = esp_camera_fb_get();
-    esp_camera_fb_return(fb);
-    fb = esp_camera_fb_get();
-
-    if (paramFlashlightInternal.flashTime > 0) { // Switch off if flashlight was on
-        setStatusLed(false);
-        setFlashlight(false);
+    else {
+        LogFile.writeToFile(ESP_LOG_ERROR, TAG, "captureToFile: Failed to get camera mutex");
+        return ESP_FAIL;
     }
 
     if (fb == NULL) {
@@ -807,7 +847,8 @@ static size_t jpg_encode_stream(void *arg, size_t index, const void *data, size_
 }
 
 
-esp_err_t ClassControlCamera::captureToHTTP(httpd_req_t *_req)
+esp_err_t ClassControlCamera::captureToHTTP(httpd_req_t *_req, CfgData::SectionTakeImage::Camera *paramCameraTemp,
+                                            CfgData::SectionTakeImage::Flashlight *paramFlashlightTemp)
 {
     if (!cameraInitSuccessful) {
         return ESP_FAIL;
@@ -817,23 +858,48 @@ esp_err_t ClassControlCamera::captureToHTTP(httpd_req_t *_req)
     size_t fb_len = 0;
     int64_t fr_start = esp_timer_get_time();
 
-    if (paramFlashlightInternal.flashTime > 0) {
-        setStatusLed(true);
-        setFlashlight(true);
-        vTaskDelay(paramFlashlightInternal.flashTime / portTICK_PERIOD_MS);
+    camera_fb_t *fb = NULL;
+    if (xSemaphoreTake(camMutex, portMAX_DELAY) == pdTRUE) {
+        // Load temporary config
+        if (paramCameraTemp != NULL) {
+            setCameraParameter(paramCameraTemp);
+        }
+        if (paramFlashlightTemp != NULL) {
+            setFlashlightParameter(paramFlashlightTemp);
+        }
+
+        if (paramFlashlightInternal.flashTime > 0) {
+            setStatusLed(true);
+            setFlashlight(true);
+            vTaskDelay(pdMS_TO_TICKS(paramFlashlightInternal.flashTime));
+        }
+
+        fb = esp_camera_fb_get();
+        esp_camera_fb_return(fb);
+        fb = esp_camera_fb_get();
+
+        if (paramFlashlightInternal.flashTime > 0) { // Switch off if flashlight was on
+            setStatusLed(false);
+            setFlashlight(false);
+        }
+
+        // Restore persistent config
+        if (paramCameraTemp != NULL) {
+            setCameraParameter(&ConfigClass::getInstance()->get()->sectionTakeImage.camera);
+        }
+        if (paramFlashlightTemp != NULL) {
+            setFlashlightParameter(&ConfigClass::getInstance()->get()->sectionTakeImage.flashlight);
+        }
+
+        xSemaphoreGive(camMutex);
     }
-
-    camera_fb_t *fb = esp_camera_fb_get();
-    esp_camera_fb_return(fb);
-    fb = esp_camera_fb_get();
-
-    if (paramFlashlightInternal.flashTime > 0) { // Switch off if flashlight was on
-        setStatusLed(false);
-        setFlashlight(false);
+    else {
+        LogFile.writeToFile(ESP_LOG_ERROR, TAG, "captureToHTTP: Failed to get camera mutex");
+        return ESP_FAIL;
     }
 
     if (fb == NULL) {
-        LogFile.writeToFile(ESP_LOG_ERROR, TAG, "captureToFile: Failed to get camera framebuffer");
+        LogFile.writeToFile(ESP_LOG_ERROR, TAG, "captureToHTTP: Failed to get camera framebuffer");
         httpd_resp_send_500(_req);
         return ESP_FAIL;
     }
@@ -880,39 +946,53 @@ esp_err_t ClassControlCamera::captureToStream(httpd_req_t *_req, bool _flashligh
     }
 
     esp_err_t res = ESP_OK;
-    size_t fb_len = 0;
-    int64_t fr_start;
+    size_t fbLen = 0;
+    size_t hlen = 0;
+    int64_t frStart = 0;
+    int64_t frEnd = 0;
+    int64_t frDeltaMs = 0;
+    camera_fb_t *fb = NULL;
     char *part_buf[64];
 
     LogFile.writeToFile(ESP_LOG_INFO, TAG, "Live stream started");
-
-    if (_flashlightOn) {
-        setStatusLed(true);
-        setFlashlight(true);
-    }
-
-    // httpd_resp_set_hdr(_req, "Access-Control-Allow-Origin", "*");  //stream is blocking web interface, only serving to local
 
     httpd_resp_set_type(_req, _STREAM_CONTENT_TYPE);
     httpd_resp_send_chunk(_req, _STREAM_BOUNDARY, strlen(_STREAM_BOUNDARY));
 
     while (1) {
-        fr_start = esp_timer_get_time();
-        camera_fb_t *fb = esp_camera_fb_get();
-        esp_camera_fb_return(fb);
-        fb = esp_camera_fb_get();
-        if (fb == NULL) {
-            LogFile.writeToFile(ESP_LOG_ERROR, TAG, "captureToStream: Failed to get camera framebuffer");
+        frStart = esp_timer_get_time();
+
+        if (xSemaphoreTake(camMutex, portMAX_DELAY) == pdTRUE) {
+            if (_flashlightOn) {
+                setStatusLed(true);
+                setFlashlight(true);
+            }
+
+            fb = esp_camera_fb_get();
+            esp_camera_fb_return(fb);
+            fb = esp_camera_fb_get();
+
+            xSemaphoreGive(camMutex);
+        }
+        else {
+            LogFile.writeToFile(ESP_LOG_ERROR, TAG, "captureToStream: Failed to get camera mutex");
+            res = ESP_FAIL;
             break;
         }
-        fb_len = fb->len;
+
+        if (fb == NULL) {
+            LogFile.writeToFile(ESP_LOG_ERROR, TAG, "captureToStream: Failed to get camera framebuffer");
+            res = ESP_FAIL;
+            break;
+        }
+        fbLen = fb->len;
 
         if (res == ESP_OK) {
-            size_t hlen = snprintf((char *)part_buf, sizeof(part_buf), _STREAM_PART, fb_len);
+            hlen = snprintf((char *)part_buf, sizeof(part_buf), _STREAM_PART, fbLen);
             res = httpd_resp_send_chunk(_req, (const char *)part_buf, hlen);
         }
         if (res == ESP_OK) {
-            res = httpd_resp_send_chunk(_req, (const char *)fb->buf, fb_len);
+            res = httpd_resp_send_chunk(_req, (const char *)fb->buf, fbLen);
         }
         if (res == ESP_OK) {
             res = httpd_resp_send_chunk(_req, _STREAM_BOUNDARY, strlen(_STREAM_BOUNDARY));
@@ -920,16 +1000,16 @@ esp_err_t ClassControlCamera::captureToStream(httpd_req_t *_req, bool _flashligh
 
         esp_camera_fb_return(fb);
 
-        int64_t fr_end = esp_timer_get_time();
-        ESP_LOGD(TAG, "JPG: %dKB %dms", (int)(fb_len / 1024), (int)((fr_end - fr_start) / 1000));
+        frEnd = esp_timer_get_time();
+        ESP_LOGD(TAG, "JPG: %dKB %dms", (int)(fbLen / 1024), (int)((frEnd - frStart) / 1000));
 
         if (res != ESP_OK) { // Exit loop, e.g. also when closing the webpage
             break;
         }
 
-        int64_t fr_delta_ms = (fr_end - fr_start) / 1000;
-        if (CAM_LIVESTREAM_REFRESHRATE > fr_delta_ms) {
-            const TickType_t xDelay = (CAM_LIVESTREAM_REFRESHRATE - fr_delta_ms) / portTICK_PERIOD_MS;
+        frDeltaMs = (frEnd - frStart) / 1000;
+        if (CAM_LIVESTREAM_REFRESHRATE > frDeltaMs) {
+            const TickType_t xDelay = pdMS_TO_TICKS(CAM_LIVESTREAM_REFRESHRATE - frDeltaMs);
             ESP_LOGD(TAG, "Stream: sleep for: %ldms", (long)xDelay * 10);
             vTaskDelay(xDelay);
         }

--- a/code/components/camera_ctrl/ClassControlCamera.h
+++ b/code/components/camera_ctrl/ClassControlCamera.h
@@ -4,6 +4,8 @@
 #include <string>
 #include <vector>
 
+#include <freertos/FreeRTOS.h>
+
 #include <esp_http_server.h>
 #include <esp_camera.h>
 
@@ -20,6 +22,7 @@ typedef struct {
 class ClassControlCamera
 {
   protected:
+    SemaphoreHandle_t camMutex;
     CfgData::SectionTakeImage::Camera paramCameraInternal;
     CfgData::SectionTakeImage::Flashlight paramFlashlightInternal;
     bool cameraInitSuccessful;
@@ -62,8 +65,10 @@ class ClassControlCamera
     void getOutputFrameSize(int &width, int &height);
 
     esp_err_t captureToBasisImage(CImageBasis *_Image);
-    esp_err_t captureToFile(std::string _nm);
-    esp_err_t captureToHTTP(httpd_req_t *_req);
+    esp_err_t captureToFile(std::string _nm, CfgData::SectionTakeImage::Camera *paramCameraTemp = NULL,
+                            CfgData::SectionTakeImage::Flashlight *paramFlashlightTemp = NULL);
+    esp_err_t captureToHTTP(httpd_req_t *_req, CfgData::SectionTakeImage::Camera *paramCameraTemp = NULL,
+                            CfgData::SectionTakeImage::Flashlight *paramFlashlightTemp = NULL);
     esp_err_t captureToStream(httpd_req_t *_req, bool _flashlightOn);
 
     void initFlashlight(void);

--- a/code/components/camera_ctrl/server_camera.cpp
+++ b/code/components/camera_ctrl/server_camera.cpp
@@ -16,39 +16,32 @@ static const char *TAG = "SERVER_CAM";
 
 esp_err_t handler_camera(httpd_req_t *req)
 {
-    const char *APIName = "camera:v2"; // API name and version
+    const char *APIName = "camera:v3"; // API name and version
     char _query[384];
     char _valuechar[30], _flashtime[30], _filename[100];
     std::string task;
+    bool saveToFile = false;
     std::string fn = "/sdcard/";
     int flashtime = 0;
 
     // Default usage message when handler gets called without any parameter
     const std::string RESTUsageInfo =
         "Handler usage:<br>"
-        "1. Set camera parameter:<br>"
-        "-  '/camera?task=set_parameter&flashtime=0.1&flashintensity=1&brightness=-2&contrast=0& "
-        "saturation=0&sharpness=1&exposurecontrolmode=0&autoexposurelevel=0&manualexposurevalue=1200& "
-        "gaincontrolmode=0&manualgainvalue=2&specialeffect=0&mirror=false&flip=false&zoomfactor=1000&zoomx=0&zoomy=0'<br>"
-        "2. Capture image<br>"
-        "  - '/camera?task=capture' : Capture without flashlight<br>"
-        "  - '/camera?task=capture_with_flashlight&flashtime=1000' : Capture with flashlight (flashtime in ms)<br>"
-        "  - '/camera?task=capture_to_file&flashtime=1000&filename=/img_tmp/filename.jpg' : \
-            Capture image with flashlight (flashtime in ms) and save '/img_tmp/filename.jpg' onto SD-card<br>"
-        "3. Control Flashlight<br>"
-        "  - '/camera?task=flashlight_on' : Flashlight on<br>"
-        "  - '/camera?task=flashlight_off' : Flashlight off<br>"
-        "4. '/camera?task=api_name' : Print API name and version<br>";
+        "1. Capture (single shot) image with temporary camera parameter set (partial or full parameter set supported):<br>"
+        "(Adding 'filename' parameter save image to SD card with given filename instead of response image)<br>"
+        "- '/camera?task=capture&flashtime=2000&flashintensity=50&brightness=0&contrast=0&"
+        "saturation=0&sharpness=1&exposurecontrolmode=1&autoexposurelevel=0&manualexposurevalue=300&"
+        "gaincontrolmode=1&manualgainvalue=0&specialeffect=0&mirror=false&flip=false&zoomfactor=1000&"
+        "zoomx=0&zoomy=0&filename=/img_tmp/filename.jpg'<br>"
+        "2. Control flashlight:<br>"
+        "- '/camera?task=flashlight_on' : Flashlight on<br>"
+        "- '/camera?task=flashlight_off' : Flashlight off<br>"
+        "3. Print API name and version:<br>"
+        "- '/camera?task=api_name'";
 
     if (httpd_req_get_url_query_str(req, _query, sizeof(_query)) == ESP_OK) {
         if (httpd_query_key_value(_query, "task", _valuechar, sizeof(_valuechar)) == ESP_OK) {
             task = std::string(_valuechar);
-        }
-        if (httpd_query_key_value(_query, "flashtime", _flashtime, sizeof(_flashtime)) == ESP_OK) {
-            flashtime = std::max(0, atoi(_flashtime));
-        }
-        if (httpd_query_key_value(_query, "filename", _filename, sizeof(_filename)) == ESP_OK) {
-            fn.append(_filename);
         }
     }
     else { // if no parameter is provided, print handler usage
@@ -61,7 +54,7 @@ esp_err_t handler_camera(httpd_req_t *req)
         httpd_resp_sendstr(req, APIName);
         return ESP_OK;
     }
-    else if (task.compare("set_parameter") == 0) {
+    else if (task.compare("capture") == 0) {
         if (!cameraCtrl.getCameraInitSuccessful()) {
             httpd_resp_send_err(req, HTTPD_403_FORBIDDEN, "Camera not initialized");
             return ESP_ERR_NOT_FOUND;
@@ -124,94 +117,51 @@ esp_err_t handler_camera(httpd_req_t *req)
         if (httpd_query_key_value(_query, "zoomy", _valuechar, sizeof(_valuechar)) == ESP_OK) {
             paramCamera.zoomOffsetY = stoi(std::string(_valuechar));
         }
+        if (httpd_query_key_value(_query, "filename", _filename, sizeof(_filename)) == ESP_OK) {
+            fn.append(_filename);
+            saveToFile = true;
+        }
 
-        cameraCtrl.setCameraParameter(&paramCamera);
-        cameraCtrl.setFlashlightParameter(&paramFlashlight);
-
-        httpd_resp_sendstr(req, "001: Camera parameter set");
-        return ESP_OK;
-    }
-    else if (task.compare("capture") == 0) {
-        int save_flashTime = cameraCtrl.getFlashTime();
-        cameraCtrl.setFlashTime(0);
-        esp_err_t result = cameraCtrl.captureToHTTP(req);
-        cameraCtrl.setFlashTime(save_flashTime);
-
-        if (result == ESP_OK) {
-            httpd_resp_sendstr(req, "002: Capture without flashlight successful");
+        // Capture image (single shot) with modified config
+        esp_err_t retVal = ESP_FAIL;
+        if (!saveToFile) {
+            retVal = cameraCtrl.captureToHTTP(req, &paramCamera, &paramFlashlight);
         }
         else {
-            httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "E91: Camera capture error");
-        }
-        return result;
-    }
-    else if (task.compare("capture_with_flashlight") == 0) {
-        if (flashtime == 0) {
-            httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST,
-                                "E93: No flashtime provided, e.g. '/capture?task=capture_with_flashlight&flashtime=1000'");
-            return ESP_FAIL;
+            retVal = cameraCtrl.captureToFile(fn, &paramCamera, &paramFlashlight);
+            if (retVal == ESP_OK) {
+                httpd_resp_sendstr(req, "001: Capture to file successful");
+            }
         }
 
-        int save_flashTime = cameraCtrl.getFlashTime();
-        cameraCtrl.setFlashTime(flashtime);
-        esp_err_t result = cameraCtrl.captureToHTTP(req);
-        cameraCtrl.setFlashTime(save_flashTime);
-
-        if (result == ESP_OK) {
-            httpd_resp_sendstr(req, "003: Capture with flashlight successful");
-        }
-        else {
-            httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "E91: Camera capture error");
-        }
-
-        return result;
-    }
-    else if (task.compare("capture_to_file") == 0) {
-        if (flashtime == 0) {
-            httpd_resp_send_err(
-                req, HTTPD_400_BAD_REQUEST,
-                "E93: No flashtime provided, e.g. '/capture?task=capture_to_file&flashtime=1000&filename=/img_tmp/test.jpg'");
-            return ESP_FAIL;
-        }
-
-        if (fn.compare("/sdcard/") == 0) {
-            httpd_resp_send_err(
-                req, HTTPD_400_BAD_REQUEST,
-                "E94: No destination provided, e.g. '/capture?task=capture_to_file&flashtime=1000&filename=/img_tmp/test.jpg'");
-            return ESP_FAIL;
-        }
-
-        int save_flashTime = cameraCtrl.getFlashTime();
-        cameraCtrl.setFlashTime(flashtime);
-        esp_err_t result = cameraCtrl.captureToFile(fn);
-        cameraCtrl.setFlashTime(save_flashTime);
-
-        if (result == ESP_OK) {
-            httpd_resp_sendstr(req, "004: Capture to file successful");
-        }
-        else {
-            httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "E91: Camera capture error");
-        }
-        return result;
+        return retVal;
     }
     else if (task.compare("flashlight_on") == 0) {
         cameraCtrl.setFlashlight(true);
-        httpd_resp_sendstr(req, "005: Flashlight on");
+        httpd_resp_sendstr(req, "002: Flashlight on");
         return ESP_OK;
     }
     else if (task.compare("flashlight_off") == 0) {
         cameraCtrl.setFlashlight(false);
-        httpd_resp_sendstr(req, "006: Flashlight off");
+        httpd_resp_sendstr(req, "003: Flashlight off");
         return ESP_OK;
     }
     else if (task.compare("stream") == 0) {
+        if (!cameraCtrl.getCameraInitSuccessful()) {
+            httpd_resp_send_err(req, HTTPD_403_FORBIDDEN, "Camera not initialized");
+            return ESP_ERR_NOT_FOUND;
+        }
         cameraCtrl.captureToStream(req, false);
-        httpd_resp_sendstr(req, "007: Camera livestream");
+        httpd_resp_sendstr(req, "004: Camera livestream");
         return ESP_OK;
     }
     else if (task.compare("stream_flashlight") == 0) {
+        if (!cameraCtrl.getCameraInitSuccessful()) {
+            httpd_resp_send_err(req, HTTPD_403_FORBIDDEN, "Camera not initialized");
+            return ESP_ERR_NOT_FOUND;
+        }
         cameraCtrl.captureToStream(req, true);
-        httpd_resp_sendstr(req, "008: Camera livestream with flashlight");
+        httpd_resp_sendstr(req, "005: Camera livestream with flashlight");
         return ESP_OK;
     }
     else {

--- a/code/components/camera_ctrl/server_camera.cpp
+++ b/code/components/camera_ctrl/server_camera.cpp
@@ -128,14 +128,14 @@ esp_err_t handler_camera(httpd_req_t *req)
 
         // Capture image (single shot) with modified config
         esp_err_t retVal = ESP_FAIL;
-        if (!saveToFile) {
-            retVal = cameraCtrl.captureToHTTP(req, &paramCamera, &paramFlashlight);
-        }
-        else {
+        if (saveToFile) {
             retVal = cameraCtrl.captureToFile(fn, &paramCamera, &paramFlashlight);
             if (retVal == ESP_OK) {
                 httpd_resp_sendstr(req, "001: Capture to file successful");
             }
+        }
+        else {
+            retVal = cameraCtrl.captureToHTTP(req, &paramCamera, &paramFlashlight);
         }
 
         return retVal;

--- a/code/components/camera_ctrl/server_camera.cpp
+++ b/code/components/camera_ctrl/server_camera.cpp
@@ -28,16 +28,20 @@ esp_err_t handler_camera(httpd_req_t *req)
     const std::string RESTUsageInfo =
         "Handler usage:<br>"
         "1. Capture (single shot) image with temporary camera parameter set (partial or full parameter set supported):<br>"
-        "(Adding 'filename' parameter save image to SD card with given filename instead of response image)<br>"
-        "- '/camera?task=capture&flashtime=2000&flashintensity=50&brightness=0&contrast=0&"
-        "saturation=0&sharpness=1&exposurecontrolmode=1&autoexposurelevel=0&manualexposurevalue=300&"
+        "- /camera?task=capture&flashtime=2000&flashintensity=50&brightness=0&contrast=0&"
+        "saturation=0&sharpness=0&exposurecontrolmode=1&autoexposurelevel=0&manualexposurevalue=300&"
         "gaincontrolmode=1&manualgainvalue=0&specialeffect=0&mirror=false&flip=false&zoomfactor=1000&"
-        "zoomx=0&zoomy=0&filename=/img_tmp/filename.jpg'<br>"
-        "2. Control flashlight:<br>"
-        "- '/camera?task=flashlight_on' : Flashlight on<br>"
-        "- '/camera?task=flashlight_off' : Flashlight off<br>"
-        "3. Print API name and version:<br>"
-        "- '/camera?task=api_name'";
+        "zoomx=0&zoomy=0<br>"
+        "2. Adding 'filename' parameter save image to SD card with given filename instead of response image:<br>"
+        "- /camera?task=capture&flashtime=2000&flashintensity=50&brightness=0&contrast=0&"
+        "saturation=0&sharpness=0&exposurecontrolmode=1&autoexposurelevel=0&manualexposurevalue=300&"
+        "gaincontrolmode=1&manualgainvalue=0&specialeffect=0&mirror=false&flip=false&zoomfactor=1000&"
+        "zoomx=0&zoomy=0&filename=/img_tmp/filename.jpg<br>"
+        "3. Control flashlight:<br>"
+        "- /camera?task=flashlight_on : Flashlight on<br>"
+        "- /camera?task=flashlight_off : Flashlight off<br>"
+        "4. Print API name and version:<br>"
+        "- /camera?task=api_name";
 
     if (httpd_req_get_url_query_str(req, _query, sizeof(_query)) == ESP_OK) {
         if (httpd_query_key_value(_query, "task", _valuechar, sizeof(_valuechar)) == ESP_OK) {

--- a/docs/API/REST/camera.md
+++ b/docs/API/REST/camera.md
@@ -15,7 +15,7 @@ Payload:
       - Response:
         - Content type: `HTML`
         - Content: `camera:vx`
-    - `set_parameter` Set camera parameter
+    - `capture` Capture image (single shot) with given parameter set and response either to REST API or save to SD card
       - Full or delta parameter update is possible
       - Possible parameter:
         - `flashtime` Flash Time [100 .. &infin; milliseconds]
@@ -35,53 +35,36 @@ Payload:
         - `zoomfactor` Zoom Factor [1000 .. 4000] (1000: 1.0x, 4000: 4.0x | Max. zoom factor is depending on hardware capabilities)
         - `zoomx` Zoom Offset X [0 .. max. 960] (Max. Offset is limited in firmware depending on actual zoom factor | Lower zoom --> lower limits)
         - `zommy` Zoom Offset Y [0 .. max. 720] (Max. Offset is limited in firmware depending on actual zoom factor | Lower zoom --> lower limits)
-      - Example: `/camera?task=set_parameter&flashtime=0.1&flashintensity=1&brightness=-2&contrast=0&saturation=0 &sharpness=0&exposurecontrolmode=1&autoexposurelevel=0&manualexposurevalue=300&gaincontrolmode=1 &manualgainvalue=0&specialeffect=0&mirror=false&flip=false&zoomfactor=1000&zoomx=0&zoomy=0`
+        - `filename` Filename incl. path on SD card (e.g. `/foldername/filename.jpg`)
+      - Example 1 (Reponse image via REST API): `/camera?task=capture&flashtime=2000&flashintensity=50&brightness=0&contrast=0&saturation=0&sharpness=1&exposurecontrolmode=1&autoexposurelevel=0&manualexposurevalue=300&gaincontrolmode=1&manualgainvalue=0&specialeffect=0&mirror=false&flip=false&zoomfactor=1000&zoomx=0&zoomy=0`
+      - Response:
+        - Content type: `JPEG`
+        - Content: Image (JPG file)
+      - Example 2 (Save image to SD card): `/camera?task=capture&flashtime=2000&flashintensity=50&brightness=0&contrast=0&saturation=0&sharpness=1&exposurecontrolmode=1&autoexposurelevel=0&manualexposurevalue=300&gaincontrolmode=1&manualgainvalue=0&specialeffect=0&mirror=false&flip=false&zoomfactor=1000&zoomx=0&zoomy=0&filename=/img_tmp/filename.jpg`
       - Response:
         - Content type: `HTML`
-        - Content: `001: Camer parameter set`
-    - `capture` Capture image without flashlight
-      - Example: `/camera?task=capture`
-      - Response:
-        - Content type: `HTML`
-        - Content: Raw image (JPG file)
-    - `capture_with_flashlight` Capture with flashlight
-      - Parameter:
-        - `flashtime` Flashlight time in ms
-      - Example: `/camera?task=capture_with_flashlight&flashtime=1000`
-      - Response:
-        - Content type: `HTML`
-        - Content: Raw image (JPG file)<br>
-          (Response delayed by flash duration)
-    - `capture_to_file` Capture image with flashlight and save onto SD card
-      - Parameter:
-        - `flashtime` Flashlight time in ms
-        - `filename` Filename incl. path on SD card
-      - Example: `/camera?task=capture_to_file&flashtime=1000&filename=/img_tmp/filename.jpg`
-      - Response:
-        - Content type: `HTML`
-        - Content: `/img_tmp/test.jpg`<br>
-          (Response delayed by flash duration)
+        - Content: `001: Capture to file successful`
     - `flashlight_on` Flashlight on
       - Example: `/camera?task=flashlight_on`
       - Response:
         - Content type: `HTML`
-        - Content: `005: Flashlight on`
+        - Content: `002: Flashlight on`
     - `flashlight_off` Flashlight off
       - Example: `/camera?task=flashlight_off`
       - Response:
         - Content type: `HTML`
-        - Content: `006: Flashlight off`
+        - Content: `003: Flashlight off`
     - `stream` Camera livestream without flashlight<br>
       __IMPORTANT__: A running stream is blocking the entire web interface (to limit memory usage for 
                      this function). Please ensure to close stream before continue with WebUI.
       - Example: `/camera?task=stream`
       - Response:
         - Content type: `HTML`
-        - Content: `007: Camera livestream`
+        - Content: `004: Camera livestream`
     - `stream_flashlight` Camera livestream with flashlight<br>
       __IMPORTANT__: A running stream is blocking the entire web interface (to limit memory usage for 
                      this function). Please ensure to close stream before continue with WebUI.
       - Example: `/camera?task=stream_flashlight`
       - Response:
         - Content type: `HTML`
-        - Content: `008: Camera livestream with flashlight`
+        - Content: `005: Camera livestream with flashlight`

--- a/sd-card/html/edit_reference.html
+++ b/sd-card/html/edit_reference.html
@@ -117,7 +117,7 @@
                 <input class="button" type="button" value="Show Actual Reference" onclick="showReference()">
             </td>
             <td>
-                <input class="button" type="button" id="createreference" value="Create New Reference" onclick="loadRawImage(false)">
+                <input class="button" type="button" id="createreference" value="Create New Reference" onclick="loadRawImage()">
             </td>
             <td></td>
         </tr>
@@ -443,7 +443,6 @@
     let context = canvas.getContext('2d');
     let imageObj = new Image();
     let isActReference = false;
-    let initialConfigUrl = "";
 
 
     function setVariableInputLimits()
@@ -489,30 +488,6 @@
 
         $('#takeimage_camera_manualexposurevalue_value').attr({"max" : sensorFrameSizeHeight});
         $('#takeimage_camera_manualexposurevalue_value').trigger('onchange');
-    }
-
-
-    function restoreCamSettings()
-    {
-        let xhttp = new XMLHttpRequest();
-        xhttp.onreadystatechange = function() {
-            if (this.readyState == 4) {
-                if (this.status >= 200 && this.status < 300) {
-                    // Nothing do do
-                }
-                else {
-                    document.getElementById("createreference").disabled = false;
-                    firework.launch("Restore image parameter failed (Response status: " + this.status +
-                                    "). Repeat action or save configuration.", 'danger', 30000);
-                    console.error("Restore image parameter failed. Response status: " + this.status);
-                }
-            }
-        };
-
-        xhttp.timeout = 10000;  // 10 seconds
-        xhttp.open("GET", initialConfigUrl, true);
-        xhttp.withCredentials = true;
-        xhttp.send();
     }
 
 
@@ -562,23 +537,19 @@
         let zoomOffsetY = document.getElementById("takeimage_camera_zoomoffsety_value").value;
         if (zoomOffsetX == "") zoomOffsetX = "0";
 
-        url = getDomainname() + "/camera?task=set_parameter&flashtime=" + flashtime + "&flashintensity=" + flashintensity +
+        url = getDomainname() + "/camera?task=capture&flashtime=" + flashtime + "&flashintensity=" + flashintensity +
                 "&brightness=" + brightness + "&contrast=" + contrast + "&saturation=" + saturation + "&sharpness=" + sharpness +
                 "&exposurecontrolmode=" + exposureControlMode + "&autoexposurelevel=" + autoExposureLevel +
                 "&manualexposurevalue=" + manualExposureValue + "&gaincontrolmode=" + gainControlMode +
                 "&manualgainvalue=" + manualGainValue + "&specialeffect=" + specialeffect + "&mirror=" + mirror + "&flip=" + flip +
                 "&zoomfactor=" + zoomFactor + "&zoomx=" + zoomOffsetX + "&zoomy=" + zoomOffsetY;
 
-        if (initialConfigUrl == "")
-            initialConfigUrl = url;
-
         let xhttp = new XMLHttpRequest();
         xhttp.onreadystatechange = function() {
             if (this.readyState == 4) {
                 if (this.status >= 200 && this.status < 300) {
-                    setTimeout(function() {
-                        loadRawImage(true);
-                    }, 100);
+                    loadCanvas(window.URL.createObjectURL(xhttp.response), true);
+                    isActReference = false;
                 }
                 else if (this.status == 403) {
                     document.getElementById("createreference").disabled = false;
@@ -596,33 +567,26 @@
             }
         };
 
-        xhttp.timeout = 10000;  // 10 seconds
+        xhttp.responseType = 'blob';
+        xhttp.timeout = 30000;  // 30 seconds (time has to be longer than usual flashlight time)
         xhttp.open("GET", url, true);
         xhttp.withCredentials = true;
         xhttp.send();
     }
 
 
-    function loadRawImage(new_image)
+    function loadRawImage()
     {
         document.getElementById("take").disabled = true;
+        document.getElementById("createreference").disabled = true;
+        document.getElementById("savereference").disabled = true;
+        document.getElementById("take").disabled = false;
 
-        if (new_image) {
-            let url = getDomainname() + "/img_tmp/raw.jpg?" + Math.floor((Math.random() * 1000000) + 1);
-            loadCanvas(url, true);
-            isActReference = false;
-        }
-        else {
-            document.getElementById("createreference").disabled = true;
-            document.getElementById("savereference").disabled = true;
-            document.getElementById("take").disabled = false;
+        setClassEnabled("camParameter", true); // Release input for all camera parameter
+        triggerClassElementOnChange("classvisibility_init"); // Init subparameter lock
+        jsonConfigModifiedDelta = {}; // Reset modified parameter container after visibility update
 
-            setClassEnabled("camParameter", true); // Release input for all camera parameter
-            triggerClassElementOnChange("classvisibility_init"); // Init subparameter lock
-            jsonConfigModifiedDelta = {}; // Reset modified parameter container after visibility update
-
-            doTake();
-        }
+        doTake();
     }
 
 
@@ -710,9 +674,6 @@
 
             $("#img_loading").hide();
             $("#canvas").show();
-
-            if (initialConfigUrl !="")
-                restoreCamSettings();
         };
 
         imageObj.onerror = function() {

--- a/sd-card/html/global_common.js
+++ b/sd-card/html/global_common.js
@@ -3,7 +3,7 @@
 * NOTE: And you also might have to disable CORS in your webbrowser.
 * IMPORTANT: For regular WebUI operation this IP parameter is not needed at all!
 */
-let DUTDeviceIP = "192.168.2.66";      // Set the IP of physical device under test
+let DUTDeviceIP = "192.168.2.20";      // Set the IP of physical device under test
 let TestEnvironmentActive = false;
 
 


### PR DESCRIPTION
fix(camera / rest api): Adapt config restore after temporary changes by REST API + align REST API

---
- Prevent against concurrent access of camera ressource to ensure proper output and allow usage of different request sources without disturbing each other.
- Ensure proper camera config restore after any temporary config changes (e.g. capture image via REST API with temporary config while creating reference image, ...) also during concurrent access of camera ressource
- Adapt camera REST API endpoint to align with restructured restore functionaliy
- Simplify camera REST API endpoint: `/camera?task=caputure` takes care of `/editflow?task=test_take` (`/set_parameter`), `/capture`, `/capture_with_flashlight`, `/save` (`/capture_to_file`)

---
#### Usage stats

Before (based on ESP32)
RAM:   [=         ]  14.4% (used 47116 bytes from 327680 bytes)
Flash: [========= ]  88.1% (used 1713525 bytes from 1945600 bytes)

After:
RAM:   [=         ]  14.4% (used 47116 bytes from 327680 bytes)
Flash: [========= ]  88.1% (used 1713505 bytes from 1945600 bytes)

