### PR TITLE
(webui): Fix tooltip position on reference image page

### DIFF
--- a/sd-card/html/edit_reference.html
+++ b/sd-card/html/edit_reference.html
@@ -69,6 +69,12 @@
             font-size: 16px;
             margin-right: 10px;
         }
+
+        .tooltip .tooltiptext {
+			min-width: 310px !important;
+			max-width: 310px !important;
+			margin-left: -40px !important;
+		}
     </style>
 
     <link rel="stylesheet" href="param_tooltip.css?v=$COMMIT_HASH">


### PR DESCRIPTION
Fix tooltip position on reference image page --> Bug introduced with #197