### PR TITLE
(gpio): Refactor mqttPublishPinState

### DIFF
--- a/code/components/gpio_ctrl/gpioPin.cpp
+++ b/code/components/gpio_ctrl/gpioPin.cpp
@@ -230,34 +230,17 @@ int GpioPin::getPinState()
 bool GpioPin::mqttPublishPinState(int _pwmDuty)
 {
     if (getMqttIsConnected() && mqttAccess) {
-        cJSON *cJSONObject = cJSON_CreateObject();
-        if (cJSONObject == NULL) {
-            LogFile.writeToFile(ESP_LOG_ERROR, TAG, "Failed to create JSON object");
-            return false;
-        }
-
-        bool retVal = true;
-
-        if (cJSON_AddNumberToObject(cJSONObject, "state", pinState) == NULL) {
-            retVal = false;
-        }
+        // Construct json notation manually. Not using cJSON library by purpose due to possbile concurrent usage / access
+        // Note: State changes could be triggered by interrupt quickly
+        std::string jsonData = "{ \"state\": " + std::to_string(pinState);
 
         if (mode == GPIO_PIN_MODE_OUTPUT_PWM || mode == GPIO_PIN_MODE_FLASHLIGHT_PWM) {
-            if (cJSON_AddNumberToObject(cJSONObject, "pwm_duty", _pwmDuty) == NULL) {
-                retVal = false;
-            }
+            jsonData += ", \"pwm_duty\": " + std::to_string(_pwmDuty);
         }
 
-        char *jsonChar = NULL;
-        jsonChar = cJSON_Print(cJSONObject);
-        cJSON_Delete(cJSONObject);
+        jsonData += " }";
 
-        if (jsonChar != NULL) {
-            retVal &= publishMqttData(mqttTopic + "/state", std::string(jsonChar), 1);
-            cJSON_free(jsonChar);
-        }
-
-        if (!retVal) {
+        if (!publishMqttData(mqttTopic + "/state", jsonData, 1)) {
             LogFile.writeToFile(ESP_LOG_WARN, TAG, "GPIO" + std::to_string((int)gpio) + ": Failed to publish state to MQTT broker");
             return false;
         }


### PR DESCRIPTION
Construct json manually to avoid concurrent cJSON usage / access (double free scenario)
- In rarly cases device crashes due to a double free of cJSON related json char array
--> Assumption: accessing ressource to quickly (gpio state change could be interrupt driven)

Related to #154

---
### Usage stats

Before (based on ESP32):
RAM:   [=         ]  14.4% (used 47108 bytes from 327680 bytes)
Flash: [========= ]  88.1% (used 1713401 bytes from 1945600 bytes)

After:
RAM:   [=         ]  14.4% (used 47108 bytes from 327680 bytes)
Flash: [========= ]  88.1% (used 1713381 bytes from 1945600 bytes)