### PR TITLE
chore(submodule): Remove submodule esp-nn

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,6 @@
 [submodule "code/components/esp32-camera"]
 	path = code/components/esp32-camera
 	url = https://github.com/espressif/esp32-camera.git
-[submodule "code/components/esp-nn"]
-	path = code/components/esp-nn
-	url = https://github.com/espressif/esp-nn.git
 [submodule "code/components/esp-tflite-micro"]
 	path = code/components/esp-tflite-micro
 	url = https://github.com/espressif/esp-tflite-micro.git


### PR DESCRIPTION
The code of submodule `esp-nn` is already included in submodule `esp-tflite-micro` therefore it's not required to link as dedicated submodule 

--> Remove submodule `esp-nn`

References: 
- [esp-tflite-micro: readme](https://github.com/espressif/esp-tflite-micro?tab=readme-ov-file#esp-nn-integration)
- [esp-tflite-micro: code location](https://github.com/espressif/esp-tflite-micro/tree/master/tensorflow/lite/micro/kernels/esp_nn)
