### PR TITLE
feat(hardware): Support Freenove ESP32S3-WROOM board (N8R8)

### DIFF
--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -41,6 +41,7 @@ jobs:
         plat:
          - esp32cam
          - xiao-esp32s3-sense
+         - freenove-esp32s3-n8r8
          - freenove-esp32s3-n16r8
     steps:
     - name: Checkout branch
@@ -173,6 +174,7 @@ jobs:
         plat:
          - esp32cam
          - xiao-esp32s3-sense
+         - freenove-esp32s3-n8r8
          - freenove-esp32s3-n16r8
 
     # Sets permissions of the GITHUB_TOKEN to allow downloading artifacts
@@ -229,6 +231,7 @@ jobs:
         plat:
          - esp32cam
          - xiao-esp32s3-sense
+         - freenove-esp32s3-n8r8
          - freenove-esp32s3-n16r8
 
     # Sets permissions of the GITHUB_TOKEN to allow downloading artifacts
@@ -254,6 +257,7 @@ jobs:
         cd ./artifacts
         ls
         cd ..
+        mkdir -p ./firmware/${{ matrix.plat }}
         cp -f ./artifacts/bootloader.bin ./firmware/${{ matrix.plat }}/bootloader.bin
         cp -f ./artifacts/partitions.bin ./firmware/${{ matrix.plat }}/partitions.bin
         cp -f ./artifacts/firmware.bin ./firmware/${{ matrix.plat }}/firmware.bin

--- a/.github/workflows/update-webinstaller.yaml
+++ b/.github/workflows/update-webinstaller.yaml
@@ -14,6 +14,7 @@ jobs:
         plat:
          - esp32cam
          - xiao-esp32s3-sense
+         - freenove-esp32s3-n8r8
          - freenove-esp32s3-n16r8
 
     # Sets permissions of the GITHUB_TOKEN to allow downloading artifacts
@@ -45,6 +46,7 @@ jobs:
 
         unzip ./artifacts/AI-on-the-edge-device__${{ matrix.plat }}__SLFork_*.zip -d ./artifacts/
 
+        mkdir -p ./firmware/${{ matrix.plat }}
         cp -f ./artifacts/firmware.bin ./firmware/${{ matrix.plat }}/bootloader.bin
         cp -f ./artifacts/partitions.bin ./firmware/${{ matrix.plat }}/partitions.bin
         cp -f ./artifacts/firmware.bin ./firmware/${{ matrix.plat }}/firmware.bin

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ As a result, you get the digitized value of your meter. There are several option
 |:---                                                                            |:---      |:---           |:--- 
 | [ESP32-CAM](http://www.ai-thinker.com/pro_view-24.html)                        | ESP32    | All           |⚠️ Only boards with $\ge$ 4MB RAM are supported<br>⚠️ Beware of inferior quality Chinese clones
 | [XIAO ESP32 Sense](https://www.seeedstudio.com/XIAO-ESP32S3-Sense-p-5639.html) | ESP32S3  | $\ge$ v17.0.0 |⚠️ Running quite hot, a small heat sink is recommended<br>ℹ️ No onboard illumination: External illumination (PWM / SmartLED) required
-| [Freenove ESP32S3-WROOM](https://github.com/Freenove/Freenove_ESP32_S3_WROOM_Board) | ESP32S3-WROOM-1-N16R8<br>ESP32S3-WROOM-1-N8R8 | $\ge$ v17.0.0<br>$\ge$ v17.1.0 |ℹ️ SOC and pin compatible boards with 8MB / 16MB flash and 8MB RAM are supported
+| [Freenove ESP32S3-WROOM](https://github.com/Freenove/Freenove_ESP32_S3_WROOM_Board) | ESP32S3-WROOM-1-N16R8<br><br>ESP32S3-WROOM-1-N8R8 | $\ge$ v17.0.0<br><br>$\ge$ v17.1.0 |ℹ️ SOC and pin compatible boards with 8MB / 16MB flash and 8MB RAM are supported
 
 ### Camera
 | Camera Type                                                                             | Sensor Resolution  | Digital Zoom | Firmware Release | Remarks                       

--- a/README.md
+++ b/README.md
@@ -46,17 +46,17 @@ As a result, you get the digitized value of your meter. There are several option
 ### Board
 | Board Type                                                                     | SOC      | Firmware Release | Remarks                       
 |:---                                                                            |:---      |:---           |:--- 
-| [ESP32-CAM](http://www.ai-thinker.com/pro_view-24.html)                        | ESP32    | All           |⚠️ Only boards with >4MB RAM are supported<br>⚠️ Beware of inferior quality Chinese clones
+| [ESP32-CAM](http://www.ai-thinker.com/pro_view-24.html)                        | ESP32    | All           |⚠️ Only boards with $\ge$ 4MB RAM are supported<br>⚠️ Beware of inferior quality Chinese clones
 | [XIAO ESP32 Sense](https://www.seeedstudio.com/XIAO-ESP32S3-Sense-p-5639.html) | ESP32S3  | $\ge$ v17.0.0 |⚠️ Running quite hot, a small heat sink is recommended<br>ℹ️ No onboard illumination: External illumination (PWM / SmartLED) required
-| [ESP32S3-WROOM](https://github.com/Freenove/Freenove_ESP32_S3_WROOM_Board) | ESP32S3-WROOM-1-N16R8 | $\ge$ v17.0.0 |ℹ️ SOC and pin compatible borads of Freenove ESP32S3-WROOM with 16MB flash and 8MB RAM supported
+| [Freenove ESP32S3-WROOM](https://github.com/Freenove/Freenove_ESP32_S3_WROOM_Board) | ESP32S3-WROOM-1-N16R8<br>ESP32S3-WROOM-1-N8R8 | $\ge$ v17.0.0<br>$\ge$ v17.1.0 |ℹ️ SOC and pin compatible boards with 8MB / 16MB flash and 8MB RAM are supported
 
 ### Camera
 | Camera Type                                                                             | Sensor Resolution  | Digital Zoom | Firmware Release | Remarks                       
 |:---                                                                                     |:---                |:---          |:---              |:--- 
 | [OV2640](https://www.arducam.com/ov2640/)                                               | 2MP                | 1.0x - 2.5x  | All              | ℹ️ Officially EOL since 2009, but still very popular<br>ℹ️ Pin and function compatible Chinese clones are supported
-| [OV5640](https://cdn.sparkfun.com/datasheets/Sensors/LightImaging/OV5640_datasheet.pdf) | 5MP                | 1.0x - 4.0x  | $\ge$ v17.0.0    |ℹ️ Officially EOL since 2019, but still very popular<br>ℹ️ Autofocus is not supported<br>ℹ️ Power consumption higher than OV2640<br>⚠️ Running quite hot, a small heat sink or a reduced camera frequency is recommended<br>⚠️ ESP32-CAM: Camera functional. Deviation of core + I/O voltage supply (board: 1.2V / 3.3V, camera: 1.5V / 2.8V (abs. max. 4.5V)).<br>⚠️ XIAO ESP32S3 Sense: Camera functional. Small deviation of core voltage supply (board: 1.3V, camera: 1.5V)<br>⚠️ Freenove-ESP32S3-WROOM: Camera functional. Deviation of core voltage supply + I/O voltage supply (board: 1.2V / 3.3V, camera: 1.5V / 2.8V).
+| [OV5640](https://cdn.sparkfun.com/datasheets/Sensors/LightImaging/OV5640_datasheet.pdf) | 5MP                | 1.0x - 4.0x  | $\ge$ v17.0.0    |ℹ️ Officially EOL since 2019, but still very popular<br>ℹ️ Autofocus is not supported<br>ℹ️ Power consumption higher than OV2640<br>⚠️ Running quite hot, a small heat sink or a reduced camera frequency (10Mhz) is recommended<br>⚠️ ESP32-CAM: Camera functional. Deviation of core + I/O voltage supply (board: 1.2V / 3.3V, camera: 1.5V / 2.8V (abs. max. 4.5V)).<br>⚠️ XIAO ESP32S3 Sense: Camera functional. Small deviation of core voltage supply (board: 1.3V, camera: 1.5V)<br>⚠️ Freenove-ESP32S3-WROOM: Camera functional. Deviation of core voltage supply + I/O voltage supply (board: 1.2V / 3.3V, camera: 1.5V / 2.8V).
 
-#### Important Note
+#### ⚠️ Important Note
 The camera clock frequency (configurable via WebUI or config file) might have negative impact (interfere with WLAN signal) on wireless network responsiveness (slow loading WebUI, higher latency), especially using low quality boards or boards with onboard antenna. Depending on used hardware combination and WIFI channel, try to find the best camera clock frequency under the evaluation of network responsiveness and resulting image quality.
 
 

--- a/code/include/defines.h
+++ b/code/include/defines.h
@@ -305,6 +305,10 @@ CONFIG_WPA_11R_SUPPORT=n
 #define BOARD_TYPE_NAME    "XIAO-ESP32S3-Sense"     // Keep Board type equal to main board environment name.
                                                     // This is used for OTA update package verification (converted to lower case)
 
+#elif defined(BOARD_FREENOVE_ESP32S3_N8R8)
+#define BOARD_TYPE_NAME     "Freenove-ESP32S3-N8R8" // Keep Board type equal to main board environment name.
+                                                    // This is used for OTA update package verification (converted to lower case)
+
 #elif defined(BOARD_FREENOVE_ESP32S3_N16R8)
 #define BOARD_TYPE_NAME     "Freenove-ESP32S3-N16R8"// Keep Board type equal to main board environment name.
                                                     // This is used for OTA update package verification (converted to lower case)
@@ -518,7 +522,7 @@ CONFIG_WPA_11R_SUPPORT=n
     #define GPIO_SPARE_6                    GPIO_NUM_6
     #define GPIO_SPARE_6_USAGE              "spare"
 
-#elif defined(BOARD_FREENOVE_ESP32S3_N16R8)
+#elif defined(BOARD_FREENOVE_ESP32S3_N8R8) || defined(BOARD_FREENOVE_ESP32S3_N16R8)
     #ifndef BOARD_SDCARD_SDMMC_BUS_WIDTH_1
         #define BOARD_SDCARD_SDMMC_BUS_WIDTH_1              // Only 1 line SD card operation is supported (hardware related)
     #endif

--- a/code/platformio.ini
+++ b/code/platformio.ini
@@ -129,6 +129,49 @@ build_flags =
     -D BOARD_XIAO_ESP32S3
 
 
+
+; #############################################################################
+; Board
+; Freenove ESP32S3-WROOM-1-N8R8 (Freenove original board)
+; #############################################################################
+[env:freenove-esp32s3-n8r8]
+extends = common:esp32-idf
+framework = espidf
+board = freenove_esp32_s3_wroom
+board_build.partitions = partitions_8MB.csv
+board_build.filesystem = fatfs
+build_flags =
+    ; ### common imported :
+    ${common:esp32-idf.build_flags}
+	${flags:runtime.build_flags}
+    ; ### Hardware: Define board type (see 'include/defines.h' for definitions)
+    -D BOARD_FREENOVE_ESP32S3_N8R8
+    ; ### Software modules: Uncomment to disable
+    ;-D ENV_DISABLE_MQTT
+    ;-D ENV_DISABLE_INFLUXDB
+    ;-D ENV_DISABLE_WEBHOOK
+monitor_speed = 115200
+monitor_filters = default, esp32_exception_decoder
+
+
+; +++++++++++++++++++++++++++++++++++++++++++
+; Use this environment if building locally
+; Include parameter tooltips to HTML parameter config file
+; and hash to HTML files (caching)
+; +++++++++++++++++++++++++++++++++++++++++++
+[env:freenove-esp32s3-n8r8-localbuild]
+extends = env:freenove-esp32s3-n8r8
+extra_scripts = post:scripts/localbuild.py # Add parameter tooltips to HTML page
+                                           # and hashes to all cached HTML files
+build_flags =
+    ; ### common imported :
+    ${common:esp32-idf.build_flags}
+	${flags:runtime.build_flags}
+    ; ### Hardware: Define board type (see 'include/defines.h' for definitions)
+    -D BOARD_FREENOVE_ESP32S3_N8R8
+
+
+
 ; #############################################################################
 ; Board
 ; Freenove ESP32S3-WROOM-1-N16R8 (Freenove pin compatible clones)

--- a/code/sdkconfig.freenove-esp32s3-n8r8.defaults
+++ b/code/sdkconfig.freenove-esp32s3-n8r8.defaults
@@ -1,0 +1,44 @@
+##################################################
+# Application and board specific configuration
+# Edit this file instead of sdkconfig.{board_type}!
+# After editing make sure to explicitly delete
+# sdkconfig.{board_type} to apply your changes!
+##################################################
+
+#
+# Serial flasher config
+#
+CONFIG_ESPTOOLPY_FLASHSIZE_8MB=y
+CONFIG_ESPTOOLPY_FLASHSIZE="8MB"
+CONFIG_ESPTOOLPY_FLASHSIZE_DETECT=y
+
+
+#
+# Partition Table
+#
+CONFIG_PARTITION_TABLE_CUSTOM=y
+CONFIG_PARTITION_TABLE_CUSTOM_FILENAME="partitions_8MB.csv"
+CONFIG_PARTITION_TABLE_OFFSET=0x8000
+CONFIG_PARTITION_TABLE_MD5=y
+
+
+#
+# Common ESP-related
+#
+CONFIG_ESP_ERR_TO_NAME_LOOKUP=n
+CONFIG_ESP_ALLOW_BSS_SEG_EXTERNAL_MEMORY=n
+
+
+#
+# SPI RAM config
+#
+CONFIG_SPIRAM_MODE_OCT=y
+CONFIG_SPIRAM_SPEED_80M=y
+CONFIG_SPIRAM_BOOT_INIT=y
+CONFIG_SPIRAM_USE_MALLOC=y
+CONFIG_SPIRAM_MEMTEST=y
+CONFIG_SPIRAM_MALLOC_ALWAYSINTERNAL=8192
+CONFIG_SPIRAM_MALLOC_RESERVE_INTERNAL=131072
+CONFIG_SPIRAM_IGNORE_NOTFOUND=y
+CONFIG_SPIRAM_ALLOW_BSS_SEG_EXTERNAL_MEMORY=n
+CONFIG_SPIRAM_ALLOW_STACK_EXTERNAL_MEMORY=n

--- a/docs/Installation/DeviceProvisioning/AccessPoint.md
+++ b/docs/Installation/DeviceProvisioning/AccessPoint.md
@@ -1,7 +1,7 @@
 ## Device Provisioning
 
 ### Access Point
-1. Connect to device's WLAN access point `AI-on-the-Edge` (WLAN Channel 11 | Open Network | DHCP Server enabled)
+1. Insert formated SD card and power pre-flashed device. Connect to device's WLAN access point `AI-on-the-Edge` (WLAN Channel 11 | Open Network | DHCP Server enabled)
 
 2. Browse to http://192.168.4.1 and follow the instructions<br>
 2.1. Provide WLAN configuration and credentials<br>
@@ -18,4 +18,4 @@ Please follow the instruction of 'Inital Setup Wizard':
 <img src="../../../images/initial_setup_wizard.jpg">
 
 Compare also [jomjol documentation](https://jomjol.github.io/AI-on-the-edge-device-docs/Installation/#remote-setup-using-the-built-in-access-point).
-:warning: Be aware, not all content is 
+Be aware, not all content is suitable for this fork.

--- a/docs/Installation/DeviceProvisioning/Manual.md
+++ b/docs/Installation/DeviceProvisioning/Manual.md
@@ -12,7 +12,7 @@ There are different ways to flash the microcontroller:
 - [Espressif Flash Tool](https://www.espressif.com/sites/default/files/tools/flash_download_tool_3.9.5.zip)<br>
 - [ESPtool (command-line tool)](https://docs.espressif.com/projects/esptool/en/latest/esp32/esptool/index.html)
 
-Check readme file in firmware package and [jomjol documentation](https://jomjol.github.io/AI-on-the-edge-device-docs/Installation/#manual-flashing) for further details.
+Check readme file in firmware zip package for further details.
 
 
 #### Step 2: Installation Of SD Card Content

--- a/docs/Installation/DeviceProvisioning/WebInstaller.md
+++ b/docs/Installation/DeviceProvisioning/WebInstaller.md
@@ -1,7 +1,7 @@
 ## Device Provisioning
 
 ### Web Installer
-Please follow the instructions mentioned here:
+Please follow the instructions mentioned here:<br>
 <img src="../../../images/webinstaller_home.jpg">
 
 #### Workflow Step 2: Initial connection to flash firmware
@@ -23,5 +23,5 @@ Please follow the instructions mentioned here:
 <img src="../../../images/webinstaller_install_sdcard_content.jpg">
 
 #### Workflow Step 8:
-Please follow the instruction of 'Inital Setup Wizard':
+Please follow the instruction of 'Inital Setup Wizard':<br>
 <img src="../../../images/initial_setup_wizard.jpg">

--- a/docs/Installation/DeviceReadme/freenove-esp32s3-n8r8.md
+++ b/docs/Installation/DeviceReadme/freenove-esp32s3-n8r8.md
@@ -1,0 +1,54 @@
+# Firmware Installation (Freenove ESP32S3 N8R8)
+
+## Manual Firmware Installation / Update
+
+  ### 1. Flash microcontroller content (ESP32S3 based microcontroller)
+
+   - Put your board into bootloader mode (IO0 grounded + board reset)
+   - Use port labeld with `USB-OTG`
+   - Three files to be flashed with correct flash offset
+
+      | Filename          | Offset      | Description
+      |:------------------|:------------|:------
+      | bootloader.bin    | 0x0         | Bootloader
+      | partitions.bin    | 0x8000      | Partition table
+      | firmware.bin      | 0x10000     | User application
+  
+  - Use `Flash Download Tool` from Espressif or the console-based `esptool` to flash the files.
+  Usage is described [here](https://jomjol.github.io/AI-on-the-edge-device-docs/Installation/#flashing-using-the-flash-tool-from-espressif-gui).
+
+
+  ### 2. Prepare SD Card
+  - Format SD card with FAT32 (Windows recommenend. In MacOS formated cards could not working properly)
+  - Copy folders `/config` and `/html` from zip file to SD card root folder
+
+
+  ### 3. Configure WLAN
+
+  #### Modify content directly in config file
+    Use config.json template from `sdcard/config/template` folder, copy it to 
+    `sdcard/config` folder and to configure your wlan connection.<br>
+    Note 1: If device is already booted once, a full config with default configuration is already sitting in `/config` folder. 
+    You can also use this file, search for section network and adapt the wlan config there.
+    Note 2: Be careful with syntax. Messing up the JSON notation, config is getting rejected.
+
+
+## Alternative Provisioning Options
+
+### Device Provisioning via Web Installer
+
+ Usage is decribed [here](https://github.com/Slider0007/AI-on-the-edge-device/blob/develop/docs/Installation/DeviceProvisioning/WebInstaller.md).
+
+
+### Device Provisioning via Access Point
+
+ Usage is decribed [here](https://github.com/Slider0007/AI-on-the-edge-device/blob/develop/docs/Installation/DeviceProvisioning/AccessPoint.md).
+
+
+### Firmware Update via OTA (Over-The-Air)
+
+  Note: This option is only available after initial installation was successful and regular device web interface is accessible.
+
+  Select firmware package zip from github repository in WebUI OTA Updater page. 
+  The device is getting updated automatically. The existing configuration will not be overwritten.
+


### PR DESCRIPTION
### Add support for Freenove ESP32S3-WROOM board (N8R8)

Implementation suitable for official board with 8MB flash and 8MB RAM using module `ESP32-S3-WROOM-1-N8R8`:
- [Freenove ESP32-S3-WROOM CAM Board](https://store.freenove.com/products/fnk0085)

#### Flashlight Configuration
- Default flashlight pin configuration: GPIO48 (WS2812)
- Flashlight configuration can be adapted via WebUI -> `Settings > Configuration > GPIO section`

---
### Build
- Update build pipeline to support new board
- Use build zip packages suitable for this hardware:
  -> Generic syntax: AI-on-the-edge-device__**{board type}**__xxx.zip
  -> Example: AI-on-the-edge-device__freenove_esp32s3_n8r8__xxx.zip

---
### Usage stats

Before (based on ESP32):
RAM:   [==        ]  15.8% (used 51776 bytes from 327680 bytes)
Flash: [========= ]  86.9% (used 1690138 bytes from 1945600 bytes)

After:
RAM:   [==        ]  15.8% (used 51776 bytes from 327680 bytes)
Flash: [========= ]  86.9% (used 1690138 bytes from 1945600 bytes)