### PR TITLE
(config-handling): Fallback handling for corrupted or malformed persistent config file

### DIFF
--- a/code/components/config_handling/configClass.cpp
+++ b/code/components/config_handling/configClass.cpp
@@ -174,6 +174,9 @@ void ConfigClass::readConfigFile(bool unityTest, std::string unityTestData)
 
     // Check for invalid content -> bad/malformed syntax
     if (cJsonObject == NULL) {
+        // Save invalid config file for debug purpose
+        copyFile(CONFIG_PERSISTENCE_FILE, CONFIG_PERSISTENCE_FILE_INVALID);
+
         if (!fallbackCfgChecked) { // Try read fallback file if not yet read
             LogFile.writeToFile(ESP_LOG_WARN, TAG, "Invalid persistent config data | Check for fallback config file");
             std::ifstream file(CONFIG_PERSISTENCE_FILE_FALLBACK, std::ifstream::in);

--- a/code/components/config_handling/configClass.cpp
+++ b/code/components/config_handling/configClass.cpp
@@ -119,13 +119,14 @@ ConfigClass::~ConfigClass()
 void ConfigClass::readConfigFile(bool unityTest, std::string unityTestData)
 {
     std::stringstream streamBuffer;
+    bool fallbackCfgChecked = false;
 
     if (unityTest) {                     // Unity test
         clearCfgDataTemp();              // Clear internal struct
         streamBuffer.str(unityTestData); // Inject test data
     }
     else { // Read data from file
-        std::ifstream file(CONFIG_PERSISTENCE_FILE);
+        std::ifstream file(CONFIG_PERSISTENCE_FILE, std::ifstream::in);
 
         if (file.is_open() && file.good()) {
             LogFile.writeToFile(ESP_LOG_INFO, TAG, "Config file found");
@@ -136,8 +137,22 @@ void ConfigClass::readConfigFile(bool unityTest, std::string unityTestData)
 
     // Check for empty content -> either empty file or no / bad file
     if (streamBuffer.rdbuf()->in_avail() == 0) {
-        LogFile.writeToFile(ESP_LOG_INFO, TAG, "No persistent config found");
-        streamBuffer.str("{}"); // Ensure any content
+        LogFile.writeToFile(ESP_LOG_INFO, TAG, "No persistent config data | Check for fallback config file");
+
+        std::ifstream file(CONFIG_PERSISTENCE_FILE_FALLBACK, std::ifstream::in);
+        if (file.is_open() && file.good()) {
+            LogFile.writeToFile(ESP_LOG_INFO, TAG, "Fallback config file found");
+            streamBuffer << file.rdbuf();
+            file.close();
+        }
+
+        if (streamBuffer.rdbuf()->in_avail() == 0) {
+            streamBuffer.str("{}"); // Ensure any content
+            LogFile.writeToFile(ESP_LOG_INFO, TAG, "No persistent config data | Use default config");
+            // Continue to try to restore WLAN config from NVS, otherwise Access Point is getting started to reconfigure.
+        }
+
+        fallbackCfgChecked = true;
     }
 
     portENTER_CRITICAL(&mutex);
@@ -152,15 +167,45 @@ void ConfigClass::readConfigFile(bool unityTest, std::string unityTestData)
 
     // Parse content to cJSON object structure
     cJsonObject = cJSON_Parse(streamBuffer.str().c_str());
-    streamBuffer.str(""); // Clear stream buffer
 
     // Reset cJSON hooks to default
     cJSON_InitHooks(NULL);
     portEXIT_CRITICAL(&mutex);
 
+    // Check for invalid content -> bad/malformed syntax
     if (cJsonObject == NULL) {
-        LogFile.writeToFile(ESP_LOG_ERROR, TAG, "parseConfig: Failed to parse JSON data | Fallback: Use default config");
-        // Continue to try to restore WLAN config from NVS, otherwise Access Point is getting started to reconfigure.
+        if (!fallbackCfgChecked) { // Try read fallback file if not yet read
+            LogFile.writeToFile(ESP_LOG_WARN, TAG, "Invalid persistent config data | Check for fallback config file");
+            std::ifstream file(CONFIG_PERSISTENCE_FILE_FALLBACK, std::ifstream::in);
+            if (file.is_open() && file.good()) {
+                LogFile.writeToFile(ESP_LOG_INFO, TAG, "Fallback config file found");
+                streamBuffer.str(""); // Clear stream buffer
+                streamBuffer << file.rdbuf();
+                file.close();
+
+                portENTER_CRITICAL(&mutex);
+                // Modify hook to use SPIRAM for cJSON object
+                cJSON_Hooks hooks;
+                hooks.malloc_fn = malloc_psram_heap_cjson;
+                hooks.free_fn = free_psram_heap_cjson;
+                cJSON_InitHooks(&hooks);
+                cJSONObjectPSRAM.preallocatedMemory = cJsonObjectBuffer;
+                cJSONObjectPSRAM.preallocatedMemorySize = CONFIG_HANDLING_PREALLOCATED_BUFFER_SIZE;
+                cJSONObjectPSRAM.usedMemory = 0;
+
+                // Parse content to cJSON object structure
+                cJsonObject = cJSON_Parse(streamBuffer.str().c_str());
+
+                // Reset cJSON hooks to default
+                cJSON_InitHooks(NULL);
+                portEXIT_CRITICAL(&mutex);
+            }
+        }
+
+        if (cJsonObject == NULL) {
+            LogFile.writeToFile(ESP_LOG_ERROR, TAG, "Invalid persistent config data | Use default config");
+            // Continue to try to restore WLAN config from NVS, otherwise Access Point is getting started to reconfigure.
+        }
     }
 
     // Parse config out of cJSON object structure
@@ -2550,7 +2595,7 @@ esp_err_t ConfigClass::getConfigRequest(httpd_req_t *req)
 //**************************************************************************************************
 esp_err_t ConfigClass::writeConfigFile()
 {
-    std::ofstream file(CONFIG_PERSISTENCE_FILE);
+    std::ofstream file(CONFIG_PERSISTENCE_FILE, std::ofstream::out);
 
     if (!file.is_open()) {
         LogFile.writeToFile(ESP_LOG_ERROR, TAG, "writeConfigFile: Failed to write JSON file");
@@ -2559,6 +2604,9 @@ esp_err_t ConfigClass::writeConfigFile()
 
     file << jsonBuffer;
     file.close();
+
+    // Save config file additionally as fallback config file
+    copyFile(CONFIG_PERSISTENCE_FILE, CONFIG_PERSISTENCE_FILE_FALLBACK);
 
     return ESP_OK;
 }

--- a/code/include/defines.h
+++ b/code/include/defines.h
@@ -83,8 +83,9 @@
 
 // server_GPIO + server_file + SoftAP + ClassFlowControl + Main
 //******************************
-#define CONFIG_PERSISTENCE_FILE "/sdcard/config/config.json" // Config persistence file for firmware v17.x and newer
-#define CONFIG_PERSISTENCE_FILE_BACKUP "/sdcard/config/backup/config_json.bak" // Config persistence backup file for firmware v17.x and newer
+#define CONFIG_PERSISTENCE_FILE "/sdcard/config/config.json" // Config persistence file
+#define CONFIG_PERSISTENCE_FILE_FALLBACK "/sdcard/config/backup/config_fallback.json" // Config fallback persistence file
+#define CONFIG_PERSISTENCE_FILE_BACKUP "/sdcard/config/backup/config_json.bak" // Config persistence backup file (migration)
 
 #define CONFIG_FILE_LEGACY "/sdcard/config/config.ini" // Config file for firmware v16.x and older
 #define CONFIG_FILE_BACKUP_LEGACY "/sdcard/config/backup/config_ini.bak"

--- a/code/include/defines.h
+++ b/code/include/defines.h
@@ -84,8 +84,9 @@
 // server_GPIO + server_file + SoftAP + ClassFlowControl + Main
 //******************************
 #define CONFIG_PERSISTENCE_FILE "/sdcard/config/config.json" // Config persistence file
-#define CONFIG_PERSISTENCE_FILE_FALLBACK "/sdcard/config/backup/config_fallback.json" // Config fallback persistence file
-#define CONFIG_PERSISTENCE_FILE_BACKUP "/sdcard/config/backup/config_json.bak" // Config persistence backup file (migration)
+#define CONFIG_PERSISTENCE_FILE_FALLBACK "/sdcard/config/backup/config_fallback.json" // Config persistence file (fallback)
+#define CONFIG_PERSISTENCE_FILE_INVALID "/sdcard/config/backup/config_invalid.json" // Config persistence file (invalid, save for debug)
+#define CONFIG_PERSISTENCE_FILE_BACKUP "/sdcard/config/backup/config_json.bak" // Config persistence file (migration backup)
 
 #define CONFIG_FILE_LEGACY "/sdcard/config/config.ini" // Config file for firmware v16.x and older
 #define CONFIG_FILE_BACKUP_LEGACY "/sdcard/config/backup/config_ini.bak"


### PR DESCRIPTION
Keep a fallback persistent config file (`/config/backup/config_fallback.json`) in case main config file (`/config/config.json`) is missing, corrupted or has any malformed JSON notation
- Whenever main persistent config file is missing, corrupted or malformed, try to load peristent config data from fallback config file
- If none of the config files are usable or available, continue using default configuration
- For debugging purpose keep latest invalid config file (`/config/backup/config_invalid.json`)

Enhancement related to #165

---
### Usage stats

Before (based on ESP32):
RAM:   [==        ]  15.8% (used 51612 bytes from 327680 bytes)
Flash: [========= ]  86.6% (used 1685430 bytes from 1945600 bytes)

After:
RAM:   [==        ]  15.8% (used 51612 bytes from 327680 bytes)
Flash: [========= ]  86.6% (used 1685630 bytes from 1945600 bytes)