### PR TITLE
fix(home assistant discovery)!: Fix inconsistencies (device / state class)

### DIFF
--- a/code/components/config_handling/cfgDataStruct.h
+++ b/code/components/config_handling/cfgDataStruct.h
@@ -58,14 +58,20 @@ enum HAMeterType {
     TYPE_NONE = 0,
     WATER_M3 = 1,
     WATER_L = 2,
-    WATER_FT3 = 3,
-    WATER_GAL = 4,
+    WATER_GAL = 3,
+    WATER_FT3 = 4,
     GAS_M3 = 5,
     GAS_FT3 = 6,
     ENERGY_WH = 7,
     ENERGY_KWH = 8,
     ENERGY_MWH = 9,
     ENERGY_GJ = 10,
+    TEMPERATURE_C = 11,
+    TEMPERATURE_F = 12,
+    PRESSURE_BAR = 13,
+    PRESSURE_PSI = 14,
+    WATER_LMIN = 15,
+    WATER_GALMIN = 16
 };
 
 

--- a/code/components/config_handling/configClass.cpp
+++ b/code/components/config_handling/configClass.cpp
@@ -1049,7 +1049,7 @@ esp_err_t ConfigClass::parseConfig(httpd_req_t *req, bool init, bool unityTest)
 
     objEl = cJSON_GetObjectItem(cJSON_GetObjectItem(cJSON_GetObjectItem(cJsonObject, "mqtt"), "homeassistant"), "metertype");
     if (cJSON_IsNumber(objEl)) {
-        cfgDataTemp.sectionMqtt.homeAssistant.meterType = std::clamp(objEl->valueint, 0, 10);
+        cfgDataTemp.sectionMqtt.homeAssistant.meterType = std::clamp(objEl->valueint, 0, 16);
     }
 
     objEl = cJSON_GetObjectItem(cJSON_GetObjectItem(cJSON_GetObjectItem(cJsonObject, "mqtt"), "homeassistant"), "retaindiscovery");

--- a/code/components/mainprocess_ctrl/ClassFlowMQTT.cpp
+++ b/code/components/mainprocess_ctrl/ClassFlowMQTT.cpp
@@ -36,38 +36,8 @@ bool ClassFlowMQTT::loadParameter()
         return false;
     }
 
-    if (cfgDataPtr->homeAssistant.meterType == WATER_M3) {
-        mqttServer_setMeterType("water", "m³", "h", "m³/h");
-    }
-    else if (cfgDataPtr->homeAssistant.meterType == WATER_L) {
-        mqttServer_setMeterType("water", "L", "h", "L/h");
-    }
-    else if (cfgDataPtr->homeAssistant.meterType == WATER_FT3) {
-        mqttServer_setMeterType("water", "ft³", "m", "ft³/m"); // Minutes
-    }
-    else if (cfgDataPtr->homeAssistant.meterType == WATER_GAL) {
-        mqttServer_setMeterType("water", "gal", "h", "gal/h");
-    }
-    else if (cfgDataPtr->homeAssistant.meterType == GAS_M3) {
-        mqttServer_setMeterType("gas", "m³", "h", "m³/h");
-    }
-    else if (cfgDataPtr->homeAssistant.meterType == GAS_FT3) {
-        mqttServer_setMeterType("gas", "ft³", "m", "ft³/m"); // Minutes
-    }
-    else if (cfgDataPtr->homeAssistant.meterType == ENERGY_WH) {
-        mqttServer_setMeterType("energy", "Wh", "h", "W");
-    }
-    else if (cfgDataPtr->homeAssistant.meterType == ENERGY_KWH) {
-        mqttServer_setMeterType("energy", "kWh", "h", "kW");
-    }
-    else if (cfgDataPtr->homeAssistant.meterType == ENERGY_MWH) {
-        mqttServer_setMeterType("energy", "MWh", "h", "MW");
-    }
-    else if (cfgDataPtr->homeAssistant.meterType == ENERGY_GJ) {
-        mqttServer_setMeterType("energy", "GJ", "h", "GJ/h");
-    }
-    else {
-        mqttServer_setMeterType("", "", "", "");
+    if (cfgDataPtr->homeAssistant.discoveryEnabled) {
+        mqttServer_setHaMeterType(cfgDataPtr->homeAssistant.meterType);
     }
 
     return true;

--- a/code/components/mqtt_ctrl/server_mqtt.cpp
+++ b/code/components/mqtt_ctrl/server_mqtt.cpp
@@ -634,22 +634,16 @@ bool mqttServer_publishHADiscovery(int _qos)
         // https://github.com/home-assistant/core/blob/master/homeassistant/components/sensor/const.py
         if (meterConfig.meterType == "water" || meterConfig.meterType == "gas") {
             meterConfig.valueStateClass = sequence->paramPostProc->allowNegativeRate ? "total" : "total_increasing";
-            if (meterConfig.rateUnit != "L/h" && meterConfig.rateUnit != "gal/h") { // Legacy: L/h and gal/h are not valid units in home
-                                                                                    // assistant: Use device class `None`
-                meterConfig.rateDeviceClass = "volume_flow_rate";
-            }
-            else {
-                meterConfig.rateDeviceClass = ""; // Device class: None
-            }
+
+            // Legacy: L/h and gal/h are not valid units in home assistant: Use device class `None`
+            ((meterConfig.rateUnit != "L/h") && (meterConfig.rateUnit != "gal/h")) ? meterConfig.rateDeviceClass = "volume_flow_rate"
+                                                                                   : meterConfig.rateDeviceClass = "";
         }
         else if (meterConfig.meterType == "energy") {
             meterConfig.valueStateClass = sequence->paramPostProc->allowNegativeRate ? "total" : "total_increasing";
-            if (meterConfig.rateUnit != "GJ/h") { // Legacy: GJ/h is not a valid unit in home assistant: Use device class `None`
-                meterConfig.rateDeviceClass = "power";
-            }
-            else {
-                meterConfig.rateDeviceClass = ""; // Device class: None
-            }
+
+            // Legacy: GJ/h is not a valid unit in home assistant: Use device class `None`
+            meterConfig.rateUnit != "GJ/h" ? meterConfig.rateDeviceClass = "power" : meterConfig.rateDeviceClass = "";
         }
         else if (meterConfig.meterType == "temperature" || meterConfig.meterType == "pressure") {
             meterConfig.valueStateClass = "measurement";
@@ -741,7 +735,7 @@ bool mqttServer_publishHADiscovery(int _qos)
             .friendlyName = "Rate / Interval (" + to_stringWithPrecision(processingInterval, 1) + "min)",
             .icon = "arrow-expand-vertical",
             .unit = meterConfig.valueUnit,
-            //.deviceClass = meterConfig.rateDeviceClass, // Special case, not using any common rate unit --> None
+            .deviceClass = "", // Special case, not using any common rate unit: Use Device class 'None'
             .stateClass = "measurement",
             .entityCategory = "diagnostic" //
         };

--- a/code/components/mqtt_ctrl/server_mqtt.cpp
+++ b/code/components/mqtt_ctrl/server_mqtt.cpp
@@ -257,7 +257,7 @@ void mqttServer_setHaMeterType(const int _haMeterType)
         meterConfig.meterType = "water";
         meterConfig.valueUnit = "L";
         meterConfig.timeUnit = "h";
-        meterConfig.rateUnit = "L/h"; // Legacy: L/h is no valid rate unit in home assistant
+        meterConfig.rateUnit = "L/h"; // Legacy: Keep, even this is not a valid unit in home assistant
     }
     else if (_haMeterType == WATER_LMIN) {
         meterConfig.meterType = "water";
@@ -265,23 +265,23 @@ void mqttServer_setHaMeterType(const int _haMeterType)
         meterConfig.timeUnit = "min";
         meterConfig.rateUnit = "L/min";
     }
-    else if (_haMeterType == WATER_FT3) {
-        meterConfig.meterType = "water";
-        meterConfig.valueUnit = "ft³";
-        meterConfig.timeUnit = "min";
-        meterConfig.rateUnit = "ft³/min";
-    }
     else if (_haMeterType == WATER_GAL) {
         meterConfig.meterType = "water";
         meterConfig.valueUnit = "gal";
         meterConfig.timeUnit = "h";
-        meterConfig.rateUnit = "gal/h";
+        meterConfig.rateUnit = "gal/h"; // Legacy: Keep, even this is not a valid unit in home assistant
     }
     else if (_haMeterType == WATER_GALMIN) {
         meterConfig.meterType = "water";
         meterConfig.valueUnit = "gal";
         meterConfig.timeUnit = "min";
         meterConfig.rateUnit = "gal/min";
+    }
+    else if (_haMeterType == WATER_FT3) {
+        meterConfig.meterType = "water";
+        meterConfig.valueUnit = "ft³";
+        meterConfig.timeUnit = "min";
+        meterConfig.rateUnit = "ft³/min";
     }
     else if (_haMeterType == GAS_M3) {
         meterConfig.meterType = "gas";
@@ -317,7 +317,7 @@ void mqttServer_setHaMeterType(const int _haMeterType)
         meterConfig.meterType = "energy";
         meterConfig.valueUnit = "GJ";
         meterConfig.timeUnit = "h";
-        meterConfig.rateUnit = "GJ/h"; // Legacy: GJ/h is no valid rate unit in home assistant
+        meterConfig.rateUnit = "GJ/h"; //  Legacy: Keep, even this is not a valid unit in home assistant
     }
     else if (_haMeterType == TEMPERATURE_C) {
         meterConfig.meterType = "temperature";
@@ -634,7 +634,7 @@ bool mqttServer_publishHADiscovery(int _qos)
         // https://github.com/home-assistant/core/blob/master/homeassistant/components/sensor/const.py
         if (meterConfig.meterType == "water" || meterConfig.meterType == "gas") {
             meterConfig.valueStateClass = sequence->paramPostProc->allowNegativeRate ? "total" : "total_increasing";
-            if (meterConfig.rateUnit != "L/h" && meterConfig.rateUnit != "gal/h") { // Legacy: L/h and gal/h are no valid rate units in home
+            if (meterConfig.rateUnit != "L/h" && meterConfig.rateUnit != "gal/h") { // Legacy: L/h and gal/h are not valid units in home
                                                                                     // assistant: Use device class `None`
                 meterConfig.rateDeviceClass = "volume_flow_rate";
             }
@@ -644,7 +644,7 @@ bool mqttServer_publishHADiscovery(int _qos)
         }
         else if (meterConfig.meterType == "energy") {
             meterConfig.valueStateClass = sequence->paramPostProc->allowNegativeRate ? "total" : "total_increasing";
-            if (meterConfig.rateUnit != "GJ/h") { // Legacy: GJ/h is no valid rate unit in home assistant: Use device class `None`
+            if (meterConfig.rateUnit != "GJ/h") { // Legacy: GJ/h is not a valid unit in home assistant: Use device class `None`
                 meterConfig.rateDeviceClass = "power";
             }
             else {

--- a/code/components/mqtt_ctrl/server_mqtt.cpp
+++ b/code/components/mqtt_ctrl/server_mqtt.cpp
@@ -35,7 +35,7 @@ static bool publishDeviceInfoScheduled = true;
 static const CfgData::SectionMqtt *cfgDataPtr = NULL;
 static const std::vector<SequenceData *> *sequenceData;
 static float processingInterval; // Minutes
-static std::string meterType, valueUnit, timeUnit, rateUnit;
+static HAMeterConfig meterConfig;
 
 
 // Publish device info topics (common topics, static, retained)
@@ -240,18 +240,121 @@ void mqttServer_setParameter(const CfgData::SectionMqtt *_cfgDataPtr, const std:
 }
 
 
-void mqttServer_setMeterType(std::string _meterType, std::string _valueUnit, std::string _timeUnit, std::string _rateUnit)
+void mqttServer_setHaMeterType(const int _haMeterType)
 {
-    meterType = _meterType;
-    valueUnit = _valueUnit;
-    timeUnit = _timeUnit;
-    rateUnit = _rateUnit;
+    // Preconfigure meter configuration
+    // Check for avialable units:
+    // https://developers.home-assistant.io/docs/core/entity/sensor/
+    // https://github.com/home-assistant/core/blob/master/homeassistant/components/sensor/const.py
+    // DONT'T FORGET, see further down: Device / state class validation (in loop for publish number sequence related topics)
+    if (_haMeterType == WATER_M3) {
+        meterConfig.meterType = "water";
+        meterConfig.valueUnit = "m³";
+        meterConfig.timeUnit = "h";
+        meterConfig.rateUnit = "m³/h";
+    }
+    else if (_haMeterType == WATER_L) {
+        meterConfig.meterType = "water";
+        meterConfig.valueUnit = "L";
+        meterConfig.timeUnit = "h";
+        meterConfig.rateUnit = "L/h"; // Legacy: L/h is no valid rate unit in home assistant
+    }
+    else if (_haMeterType == WATER_LMIN) {
+        meterConfig.meterType = "water";
+        meterConfig.valueUnit = "L";
+        meterConfig.timeUnit = "min";
+        meterConfig.rateUnit = "L/min";
+    }
+    else if (_haMeterType == WATER_FT3) {
+        meterConfig.meterType = "water";
+        meterConfig.valueUnit = "ft³";
+        meterConfig.timeUnit = "min";
+        meterConfig.rateUnit = "ft³/min";
+    }
+    else if (_haMeterType == WATER_GAL) {
+        meterConfig.meterType = "water";
+        meterConfig.valueUnit = "gal";
+        meterConfig.timeUnit = "h";
+        meterConfig.rateUnit = "gal/h";
+    }
+    else if (_haMeterType == WATER_GALMIN) {
+        meterConfig.meterType = "water";
+        meterConfig.valueUnit = "gal";
+        meterConfig.timeUnit = "min";
+        meterConfig.rateUnit = "gal/min";
+    }
+    else if (_haMeterType == GAS_M3) {
+        meterConfig.meterType = "gas";
+        meterConfig.valueUnit = "m³";
+        meterConfig.timeUnit = "h";
+        meterConfig.rateUnit = "m³/h";
+    }
+    else if (_haMeterType == GAS_FT3) {
+        meterConfig.meterType = "gas";
+        meterConfig.valueUnit = "ft³";
+        meterConfig.timeUnit = "min";
+        meterConfig.rateUnit = "ft³/min";
+    }
+    else if (_haMeterType == ENERGY_WH) {
+        meterConfig.meterType = "energy";
+        meterConfig.valueUnit = "Wh";
+        meterConfig.timeUnit = "h";
+        meterConfig.rateUnit = "W";
+    }
+    else if (_haMeterType == ENERGY_KWH) {
+        meterConfig.meterType = "energy";
+        meterConfig.valueUnit = "kWh";
+        meterConfig.timeUnit = "h";
+        meterConfig.rateUnit = "kW";
+    }
+    else if (_haMeterType == ENERGY_MWH) {
+        meterConfig.meterType = "energy";
+        meterConfig.valueUnit = "MWh";
+        meterConfig.timeUnit = "h";
+        meterConfig.rateUnit = "MW";
+    }
+    else if (_haMeterType == ENERGY_GJ) {
+        meterConfig.meterType = "energy";
+        meterConfig.valueUnit = "GJ";
+        meterConfig.timeUnit = "h";
+        meterConfig.rateUnit = "GJ/h"; // Legacy: GJ/h is no valid rate unit in home assistant
+    }
+    else if (_haMeterType == TEMPERATURE_C) {
+        meterConfig.meterType = "temperature";
+        meterConfig.valueUnit = "°C";
+        meterConfig.timeUnit = "min";
+        meterConfig.rateUnit = "K/min";
+    }
+    else if (_haMeterType == TEMPERATURE_F) {
+        meterConfig.meterType = "temperature";
+        meterConfig.valueUnit = "°F";
+        meterConfig.timeUnit = "min";
+        meterConfig.rateUnit = "K/min";
+    }
+    else if (_haMeterType == PRESSURE_BAR) {
+        meterConfig.meterType = "pressure";
+        meterConfig.valueUnit = "bar";
+        meterConfig.timeUnit = "min";
+        meterConfig.rateUnit = "bar/min";
+    }
+    else if (_haMeterType == PRESSURE_PSI) {
+        meterConfig.meterType = "pressure";
+        meterConfig.valueUnit = "psi";
+        meterConfig.timeUnit = "min";
+        meterConfig.rateUnit = "psi/min";
+    }
+    else {
+        meterConfig.meterType = "";
+        meterConfig.valueUnit = "";
+        meterConfig.timeUnit = "Unknown";
+        meterConfig.rateUnit = "";
+    }
 }
 
 
 std::string mqttServer_getTimeUnit(void)
 {
-    return timeUnit;
+    return meterConfig.timeUnit;
 }
 
 
@@ -348,8 +451,8 @@ bool mqttServer_publishHADiscovery(int _qos)
     }
 
     LogFile.writeToFile(ESP_LOG_DEBUG, TAG,
-                        "Publish HA discovery | Sensor device class: " + meterType + ", Value unit: " + valueUnit +
-                            " , Rate unit: " + rateUnit);
+                        "Publish HA discovery | Meter type: " + meterConfig.meterType + ", Value unit: " + meterConfig.valueUnit +
+                            " , Rate unit: " + meterConfig.rateUnit);
 
     publishHADiscoveryTopicDeviceInfo = true; // Publish full common device info data only once
     bool publishOK = true;
@@ -526,6 +629,37 @@ bool mqttServer_publishHADiscovery(int _qos)
 
     // Publish number sequence related topics
     for (const auto &sequence : *sequenceData) {
+        // Device / state class validation
+        // Check for valid device class / state class combinations:
+        // https://github.com/home-assistant/core/blob/master/homeassistant/components/sensor/const.py
+        if (meterConfig.meterType == "water" || meterConfig.meterType == "gas") {
+            meterConfig.valueStateClass = sequence->paramPostProc->allowNegativeRate ? "total" : "total_increasing";
+            if (meterConfig.rateUnit != "L/h" && meterConfig.rateUnit != "gal/h") { // Legacy: L/h and gal/h are no valid rate units in home
+                                                                                    // assistant: Use device class `None`
+                meterConfig.rateDeviceClass = "volume_flow_rate";
+            }
+            else {
+                meterConfig.rateDeviceClass = ""; // Device class: None
+            }
+        }
+        else if (meterConfig.meterType == "energy") {
+            meterConfig.valueStateClass = sequence->paramPostProc->allowNegativeRate ? "total" : "total_increasing";
+            if (meterConfig.rateUnit != "GJ/h") { // Legacy: GJ/h is no valid rate unit in home assistant: Use device class `None`
+                meterConfig.rateDeviceClass = "power";
+            }
+            else {
+                meterConfig.rateDeviceClass = ""; // Device class: None
+            }
+        }
+        else if (meterConfig.meterType == "temperature" || meterConfig.meterType == "pressure") {
+            meterConfig.valueStateClass = "measurement";
+            meterConfig.rateDeviceClass = "";
+        }
+        else {
+            meterConfig.valueStateClass = "measurement";
+            meterConfig.rateDeviceClass = "";
+        }
+
         HADiscoveryData = {};
         HADiscoveryData = {
             .structureName = sequence->sequenceName,
@@ -534,9 +668,9 @@ bool mqttServer_publishHADiscovery(int _qos)
             .topicName = "actual_value",
             .friendlyName = "Actual Value",
             .icon = "gauge",
-            .unit = valueUnit,
-            .deviceClass = meterType,
-            .stateClass = sequence->paramPostProc->allowNegativeRate ? "measurement" : "total_increasing" //
+            .unit = meterConfig.valueUnit,
+            .deviceClass = meterConfig.meterType,
+            .stateClass = meterConfig.valueStateClass //
         };
         publishOK &= publishHADiscoveryTopic(&HADiscoveryData, _qos);
 
@@ -549,9 +683,9 @@ bool mqttServer_publishHADiscovery(int _qos)
                 .topicName = "fallback_value",
                 .friendlyName = "Fallback Value",
                 .icon = "gauge",
-                .unit = valueUnit,
-                .deviceClass = meterType,
-                .stateClass = "measurement",
+                .unit = meterConfig.valueUnit,
+                .deviceClass = meterConfig.meterType,
+                .stateClass = meterConfig.valueStateClass,
                 .entityCategory = "diagnostic" //
             };
             publishOK &= publishHADiscoveryTopic(&HADiscoveryData, _qos);
@@ -565,9 +699,9 @@ bool mqttServer_publishHADiscovery(int _qos)
             .topicName = "raw_value",
             .friendlyName = "Raw Value",
             .icon = "gauge",
-            .unit = valueUnit,
-            .deviceClass = meterType,
-            .stateClass = "measurement",
+            .unit = meterConfig.valueUnit,
+            .deviceClass = meterConfig.meterType,
+            .stateClass = meterConfig.valueStateClass,
             .entityCategory = "diagnostic" //
         };
         publishOK &= publishHADiscoveryTopic(&HADiscoveryData, _qos);
@@ -592,8 +726,8 @@ bool mqttServer_publishHADiscovery(int _qos)
             .topicName = "rate_per_time_unit",
             .friendlyName = "Rate",
             .icon = "swap-vertical",
-            .unit = rateUnit,
-            .deviceClass = meterType == "energy" ? "power" : "volume_flow_rate",
+            .unit = meterConfig.rateUnit,
+            .deviceClass = meterConfig.rateDeviceClass,
             .stateClass = "measurement" //
         };
         publishOK &= publishHADiscoveryTopic(&HADiscoveryData, _qos);
@@ -604,9 +738,10 @@ bool mqttServer_publishHADiscovery(int _qos)
             .isTopicJSONNotation = true,
             .topic = "/process/data/" + std::to_string(sequence->sequenceId) + "/json",
             .topicName = "rate_per_interval",
-            .friendlyName = "Rate / Interval",
+            .friendlyName = "Rate / Interval (" + to_stringWithPrecision(processingInterval, 1) + "min)",
             .icon = "arrow-expand-vertical",
-            .unit = valueUnit != "" ? valueUnit + "/" + to_stringWithPrecision(processingInterval, 1) + "min" : "",
+            .unit = meterConfig.valueUnit,
+            //.deviceClass = meterConfig.rateDeviceClass, // Special case, not using any common rate unit --> None
             .stateClass = "measurement",
             .entityCategory = "diagnostic" //
         };
@@ -780,7 +915,7 @@ static bool publishHADiscoveryTopic(const strHADiscoveryData *_data, const int _
         }
 
         payload += std::string(", \"dev\": {") + "\"ids\":[\"" + nodeID + "\"]," + "\"name\":\"" + nodeID + "\"," +
-                   "\"mdl\":\"AI-on-the-Edge device [" + getBoardType() + "]\"," + "\"mf\":\"AI-on-the-Edge\"," + "\"sw\":\"" +
+                   "\"mdl\":\"AI-on-the-Edge device (" + getBoardType() + ")\"," + "\"mf\":\"AI-on-the-Edge\"," + "\"sw\":\"" +
                    firmwareVersion + " [SLFork]\"," + "\"cu\":\"http://" + getIpAddress() + "\"}";
     }
     else { // Publish device reference only to group data together

--- a/code/components/mqtt_ctrl/server_mqtt.cpp
+++ b/code/components/mqtt_ctrl/server_mqtt.cpp
@@ -248,103 +248,103 @@ void mqttServer_setHaMeterType(const int _haMeterType)
     // https://github.com/home-assistant/core/blob/master/homeassistant/components/sensor/const.py
     // DONT'T FORGET, see further down: Device / state class validation (in loop for publish number sequence related topics)
     if (_haMeterType == WATER_M3) {
-        meterConfig.meterType = "water";
+        meterConfig.deviceClass = "water";
         meterConfig.valueUnit = "m³";
         meterConfig.timeUnit = "h";
         meterConfig.rateUnit = "m³/h";
     }
     else if (_haMeterType == WATER_L) {
-        meterConfig.meterType = "water";
+        meterConfig.deviceClass = "water";
         meterConfig.valueUnit = "L";
         meterConfig.timeUnit = "h";
         meterConfig.rateUnit = "L/h"; // Legacy: Keep, even this is not a valid unit in home assistant
     }
     else if (_haMeterType == WATER_LMIN) {
-        meterConfig.meterType = "water";
+        meterConfig.deviceClass = "water";
         meterConfig.valueUnit = "L";
         meterConfig.timeUnit = "min";
         meterConfig.rateUnit = "L/min";
     }
     else if (_haMeterType == WATER_GAL) {
-        meterConfig.meterType = "water";
+        meterConfig.deviceClass = "water";
         meterConfig.valueUnit = "gal";
         meterConfig.timeUnit = "h";
         meterConfig.rateUnit = "gal/h"; // Legacy: Keep, even this is not a valid unit in home assistant
     }
     else if (_haMeterType == WATER_GALMIN) {
-        meterConfig.meterType = "water";
+        meterConfig.deviceClass = "water";
         meterConfig.valueUnit = "gal";
         meterConfig.timeUnit = "min";
         meterConfig.rateUnit = "gal/min";
     }
     else if (_haMeterType == WATER_FT3) {
-        meterConfig.meterType = "water";
+        meterConfig.deviceClass = "water";
         meterConfig.valueUnit = "ft³";
         meterConfig.timeUnit = "min";
         meterConfig.rateUnit = "ft³/min";
     }
     else if (_haMeterType == GAS_M3) {
-        meterConfig.meterType = "gas";
+        meterConfig.deviceClass = "gas";
         meterConfig.valueUnit = "m³";
         meterConfig.timeUnit = "h";
         meterConfig.rateUnit = "m³/h";
     }
     else if (_haMeterType == GAS_FT3) {
-        meterConfig.meterType = "gas";
+        meterConfig.deviceClass = "gas";
         meterConfig.valueUnit = "ft³";
         meterConfig.timeUnit = "min";
         meterConfig.rateUnit = "ft³/min";
     }
     else if (_haMeterType == ENERGY_WH) {
-        meterConfig.meterType = "energy";
+        meterConfig.deviceClass = "energy";
         meterConfig.valueUnit = "Wh";
         meterConfig.timeUnit = "h";
         meterConfig.rateUnit = "W";
     }
     else if (_haMeterType == ENERGY_KWH) {
-        meterConfig.meterType = "energy";
+        meterConfig.deviceClass = "energy";
         meterConfig.valueUnit = "kWh";
         meterConfig.timeUnit = "h";
         meterConfig.rateUnit = "kW";
     }
     else if (_haMeterType == ENERGY_MWH) {
-        meterConfig.meterType = "energy";
+        meterConfig.deviceClass = "energy";
         meterConfig.valueUnit = "MWh";
         meterConfig.timeUnit = "h";
         meterConfig.rateUnit = "MW";
     }
     else if (_haMeterType == ENERGY_GJ) {
-        meterConfig.meterType = "energy";
+        meterConfig.deviceClass = "energy";
         meterConfig.valueUnit = "GJ";
         meterConfig.timeUnit = "h";
         meterConfig.rateUnit = "GJ/h"; //  Legacy: Keep, even this is not a valid unit in home assistant
     }
     else if (_haMeterType == TEMPERATURE_C) {
-        meterConfig.meterType = "temperature";
+        meterConfig.deviceClass = "temperature";
         meterConfig.valueUnit = "°C";
         meterConfig.timeUnit = "min";
         meterConfig.rateUnit = "K/min";
     }
     else if (_haMeterType == TEMPERATURE_F) {
-        meterConfig.meterType = "temperature";
+        meterConfig.deviceClass = "temperature";
         meterConfig.valueUnit = "°F";
         meterConfig.timeUnit = "min";
         meterConfig.rateUnit = "K/min";
     }
     else if (_haMeterType == PRESSURE_BAR) {
-        meterConfig.meterType = "pressure";
+        meterConfig.deviceClass = "pressure";
         meterConfig.valueUnit = "bar";
         meterConfig.timeUnit = "min";
         meterConfig.rateUnit = "bar/min";
     }
     else if (_haMeterType == PRESSURE_PSI) {
-        meterConfig.meterType = "pressure";
+        meterConfig.deviceClass = "pressure";
         meterConfig.valueUnit = "psi";
         meterConfig.timeUnit = "min";
         meterConfig.rateUnit = "psi/min";
     }
     else {
-        meterConfig.meterType = "";
+        meterConfig.deviceClass = "";
         meterConfig.valueUnit = "";
         meterConfig.timeUnit = "Unknown";
         meterConfig.rateUnit = "";
@@ -451,7 +451,7 @@ bool mqttServer_publishHADiscovery(int _qos)
     }
 
     LogFile.writeToFile(ESP_LOG_DEBUG, TAG,
-                        "Publish HA discovery | Meter type: " + meterConfig.meterType + ", Value unit: " + meterConfig.valueUnit +
+                        "Publish HA discovery | Meter type: " + meterConfig.deviceClass + ", Value unit: " + meterConfig.valueUnit +
                             " , Rate unit: " + meterConfig.rateUnit);
 
     publishHADiscoveryTopicDeviceInfo = true; // Publish full common device info data only once
@@ -632,20 +632,20 @@ bool mqttServer_publishHADiscovery(int _qos)
         // Device / state class validation
         // Check for valid device class / state class combinations:
         // https://github.com/home-assistant/core/blob/master/homeassistant/components/sensor/const.py
-        if (meterConfig.meterType == "water" || meterConfig.meterType == "gas") {
+        if (meterConfig.deviceClass == "water" || meterConfig.deviceClass == "gas") {
             meterConfig.valueStateClass = sequence->paramPostProc->allowNegativeRate ? "total" : "total_increasing";
 
             // Legacy: L/h and gal/h are not valid units in home assistant: Use device class `None`
             ((meterConfig.rateUnit != "L/h") && (meterConfig.rateUnit != "gal/h")) ? meterConfig.rateDeviceClass = "volume_flow_rate"
                                                                                    : meterConfig.rateDeviceClass = "";
         }
-        else if (meterConfig.meterType == "energy") {
+        else if (meterConfig.deviceClass == "energy") {
             meterConfig.valueStateClass = sequence->paramPostProc->allowNegativeRate ? "total" : "total_increasing";
 
             // Legacy: GJ/h is not a valid unit in home assistant: Use device class `None`
             meterConfig.rateUnit != "GJ/h" ? meterConfig.rateDeviceClass = "power" : meterConfig.rateDeviceClass = "";
         }
-        else if (meterConfig.meterType == "temperature" || meterConfig.meterType == "pressure") {
+        else if (meterConfig.deviceClass == "temperature" || meterConfig.deviceClass == "pressure") {
             meterConfig.valueStateClass = "measurement";
             meterConfig.rateDeviceClass = "";
         }
@@ -663,7 +663,7 @@ bool mqttServer_publishHADiscovery(int _qos)
             .friendlyName = "Actual Value",
             .icon = "gauge",
             .unit = meterConfig.valueUnit,
-            .deviceClass = meterConfig.meterType,
+            .deviceClass = meterConfig.deviceClass,
             .stateClass = meterConfig.valueStateClass //
         };
         publishOK &= publishHADiscoveryTopic(&HADiscoveryData, _qos);
@@ -678,7 +678,7 @@ bool mqttServer_publishHADiscovery(int _qos)
                 .friendlyName = "Fallback Value",
                 .icon = "gauge",
                 .unit = meterConfig.valueUnit,
-                .deviceClass = meterConfig.meterType,
+                .deviceClass = meterConfig.deviceClass,
                 .stateClass = meterConfig.valueStateClass,
                 .entityCategory = "diagnostic" //
             };
@@ -694,7 +694,7 @@ bool mqttServer_publishHADiscovery(int _qos)
             .friendlyName = "Raw Value",
             .icon = "gauge",
             .unit = meterConfig.valueUnit,
-            .deviceClass = meterConfig.meterType,
+            .deviceClass = meterConfig.deviceClass,
             .stateClass = meterConfig.valueStateClass,
             .entityCategory = "diagnostic" //
         };
@@ -735,7 +735,7 @@ bool mqttServer_publishHADiscovery(int _qos)
             .friendlyName = "Rate / Interval (" + to_stringWithPrecision(processingInterval, 1) + "min)",
             .icon = "arrow-expand-vertical",
             .unit = meterConfig.valueUnit,
-            .deviceClass = "", // Special case, not using any common rate unit: Use Device class 'None'
+            .deviceClass = "", // Special case, not using any common rate unit: Use device class 'None'
             .stateClass = "measurement",
             .entityCategory = "diagnostic" //
         };

--- a/code/components/mqtt_ctrl/server_mqtt.h
+++ b/code/components/mqtt_ctrl/server_mqtt.h
@@ -6,6 +6,17 @@
 
 #include "ClassFlowDefineTypes.h"
 #include "ClassFlowMQTT.h"
+#include "configClass.h"
+
+
+struct HAMeterConfig {
+    std::string meterType = "";
+    std::string valueUnit = "";
+    std::string timeUnit = "Unknown";
+    std::string rateUnit = "";
+    std::string valueStateClass = "";
+    std::string rateDeviceClass = "";
+};
 
 
 struct strHADiscoveryData {
@@ -28,8 +39,7 @@ bool mqttServer_publishDeviceStatus(int _qos);
 
 void mqttServer_setParameter(const CfgData::SectionMqtt *_cfgDataPtr, const std::vector<SequenceData *> *_sequenceData,
                              const float _processingInterval);
-void mqttServer_setMeterType(const std::string _meterType, const std::string _valueUnit, const std::string _timeUnit,
-                             const std::string _rateUnit);
+void mqttServer_setHaMeterType(const int _meterType);
 std::string mqttServer_getMainTopic();
 std::string mqttServer_getTimeUnit();
 

--- a/code/components/mqtt_ctrl/server_mqtt.h
+++ b/code/components/mqtt_ctrl/server_mqtt.h
@@ -10,7 +10,7 @@
 
 
 struct HAMeterConfig {
-    std::string meterType = "";
+    std::string deviceClass = "";
     std::string valueUnit = "";
     std::string timeUnit = "Unknown";
     std::string rateUnit = "";

--- a/docs/Configuration/Parameter/MQTT/HomeAssistant_MeterType.md
+++ b/docs/Configuration/Parameter/MQTT/HomeAssistant_MeterType.md
@@ -1,19 +1,20 @@
-# Parameter: Home Assistant Meter Type
+# Parameter: Meter Type
 
 |                   | WebUI               | REST API
 |:---               |:---                 |:----
-| Parameter Name    | Home Assistant Meter Type | metertype
-| Default Value     | `Watermeter (Value: m³, Rate: m³/h)`  | `1`
-| Input Options     | `None (no Units)`<br>`Watermeter (Value: m³, Rate: m³/h)`<br>`Watermeter (Value: l, Rate: l/h)`<br>`Watermeter (Value: gal, Rate: gal/h)`<br>`Watermeter (Value: ft³, Rate: ft³/m)`<br>`Gasmeter (Value: m³, Rate: m³/h)`<br>`Gasmeter (Value: ft³, Rate: ft³/m)`<br>`Energymeter (Value: Wh, Rate: W)`<br>`Energymeter (Value: kWh, Rate: kW)`<br>`Energymeter (Value: MWh, Rate: MW)`<br>`Energymeter (Value: GJ, Rate: GJ/h)` | `0` .. `10`
+| Parameter Name    | Meter Type          | metertype
+| Default Value     | `Water (Value: m³, Rate: m³/h)`  | `1`
+| Input Options     | `Generic (No Units)`<br>`Water (Value: m³, Rate: m³/h)`<br>`Water (Value: L, Rate: L/h*)`<br>`Water (Value: L, Rate: L/min)`<br>`Water (Value: gal, Rate: gal/h*)`<br>`Water (Value: gal, Rate: gal/min)`<br>`Water (Value: ft³, Rate: ft³/min)`<br>`Gas (Value: m³, Rate: m³/h)`<br>`Gas (Value: ft³, Rate: ft³/min)`<br>`Energy (Value: Wh, Rate: W)`<br>`Energy (Value: kWh, Rate: kW)`<br>`Energy (Value: MWh, Rate: MW)`<br>`Energy (Value: GJ, Rate: GJ/h*)`<br>`Temperature (Value: °C, Rate: K/min)`<br>`Temperature (Value: °F, Rate: K/min)`<br>`Pressure (Value: bar, Rate: bar/min)`<br>`Pressure (Value: psi, Rate: psi/min)` | `0` .. `16`
 
 
 ## Description
 
-Select the meter type so the sensors have the right units in Homeassistant.
+Select the meter type to configure the suitable icons / units in Home Assistant.
 
 
 !!! Note
-    Using `Watermeter` Home Assistant 2022.11 or newer is mandatory!
+    Using `Watermeter` Home Assistant 2022.11 or newer is mandatory.<br>
+    * Rate unit is not officially supported in Home Assistant: Use device class `None`
 
 
 !!! Note

--- a/sd-card/html/edit_config_param.html
+++ b/sd-card/html/edit_config_param.html
@@ -1515,17 +1515,23 @@
 					<!--  See https://developers.home-assistant.io/docs/core/entity/sensor/#available-device-classes -->
 					<select class="select_large" name="mqtt.homeassistant.metertype" id="mqtt_homeassistant_metertype_value"
 							onchange="gatherChangedParameter(this.form, true)">
-						<option value="0">None (no Units)</option>
-						<option value="1" selected>Watermeter (Value: m³, Rate: m³/h)</option>
-						<option value="2">Watermeter (Value: l, Rate: l/h)</option>
-						<option value="3">Watermeter (Value: gal, Rate: gal/h)</option>
-						<option value="4">Watermeter (Value: ft³, Rate: ft³/m)</option>
-						<option value="5">Gasmeter (Value: m³, Rate: m³/h)</option>
-						<option value="6">Gasmeter (Value: ft³, Rate: ft³/m)</option>
-						<option value="7">Energymeter (Value: Wh, Rate: W)</option>
-						<option value="8">Energymeter (Value: kWh, Rate: kW)</option>
-						<option value="9">Energymeter (Value: MWh, Rate: MW)</option>
-						<option value="10">Energymeter (Value: GJ, Rate: GJ/h)</option>
+						<option value="0">Generic (No Units)</option>
+						<option value="1" selected>Water (Value: m³, Rate: m³/h)</option>
+						<option value="2">Water (Value: L, Rate: L/h*)</option>
+						<option value="15">Water (Value: L, Rate: L/min)</option>
+						<option value="3">Water (Value: gal, Rate: gal/h*)</option>
+						<option value="16">Water (Value: gal, Rate: gal/min)</option>
+						<option value="4">Water (Value: ft³, Rate: ft³/min)</option>
+						<option value="5">Gas (Value: m³, Rate: m³/h)</option>
+						<option value="6">Gas (Value: ft³, Rate: ft³/min)</option>
+						<option value="7">Energy (Value: Wh, Rate: W)</option>
+						<option value="8">Energy (Value: kWh, Rate: kW)</option>
+						<option value="9">Energy (Value: MWh, Rate: MW)</option>
+						<option value="10">Energy (Value: GJ, Rate: GJ/h*)</option>
+						<option value="11">Temperature (Value: °C, Rate: °C/min)</option>
+						<option value="12">Temperature (Value: °F, Rate: °F/min)</option>
+						<option value="13">Pressure (Value: bar, Rate: bar/min)</option>
+						<option value="14">Pressure (Value: psi, Rate: psi/min)</option>
 					</select>
 				</form>
 			</td>


### PR DESCRIPTION
### BREAKING CHANGES
- Fix Home Assistant warnings due to unit inconsistencies
  - #182 
    --> Usage of correct 'rate per minute' unit of newly introduced device class `volume_flow_rate` ([Home Assistant Release 2024.2.0](https://github.com/home-assistant/core/releases/tag/2024.2.0): [Available Units](https://github.com/home-assistant/core/blob/9dbf84228e0140d70a701b7d75df1da7f87b1d64/homeassistant/components/sensor/const.py#L404)) -->  Rename `XXX/m` to `XXX/min`
  - Rates `L/h` and `gal/h` are no valid units for device class `volume_flow_rate` (Keep rates for backward compability)
    --> Do not set device class for these rates for backward compability and to avoid Home Assitant warning (Device class: `None')
  - Rate `GJ/h` is not a vaild unit for device class `power` (Keep rate for backward compability)
    --> Do not set device class for this rate for backward compability and to avoid Home Assitant warning (Device class: `None')
  - Device classes `water`, `gas` or `energy` + negative rate allowed: Use state class `total` instead of `measurement` for `fallback value` (to be aligned with `actual value` and avoid warning in Home Assistant)
  - `Raw Value`: Do not apply any device class, state class and unit to avoid warning in Home Assistant due to potential conversion issues from string (e.g. `2N234.333`) to float value when using models with `NaN` elements (#234)

### :warning: **Please verify existing Home Assistant device configurations**

---
### Added

- Add temperature (inspired by #3454) and pressure device classes
- Add `L/min` and `gal/min` as new valid `volume_flow_rate` rate units
  --> For new installations please use these units instead of not supported units `L/h` and `gal/h`

---
### Further changes

- Refactor meter type configuration

---
### Usage stats

Before (based on ESP32):
RAM:   [==        ]  15.8% (used 51728 bytes from 327680 bytes)
Flash: [========= ]  86.8% (used 1689502 bytes from 1945600 bytes)

After:
RAM:   [==        ]  15.8% (used 51776 bytes from 327680 bytes)
Flash: [========= ]  86.9% (used 1689794 bytes from 1945600 bytes)