### PR TITLE
(camera): Correct camera init order

### DIFF
--- a/code/components/camera_ctrl/ClassControlCamera.cpp
+++ b/code/components/camera_ctrl/ClassControlCamera.cpp
@@ -266,9 +266,10 @@ esp_err_t ClassControlCamera::setCameraParameter(const CfgData::SectionTakeImage
         paramCameraInternal = *(CfgData::SectionTakeImage::Camera *)_paramCamera;
     }
 
+    // NOTE: Keep this order of init
     setImageQuality();
-    setImageManipulation();
     setImageSize();
+    setImageManipulation();
 
     vTaskDelay(pdMS_TO_TICKS(100));
 


### PR DESCRIPTION
Fix camera init issue
- The changed init order seems to be unstable --> Revert back to previous oder
- Introduced and related to #207