### PR TITLE
(gpio): Avoid double handler init

### DIFF
--- a/code/components/gpio_ctrl/gpioControl.cpp
+++ b/code/components/gpio_ctrl/gpioControl.cpp
@@ -356,12 +356,17 @@ void GpioHandler::clearData()
 {
     if (gpioMap != NULL) {
         for (std::map<gpio_num_t, GpioPin *>::iterator it = gpioMap->begin(); it != gpioMap->end(); it++) {
-            if (it->second->getSmartLed() != NULL) {
+            // Free smartLED instances
+            if (it->second->getMode() == GPIO_PIN_MODE_FLASHLIGHT_SMARTLED && it->second->getSmartLed() != NULL) {
                 delete it->second->getSmartLed();
                 it->second->setSmartLed(NULL);
             }
+            // Disable LEDC channels
+            else if (it->second->getMode() == GPIO_PIN_MODE_FLASHLIGHT_PWM || it->second->getMode() == GPIO_PIN_MODE_OUTPUT_PWM) {
+                ledc_stop(LEDC_LOW_SPEED_MODE, it->second->getLedcChannel(), 0);
+            }
 
-            delete it->second;
+            delete it->second; // Free GPIO pin instance
         }
         gpioMap->clear();
     }

--- a/code/components/gpio_ctrl/gpioControl.cpp
+++ b/code/components/gpio_ctrl/gpioControl.cpp
@@ -379,18 +379,11 @@ void GpioHandler::clearData()
 
 void GpioHandler::deinit()
 {
+    gpioHandlerEnabled = false;
+
 #ifdef ENABLE_MQTT
     unregisterMqttConnectFunction("gpioHandler");
 #endif // ENABLE_MQTT
-
-    // Disable LEDC channels
-    if (gpioMap != NULL) {
-        for (std::map<gpio_num_t, GpioPin *>::iterator it = gpioMap->begin(); it != gpioMap->end(); ++it) {
-            if (it->second->getMode() == GPIO_PIN_MODE_FLASHLIGHT_PWM || it->second->getMode() == GPIO_PIN_MODE_OUTPUT_PWM) {
-                ledc_stop(LEDC_LOW_SPEED_MODE, it->second->getLedcChannel(), 0);
-            }
-        }
-    }
 
     clearData();
 

--- a/code/components/mainprocess_ctrl/MainFlowControl.cpp
+++ b/code/components/mainprocess_ctrl/MainFlowControl.cpp
@@ -61,12 +61,15 @@ bool doInit(void)
     // ********************************************
     ConfigClass::getInstance()->reinitConfig();
 
-    // Init GPIO handler
-    // Note: GPIO has to be initialized before MQTT (topic subscription)
+    // Init GPIO handler (for generic usage)
+    // Note 1: GPIO has to be initialized before MQTT (topic subscription)
+    // Note 2: GPIO handler gets either init here or in cameraCtrl.initFlashlight() to control flashlight
     // ********************************************
     gpio_handler_deinit();
-    if (!gpio_handler_init()) {
-        bRetVal = false;
+    if (ConfigClass::getInstance()->get()->sectionGpio.customizationEnabled) {
+        if (!gpio_handler_init()) {
+            bRetVal = false;
+        }
     }
 
     // Init camera


### PR DESCRIPTION
Avoid double gpio handler init for devices with smartLED default flashlight when GPIO customization is not activated

Related to #207 