### PR TITLE
feat(network): Support mDNS service for hostname resolution

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,3 +10,6 @@
 [submodule "code/components/smartleds"]
 	path = code/components/smartleds
 	url = https://github.com/RoboticsBrno/SmartLeds.git
+[submodule "code/components/esp-protocols"]
+	path = code/components/esp-protocols
+	url = https://github.com/espressif/esp-protocols/

--- a/code/CMakeLists.txt
+++ b/code/CMakeLists.txt
@@ -1,5 +1,7 @@
 cmake_minimum_required(VERSION 3.16.0)
 
+list(APPEND EXTRA_COMPONENT_DIRS components/esp-protocols/components/mdns)
+
 if(EXISTS "${SDKCONFIG}.defaults")
     if(EXISTS "sdkconfig.defaults")
         set(SDKCONFIG_DEFAULTS "${SDKCONFIG}.defaults;sdkconfig.defaults")

--- a/code/components/mqtt_ctrl/interface_mqtt.cpp
+++ b/code/components/mqtt_ctrl/interface_mqtt.cpp
@@ -391,19 +391,19 @@ int startMqttClient(void)
 
 void deinitMqttClient(bool disable)
 {
-    if (disable) {
-        mqttState.mqttEnabled = false;
-    }
-
-    mqttState.mqttInitialized = false;
-    mqttState.mqttConnected = false;
-
     if (mqttClient) {
         unregisterMqttSubscribeFunction();
         esp_mqtt_client_stop(mqttClient);
         esp_mqtt_client_destroy(mqttClient);
         mqttClient = NULL;
     }
+
+    if (disable) {
+        mqttState.mqttEnabled = false;
+    }
+
+    mqttState.mqttInitialized = false;
+    mqttState.mqttConnected = false;
 }
 
 

--- a/code/components/mqtt_ctrl/interface_mqtt.cpp
+++ b/code/components/mqtt_ctrl/interface_mqtt.cpp
@@ -391,19 +391,19 @@ int startMqttClient(void)
 
 void deinitMqttClient(bool disable)
 {
-    if (mqttClient) {
-        unregisterMqttSubscribeFunction();
-        esp_mqtt_client_stop(mqttClient);
-        esp_mqtt_client_destroy(mqttClient);
-        mqttClient = NULL;
-    }
-
     if (disable) {
         mqttState.mqttEnabled = false;
     }
 
     mqttState.mqttInitialized = false;
     mqttState.mqttConnected = false;
+
+    if (mqttClient) {
+        unregisterMqttSubscribeFunction();
+        esp_mqtt_client_stop(mqttClient);
+        esp_mqtt_client_destroy(mqttClient);
+        mqttClient = NULL;
+    }
 }
 
 

--- a/code/components/wlan_ctrl/CMakeLists.txt
+++ b/code/components/wlan_ctrl/CMakeLists.txt
@@ -1,7 +1,7 @@
 FILE(GLOB_RECURSE app_sources ${CMAKE_CURRENT_SOURCE_DIR}/*.*)
 
 idf_component_register(SRCS ${app_sources}
-                    INCLUDE_DIRS "."
-                    REQUIRES esp_driver_uart esp_driver_usb_serial_jtag esp_wifi nvs_flash wpa_supplicant misc_helper mqtt_ctrl)
+                    INCLUDE_DIRS "." "../esp-protocols/components/mdns/include"
+                    REQUIRES esp_driver_uart esp_driver_usb_serial_jtag esp_wifi nvs_flash wpa_supplicant mdns misc_helper mqtt_ctrl)
 
 

--- a/code/components/wlan_ctrl/connect_wlan.cpp
+++ b/code/components/wlan_ctrl/connect_wlan.cpp
@@ -4,9 +4,13 @@
 #include <netdb.h>
 #include <esp_system.h>
 #include <esp_wifi.h>
+
+#ifdef WLAN_USE_MESH_ROAMING
 #include <esp_wnm.h>
 #include <esp_rrm.h>
 #include <esp_mbo.h>
+#endif // WLAN_USE_MESH_ROAMING
+
 #include <esp_mac.h>
 #include <esp_log.h>
 #include <esp_netif.h>
@@ -21,6 +25,7 @@
 #include "ClassLogFile.h"
 #include "helper.h"
 #include "statusled.h"
+#include "mdns_service.h"
 
 
 static const char *TAG = "WLAN";
@@ -416,6 +421,9 @@ esp_err_t initWifiClient(void)
         }
     }
 
+    // Init mDNS service
+    mDnsInit(cfgDataPtr->wlan.hostname);
+
     wifiState.initialized = true;
 
     LogFile.writeToFile(ESP_LOG_INFO, TAG, "Init client mode successful");
@@ -551,6 +559,20 @@ esp_err_t initWifiAp(bool _useDefaultConfig)
         LogFile.writeToFile(ESP_LOG_ERROR, TAG, "esp_wifi_start: Error: " + intToHexString(retVal));
         return retVal;
     }
+
+    // Set hostname
+    if (!cfgDataPtr->wlan.hostname.empty()) {
+        retVal = esp_netif_set_hostname(wifiAp, cfgDataPtr->wlan.hostname.c_str());
+        if (retVal != ESP_OK) {
+            LogFile.writeToFile(ESP_LOG_ERROR, TAG, "esp_netif_set_hostname: Error: " + intToHexString(retVal));
+        }
+        else {
+            LogFile.writeToFile(ESP_LOG_INFO, TAG, "Assigned hostname: " + cfgDataPtr->wlan.hostname);
+        }
+    }
+
+    // Init mDNS service
+    mDnsInit(cfgDataPtr->wlan.hostname);
 
     wifiState.initialized = true;
 
@@ -1159,6 +1181,8 @@ wifi_connection_status_t getWifiConnectionStatus(void)
 
 void deinitWifi(void)
 {
+    mDnsDeinit();
+
     wifiState.initialized = false;
 
     esp_event_handler_unregister(IP_EVENT, IP_EVENT_STA_GOT_IP, event_handler);

--- a/code/components/wlan_ctrl/mdns_service.cpp
+++ b/code/components/wlan_ctrl/mdns_service.cpp
@@ -1,0 +1,35 @@
+#include "mdns_service.h"
+
+#include "mdns.h"
+
+#include "ClassLogFile.h"
+#include "helper.h"
+
+
+static const char *TAG = "MDNS";
+
+
+esp_err_t mDnsInit(std::string hostname)
+{
+    LogFile.writeToFile(ESP_LOG_INFO, TAG, "Init mDNS service");
+
+    esp_err_t retVal = mdns_init();
+    if (retVal != ESP_OK) {
+        LogFile.writeToFile(ESP_LOG_ERROR, TAG, "Failed to init mDNS service | Error: " + intToHexString(retVal));
+        return retVal;
+    }
+
+    retVal = mdns_hostname_set(hostname.c_str());
+    if (retVal != ESP_OK) {
+        LogFile.writeToFile(ESP_LOG_ERROR, TAG, "Failed to set mDNS hostname | Error: " + intToHexString(retVal));
+        return retVal;
+    }
+
+    return ESP_OK;
+}
+
+
+void mDnsDeinit()
+{
+    mdns_free();
+}

--- a/code/components/wlan_ctrl/mdns_service.h
+++ b/code/components/wlan_ctrl/mdns_service.h
@@ -1,0 +1,12 @@
+#ifndef MDNS_SERVICE_H
+#define MDNS_SERVICE_H
+
+#include <string>
+
+#include <esp_err.h>
+
+
+esp_err_t mDnsInit(std::string hostname);
+void mDnsDeinit(void);
+
+#endif // MDNS_SERVICE_H


### PR DESCRIPTION
Support zero-confiugration multicast DNS (mDNS) service for hostname to IP address resolution within small networks without any local name server or without relying on DHCP services.

#### Benefit
The device can also be accessed via configured hostname (default: `http://watermeter.local`) even no local name server is present or static IP configuration is used.

#### Drawbacks
- It seems accessing device via hostname is slower than using device IP address
- Consuming quite some flash + RAM and additionally reduces available free heap (Right now it's still sufficient, though)

---
### Usage stats

Before (based on ESP32):
RAM:   [==        ]  15.2% (used 49652 bytes from 327680 bytes)
Flash: [========= ]  85.3% (used 1658962 bytes from 1945600 bytes)

After:
RAM:   [==        ]  15.8% (used 51612 bytes from 327680 bytes)
Flash: [========= ]  86.6% (used 1684946 bytes from 1945600 bytes)

---
Cherry-picked from #3494. Thanks to @fsck-block for the idea and code template.