### PR TITLE
chore(wlan): Force WLAN bandwidth to 20MHz

### DIFF
--- a/code/components/wlan_ctrl/connect_wlan.cpp
+++ b/code/components/wlan_ctrl/connect_wlan.cpp
@@ -405,6 +405,12 @@ esp_err_t initWifiClient(void)
         }
     }
 
+    // Force bandwidth to 20Mhz to reduce risk of interference with other channels (Default: WIFI_BW_HT40)
+    retVal = esp_wifi_set_bandwidth(WIFI_IF_STA, WIFI_BW_HT20);
+    if (retVal != ESP_OK) {
+        LogFile.writeToFile(ESP_LOG_ERROR, TAG, "esp_wifi_set_bandwidth: Error: " + intToHexString(retVal));
+    }
+
     retVal = esp_wifi_start();
     if (retVal != ESP_OK) {
         LogFile.writeToFile(ESP_LOG_ERROR, TAG, "esp_wifi_start: Error: " + intToHexString(retVal));
@@ -552,6 +558,12 @@ esp_err_t initWifiAp(bool _useDefaultConfig)
             LogFile.writeToFile(ESP_LOG_ERROR, TAG, "esp_wifi_set_config: Error: " + intToHexString(retVal));
             return retVal;
         }
+    }
+
+    // Force bandwidth to 20Mhz to reduce risk of interference with other channels (Default: WIFI_BW_HT40)
+    retVal = esp_wifi_set_bandwidth(WIFI_IF_STA, WIFI_BW_HT20);
+    if (retVal != ESP_OK) {
+        LogFile.writeToFile(ESP_LOG_ERROR, TAG, "esp_wifi_set_bandwidth: Error: " + intToHexString(retVal));
     }
 
     retVal = esp_wifi_start();

--- a/code/components/wlan_ctrl/connect_wlan.cpp
+++ b/code/components/wlan_ctrl/connect_wlan.cpp
@@ -561,7 +561,7 @@ esp_err_t initWifiAp(bool _useDefaultConfig)
     }
 
     // Force bandwidth to 20Mhz to reduce risk of interference with other channels (Default: WIFI_BW_HT40)
-    retVal = esp_wifi_set_bandwidth(WIFI_IF_STA, WIFI_BW_HT20);
+    retVal = esp_wifi_set_bandwidth(WIFI_IF_AP, WIFI_BW_HT20);
     if (retVal != ESP_OK) {
         LogFile.writeToFile(ESP_LOG_ERROR, TAG, "esp_wifi_set_bandwidth: Error: " + intToHexString(retVal));
     }


### PR DESCRIPTION
Force WLAN bandwidth to 20MHz (Default: 40Mhz)

Benefits:
- Reduces the risk of interference with other devices
- Reduced channel / frequency occupation


Drawbacks:
- Reduced throughput --> High throughput not required for this application

---
### Usage stats

Before (based on ESP32):
RAM:   [==        ]  15.8% (used 51612 bytes from 327680 bytes)
Flash: [========= ]  86.6% (used 1685630 bytes from 1945600 bytes)

After:
RAM:   [==        ]  15.8% (used 51612 bytes from 327680 bytes)
Flash: [========= ]  86.7% (used 1686682 bytes from 1945600 bytes)