### PR TITLE
(home assistant discovery): Show raw value as string

### DIFF
--- a/code/components/mqtt_ctrl/server_mqtt.cpp
+++ b/code/components/mqtt_ctrl/server_mqtt.cpp
@@ -693,9 +693,11 @@ bool mqttServer_publishHADiscovery(int _qos)
             .topicName = "raw_value",
             .friendlyName = "Raw Value",
             .icon = "gauge",
-            .unit = meterConfig.valueUnit,
-            .deviceClass = meterConfig.deviceClass,
-            .stateClass = meterConfig.valueStateClass,
+            // Special case: If value could have 'NaN' parts (e.g. 2N234.333)
+            // --> Use value as string, no long-term statistics possible
+            //.unit = meterConfig.valueUnit,
+            //.deviceClass = meterConfig.deviceClass,
+            //.stateClass = meterConfig.valueStateClass,
             .entityCategory = "diagnostic" //
         };
         publishOK &= publishHADiscoveryTopic(&HADiscoveryData, _qos);
@@ -735,7 +737,8 @@ bool mqttServer_publishHADiscovery(int _qos)
             .friendlyName = "Rate / Interval (" + to_stringWithPrecision(processingInterval, 1) + "min)",
             .icon = "arrow-expand-vertical",
             .unit = meterConfig.valueUnit,
-            .deviceClass = "", // Special case, not using any common rate unit: Use device class 'None'
+            // Special case: This rate is not using any common rate unit
+            //.deviceClass = "", // Use device class 'None'
             .stateClass = "measurement",
             .entityCategory = "diagnostic" //
         };


### PR DESCRIPTION
Raw value might have `NaN` elements included
--> Show raw value as string (do not apply any device class, state class and unit) to avoid warning in Home Assistant due to potential conversion issues from string (e.g. 2N234.333) to float value when using models with NaN elements

Related to #229

---
### Usage Stats

Before (based on ESP32):
RAM:   [==        ]  15.8% (used 51776 bytes from 327680 bytes)
Flash: [========= ]  86.9% (used 1690150 bytes from 1945600 bytes)

After:
RAM:   [==        ]  15.8% (used 51776 bytes from 327680 bytes)
Flash: [========= ]  86.9% (used 1690130 bytes from 1945600 bytes)
