### PR TITLE
refactor(cnn handling): Refactor classes `ClassFlowCNNGeneral` and `CTfLite`

### DIFF
--- a/code/components/config_handling/cfgDataStruct.h
+++ b/code/components/config_handling/cfgDataStruct.h
@@ -268,7 +268,7 @@ struct CfgData {
     struct SectionDigit {
         bool enabled = true;
         std::string model = "dig-class100_0173_s2_q.tflite"; // with extention, but without path
-        float cnnGoodThreshold = 0.0;
+        float cnnGoodThreshold = 0.50;
         std::vector<RoiPerSequence> sequence;
         struct Debug {
             bool saveRoiImages = false;

--- a/code/components/mainprocess_ctrl/ClassFlowCNNGeneral.cpp
+++ b/code/components/mainprocess_ctrl/ClassFlowCNNGeneral.cpp
@@ -385,7 +385,7 @@ bool ClassFlowCNNGeneral::doInvokeCnn(const std::string time)
 }
 
 
-std::string ClassFlowCNNGeneral::getReadout(SequenceData *sequence, int valuePreviousNumber, int resultPreviousNumber)
+std::string ClassFlowCNNGeneral::getReadout(SequenceData *sequence, int valuePreviousNumber, int resultPreviousNumber) const
 {
     LogFile.writeToFile(ESP_LOG_DEBUG, TAG,
                         "getReadout: Number sequence: " + sequence->sequenceName +
@@ -519,7 +519,7 @@ std::string ClassFlowCNNGeneral::getReadout(SequenceData *sequence, int valuePre
 
 
 /* Evaluate analog number pointer */
-int ClassFlowCNNGeneral::evalAnalogNumber(int _value, int _resultPreviousNumber)
+int ClassFlowCNNGeneral::evalAnalogNumber(int _value, int _resultPreviousNumber) const
 {
     int result = -1;
 
@@ -570,7 +570,7 @@ int ClassFlowCNNGeneral::evalAnalogNumber(int _value, int _resultPreviousNumber)
 
 /* Evaluate digit number */
 int ClassFlowCNNGeneral::evalDigitNumber(int _value, int _valuePreviousNumber, int _resultPreviousNumber, bool _isPreviousAnalog,
-                                         int digitalAnalogTransitionStart)
+                                         int digitalAnalogTransitionStart) const
 {
     int result = -1;
     int resultIntergerPart = _value / 10;
@@ -679,7 +679,7 @@ int ClassFlowCNNGeneral::evalDigitNumber(int _value, int _valuePreviousNumber, i
 
 /* Evaluate analog to digit number transition */
 int ClassFlowCNNGeneral::evalAnalogToDigitTransition(int _value, int _valuePreviousNumber, int _resultPreviousNumber,
-                                                     int analogDigitSyncValue)
+                                                     int analogDigitSyncValue) const
 {
     int result = -1;
     int resultIntergerPart = _value / 10;

--- a/code/components/mainprocess_ctrl/ClassFlowCNNGeneral.cpp
+++ b/code/components/mainprocess_ctrl/ClassFlowCNNGeneral.cpp
@@ -16,18 +16,16 @@
 static const char *TAG = "CNN";
 
 
-ClassFlowCNNGeneral::ClassFlowCNNGeneral(ClassFlowAlignment *_flowalignment, const std::string _cnnname, const CNNType _cnntype)
-    : ClassLogImage(TAG)
+ClassFlowCNNGeneral::ClassFlowCNNGeneral(ClassFlowAlignment *_flowAlignment, std::string _cnnName, CNNType _cnnType) : ClassLogImage(TAG)
 {
-    flowalignment = _flowalignment;
-    cnnname = _cnnname;
-    cnnType = _cnntype;
+    flowAlignment = _flowAlignment;
+    cnnName = _cnnName;
+    cnnType = _cnnType;
     tflite = new CTfLiteClass;
-    cnnmodelfile = "";
-    modelxsize = 32;
-    modelysize = 32;
-    modelchannel = STBI_rgb;
-    CNNGoodThreshold = 0.50;
+    modelWidth = 32;
+    modelHeight = 32;
+    modelChannel = STBI_rgb;
+    cnnGoodThreshold = 0.50;
     saveAllFiles = false;
     presetFlowStateHandler(true);
 }
@@ -56,18 +54,18 @@ bool roiPositionPlausibilityCheck(RoiData *roiEl)
 
 bool ClassFlowCNNGeneral::loadParameter()
 {
-    if (cnnname != "Digit" && cnnname != "Analog") {
+    if (cnnName != "Digit" && cnnName != "Analog") {
         LogFile.writeToFile(ESP_LOG_ERROR, TAG, "Unknown CNN class name");
         return false;
     }
 
-    // Assign pointers based on cnnname
-    const bool isDigit = (cnnname == "Digit");
+    // Assign pointers based on cnnName
+    const bool isDigit = (cnnName == "Digit");
     sectionDigitPtr = isDigit ? &ConfigClass::getInstance()->get()->sectionDigit : nullptr;
     sectionAnalogPtr = !isDigit ? &ConfigClass::getInstance()->get()->sectionAnalog : nullptr;
 
-    cnnmodelfile = "/sdcard/config/models/" + (isDigit ? sectionDigitPtr->model : sectionAnalogPtr->model);
-    CNNGoodThreshold = isDigit ? sectionDigitPtr->cnnGoodThreshold : 0.0;
+    cnnModelFile = "/sdcard/config/models/" + (isDigit ? sectionDigitPtr->model : sectionAnalogPtr->model);
+    cnnGoodThreshold = isDigit ? sectionDigitPtr->cnnGoodThreshold : 0.0;
 
     saveImagesEnabled = isDigit ? sectionDigitPtr->debug.saveRoiImages : sectionAnalogPtr->debug.saveRoiImages;
     imagesLocation = "/sdcard" + (isDigit ? sectionDigitPtr->debug.roiImagesLocation : sectionAnalogPtr->debug.roiImagesLocation);
@@ -106,7 +104,7 @@ bool ClassFlowCNNGeneral::loadParameter()
         const auto &roiList = sectionDigitPtr ? sequence->digitRoi : sequence->analogRoi;
 
         for (const auto &roi : roiList) {
-            roi->imageRoiResized = new CImageBasis(roi->param->roiName, modelxsize, modelysize, modelchannel);
+            roi->imageRoiResized = new CImageBasis(roi->param->roiName, modelWidth, modelHeight, modelChannel);
             roi->imageRoi = new CImageBasis(roi->param->roiName + "_org", roi->param->dx, roi->param->dy, STBI_rgb);
         }
     }
@@ -143,7 +141,7 @@ void ClassFlowCNNGeneral::doPostProcessEventHandling()
 
 bool ClassFlowCNNGeneral::doExtractRoi(const std::string time)
 {
-    CAlignAndCutImage *caic = flowalignment->getAlignAndCutImage();
+    CAlignAndCutImage *caic = flowAlignment->getAlignAndCutImage();
 
     if (caic == NULL) {
         LogFile.writeToFile(ESP_LOG_ERROR, TAG, "doAlignAndCut: Aligned image not available");
@@ -160,7 +158,7 @@ bool ClassFlowCNNGeneral::doExtractRoi(const std::string time)
                 roi->imageRoi->saveToFile(formatFileName("/sdcard/img_tmp/" + roi->param->roiName + "_org.jpg"));
             }
 
-            roi->imageRoi->resizeImage(modelxsize, modelysize, roi->imageRoiResized);
+            roi->imageRoi->resizeImage(modelWidth, modelHeight, roi->imageRoiResized);
 
             if (saveAllFiles) {
                 roi->imageRoiResized->saveToFile(formatFileName("/sdcard/img_tmp/" + roi->param->roiName + ".jpg"));
@@ -174,8 +172,8 @@ bool ClassFlowCNNGeneral::doExtractRoi(const std::string time)
 
 bool ClassFlowCNNGeneral::resolveNetworkParameter()
 {
-    if (!tflite->loadModel(formatFileName(cnnmodelfile))) {
-        LogFile.writeToFile(ESP_LOG_ERROR, TAG, "TFLite: Failed to load model: " + cnnmodelfile);
+    if (!tflite->loadModel(formatFileName(cnnModelFile))) {
+        LogFile.writeToFile(ESP_LOG_ERROR, TAG, "TFLite: Failed to load model: " + cnnModelFile);
         LogFile.writeHeapInfo("resolveNetworkParameter-LoadModel");
         return false;
     }
@@ -192,9 +190,9 @@ bool ClassFlowCNNGeneral::resolveNetworkParameter()
             return false;
         }
 
-        modelxsize = tflite->getInputDimension(0);
-        modelysize = tflite->getInputDimension(1);
-        modelchannel = tflite->getInputDimension(2);
+        modelWidth = tflite->getInputDimension(0);
+        modelHeight = tflite->getInputDimension(1);
+        modelChannel = tflite->getInputDimension(2);
 
         int outputDims = tflite->getOutputDimension();
         if (outputDims == -1) {
@@ -219,7 +217,7 @@ bool ClassFlowCNNGeneral::resolveNetworkParameter()
                 break;
 
             case 100:
-                cnnType = (modelxsize == 32 && modelysize == 32) ? CNNTYPE_ANALOG_CLASS100 : CNNTYPE_DIGIT_CLASS100;
+                cnnType = (modelWidth == 32 && modelHeight == 32) ? CNNTYPE_ANALOG_CLASS100 : CNNTYPE_DIGIT_CLASS100;
                 LogFile.writeToFile(ESP_LOG_DEBUG, TAG,
                                     "Type: " + std::string((cnnType == CNNTYPE_ANALOG_CLASS100) ? "Analog (ana-class100)"
                                                                                                 : "Digit (dig-class100)"));
@@ -231,7 +229,7 @@ bool ClassFlowCNNGeneral::resolveNetworkParameter()
         }
     }
 
-    LogFile.writeToFile(ESP_LOG_INFO, TAG, "Network parameter loaded: " + cnnmodelfile);
+    LogFile.writeToFile(ESP_LOG_INFO, TAG, "Network parameter loaded: " + cnnModelFile);
 
     tflite->deleteInterpreter();
 
@@ -313,7 +311,7 @@ bool ClassFlowCNNGeneral::doInvokeCnn(const std::string time)
                     roi->CNNResult = (int)std::clamp(result * 10.0f, 0.0f, 99.0f);
                     roi->sCNNResult = to_stringWithPrecision(roi->CNNResult / 10.0, 1);
 
-                    roi->isRejected = (fit < CNNGoodThreshold);
+                    roi->isRejected = (fit < cnnGoodThreshold);
                     logImageResult = roi->isRejected ? -roi->CNNResult : roi->CNNResult;
 
 #ifdef DEBUG_DETAIL_ON
@@ -327,7 +325,7 @@ bool ClassFlowCNNGeneral::doInvokeCnn(const std::string time)
                     if (roi->isRejected) {
                         LogFile.writeToFile(ESP_LOG_WARN, TAG,
                                             "Result rejected - bad fit (Fit: " + std::to_string(fit) +
-                                                ", Threshold: " + std::to_string(CNNGoodThreshold) + ")");
+                                                ", Threshold: " + std::to_string(cnnGoodThreshold) + ")");
                     }
 
                     break;
@@ -743,7 +741,7 @@ bool ClassFlowCNNGeneral::cnnTypeAllowExtendedResolution() const
 
 void ClassFlowCNNGeneral::drawROI(CImageBasis *image)
 {
-    if (!image->imageOkay()) {
+    if (!image || !image->imageOkay()) {
         LogFile.writeToFile(ESP_LOG_ERROR, TAG, "drawROI: Invalid image");
         return;
     }

--- a/code/components/mainprocess_ctrl/ClassFlowCNNGeneral.cpp
+++ b/code/components/mainprocess_ctrl/ClassFlowCNNGeneral.cpp
@@ -762,19 +762,19 @@ void ClassFlowCNNGeneral::drawROI(CImageBasis *image)
         const auto &color = colors[colorIndex % colors.size()];
 
         for (const auto &roi : roiList) {
-            if (cnnType == CNNTYPE_ANALOG_CONT || cnnType == CNNTYPE_ANALOG_CLASS100) {
-                // image->drawRect(roi->param->x, roi->param->y, roi->param->dx, roi->param->dy, color[0], color[1], color[2], 1);
-                image->drawEllipse((int)(roi->param->x + roi->param->dx / 2), (int)(roi->param->y + roi->param->dy / 2),
-                                   (int)(roi->param->dx / 2), (int)(roi->param->dy / 2), color[0], color[1], color[2], 2);
-                image->drawLine((int)(roi->param->x + roi->param->dx / 2), (int)roi->param->y, (int)(roi->param->x + roi->param->dx / 2),
-                                (int)(roi->param->y + roi->param->dy), color[0], color[1], color[2], 2);
-                image->drawLine((int)roi->param->x, (int)(roi->param->y + roi->param->dy / 2), (int)roi->param->x + roi->param->dx,
-                                (int)(roi->param->y + roi->param->dy / 2), color[0], color[1], color[2], 2);
+            if (cnnType == CNNTYPE_ANALOG_CLASS100 || cnnType == CNNTYPE_ANALOG_CONT) {
+                image->drawEllipse(roi->param->x + roi->param->dx / 2, roi->param->y + roi->param->dy / 2, roi->param->dx / 2,
+                                   roi->param->dy / 2, color[0], color[1], color[2], 2);
+                image->drawLine(roi->param->x + roi->param->dx / 2, roi->param->y, roi->param->x + roi->param->dx / 2,
+                                roi->param->y + roi->param->dy, color[0], color[1], color[2], 2);
+                image->drawLine(roi->param->x, roi->param->y + roi->param->dy / 2, roi->param->x + roi->param->dx,
+                                roi->param->y + roi->param->dy / 2, color[0], color[1], color[2], 2);
             }
             else {
                 image->drawRect(roi->param->x, roi->param->y, roi->param->dx, roi->param->dy, color[0], color[1], color[2], 2);
             }
         }
+        colorIndex++;
     }
 }
 

--- a/code/components/mainprocess_ctrl/ClassFlowCNNGeneral.cpp
+++ b/code/components/mainprocess_ctrl/ClassFlowCNNGeneral.cpp
@@ -16,9 +16,9 @@
 static const char *TAG = "CNN";
 
 
-ClassFlowCNNGeneral::ClassFlowCNNGeneral(ClassFlowAlignment *_flowalignment, std::string _cnnname, CNNType _cnntype) : ClassLogImage(TAG)
+ClassFlowCNNGeneral::ClassFlowCNNGeneral(ClassFlowAlignment *_flowalignment, const std::string _cnnname, const CNNType _cnntype)
+    : ClassLogImage(TAG)
 {
-    presetFlowStateHandler(true);
     flowalignment = _flowalignment;
     cnnname = _cnnname;
     cnnType = _cnntype;
@@ -27,16 +27,17 @@ ClassFlowCNNGeneral::ClassFlowCNNGeneral(ClassFlowAlignment *_flowalignment, std
     modelxsize = 32;
     modelysize = 32;
     modelchannel = STBI_rgb;
-    CNNGoodThreshold = 0.0;
+    CNNGoodThreshold = 0.50;
     saveAllFiles = false;
+    presetFlowStateHandler(true);
 }
 
 
 bool roiPositionPlausibilityCheck(RoiData *roiEl)
 {
     // ROI position plausibilty check
-    int imgWidth = 640;
-    int imgHeight = 480;
+    int imgWidth = CAMERA_OUTPUT_WINDOW_SIZE_WIDTH;
+    int imgHeight = CAMERA_OUTPUT_WINDOW_SIZE_HEIGHT;
     cameraCtrl.getOutputFrameSize(imgWidth, imgHeight);
 
     if (roiEl->param->x < 1 || (roiEl->param->x > (imgWidth - 1 - roiEl->param->dx))) {
@@ -52,69 +53,47 @@ bool roiPositionPlausibilityCheck(RoiData *roiEl)
     return true;
 }
 
+
 bool ClassFlowCNNGeneral::loadParameter()
 {
     if (cnnname != "Digit" && cnnname != "Analog") {
-        LogFile.writeToFile(ESP_LOG_ERROR, TAG, "Unkown CNN class name");
+        LogFile.writeToFile(ESP_LOG_ERROR, TAG, "Unknown CNN class name");
         return false;
     }
 
-    // Prepare internal sequence data struct (class instance related helper)
-    for (const auto &sequence : sequenceData) {
-        SequenceDataInternal *sequenceInternal = new SequenceDataInternal{};
-        sequenceInternal->sequenceId = sequence->sequenceId;
-        sequenceInternal->sequenceName = sequence->sequenceName;
-        sequenceDataInternal.push_back(sequenceInternal);
-    }
+    // Assign pointers based on cnnname
+    const bool isDigit = (cnnname == "Digit");
+    sectionDigitPtr = isDigit ? &ConfigClass::getInstance()->get()->sectionDigit : nullptr;
+    sectionAnalogPtr = !isDigit ? &ConfigClass::getInstance()->get()->sectionAnalog : nullptr;
 
-    if (cnnname == "Digit") {
-        cnnmodelfile = "/sdcard/config/models/" + ConfigClass::getInstance()->get()->sectionDigit.model;
-        CNNGoodThreshold = ConfigClass::getInstance()->get()->sectionDigit.cnnGoodThreshold;
+    cnnmodelfile = "/sdcard/config/models/" + (isDigit ? sectionDigitPtr->model : sectionAnalogPtr->model);
+    CNNGoodThreshold = isDigit ? sectionDigitPtr->cnnGoodThreshold : 0.0;
 
-        saveImagesEnabled = ConfigClass::getInstance()->get()->sectionDigit.debug.saveRoiImages;
-        imagesLocation = "/sdcard" + ConfigClass::getInstance()->get()->sectionDigit.debug.roiImagesLocation;
-        imagesRetention = ConfigClass::getInstance()->get()->sectionDigit.debug.roiImagesRetention;
-        saveAllFiles = ConfigClass::getInstance()->get()->sectionDigit.debug.saveAllFiles;
+    saveImagesEnabled = isDigit ? sectionDigitPtr->debug.saveRoiImages : sectionAnalogPtr->debug.saveRoiImages;
+    imagesLocation = "/sdcard" + (isDigit ? sectionDigitPtr->debug.roiImagesLocation : sectionAnalogPtr->debug.roiImagesLocation);
+    imagesRetention = isDigit ? sectionDigitPtr->debug.roiImagesRetention : sectionAnalogPtr->debug.roiImagesRetention;
+    saveAllFiles = isDigit ? sectionDigitPtr->debug.saveAllFiles : sectionAnalogPtr->debug.saveAllFiles;
 
-        for (int i = 0; i < ConfigClass::getInstance()->get()->sectionDigit.sequence.size(); i++) {
-            for (int j = 0; j < ConfigClass::getInstance()->get()->sectionDigit.sequence[i].roi.size(); j++) {
-                RoiData *roiEl = new RoiData{};
-                roiEl->param = &ConfigClass::getInstance()->get()->sectionDigit.sequence[i].roi[j];
-
-                if (!roiPositionPlausibilityCheck(roiEl)) {
-                    return false;
-                }
-
-                if (i < sequenceData.size()) {
-                    sequenceData[i]->digitRoi.push_back(roiEl);
-                    // Fill internal struct as well to make class internal processing independent of source (digit or analog)
-                    sequenceDataInternal[i]->roiData.push_back(roiEl);
-                }
-            }
+    const auto &sequences = isDigit ? sectionDigitPtr->sequence : sectionAnalogPtr->sequence;
+    for (size_t i = 0; i < sequences.size(); i++) {
+        if (i >= sequenceData.size()) {
+            LogFile.writeToFile(ESP_LOG_ERROR, TAG, "Invalid sequence index");
+            return false;
         }
-    }
-    else if (cnnname == "Analog") {
-        cnnmodelfile = "/sdcard/config/models/" + ConfigClass::getInstance()->get()->sectionAnalog.model;
 
-        saveImagesEnabled = ConfigClass::getInstance()->get()->sectionAnalog.debug.saveRoiImages;
-        imagesLocation = "/sdcard" + ConfigClass::getInstance()->get()->sectionAnalog.debug.roiImagesLocation;
-        imagesRetention = ConfigClass::getInstance()->get()->sectionAnalog.debug.roiImagesRetention;
-        saveAllFiles = ConfigClass::getInstance()->get()->sectionDigit.debug.saveAllFiles;
+        for (size_t j = 0; j < sequences[i].roi.size(); j++) {
+            auto *roiEl = new RoiData{};
+            roiEl->param = &sequences[i].roi[j];
 
-        for (int i = 0; i < ConfigClass::getInstance()->get()->sectionAnalog.sequence.size(); i++) {
-            for (int j = 0; j < ConfigClass::getInstance()->get()->sectionAnalog.sequence[i].roi.size(); j++) {
-                RoiData *roiEl = new RoiData{};
-                roiEl->param = &ConfigClass::getInstance()->get()->sectionAnalog.sequence[i].roi[j];
+            if (!roiPositionPlausibilityCheck(roiEl)) {
+                return false;
+            }
 
-                if (!roiPositionPlausibilityCheck(roiEl)) {
-                    return false;
-                }
-
-                if (i < sequenceData.size()) {
-                    sequenceData[i]->analogRoi.push_back(roiEl);
-                    // Fill internal struct as well to make class internal processing independent of source (digit or analog)
-                    sequenceDataInternal[i]->roiData.push_back(roiEl);
-                }
+            if (isDigit) {
+                sequenceData[i]->digitRoi.push_back(roiEl);
+            }
+            else {
+                sequenceData[i]->analogRoi.push_back(roiEl);
             }
         }
     }
@@ -123,23 +102,13 @@ bool ClassFlowCNNGeneral::loadParameter()
         return false;
     }
 
-    for (int i = 0; auto &sequence : sequenceDataInternal) {
-        for (int j = 0; auto &roi : sequence->roiData) {
+    for (const auto &sequence : sequenceData) {
+        const auto &roiList = sectionDigitPtr ? sequence->digitRoi : sequence->analogRoi;
+
+        for (const auto &roi : roiList) {
             roi->imageRoiResized = new CImageBasis(roi->param->roiName, modelxsize, modelysize, modelchannel);
             roi->imageRoi = new CImageBasis(roi->param->roiName + "_org", roi->param->dx, roi->param->dy, STBI_rgb);
-
-            // Set image pointer in global struct as well
-            if (cnnname == "Digit") {
-                sequenceData[i]->digitRoi[j]->imageRoiResized = roi->imageRoiResized;
-                sequenceData[i]->digitRoi[j]->imageRoi = roi->imageRoi;
-            }
-            else if (cnnname == "Analog") {
-                sequenceData[i]->analogRoi[j]->imageRoiResized = roi->imageRoiResized;
-                sequenceData[i]->analogRoi[j]->imageRoi = roi->imageRoi;
-            }
-            j++;
         }
-        i++;
     }
 
     return true;
@@ -151,22 +120,18 @@ bool ClassFlowCNNGeneral::doFlow(std::string time)
     presetFlowStateHandler(false, time);
 
     LogFile.writeToFile(ESP_LOG_DEBUG, TAG, "Process ROI extraction");
-    if (!doAlignAndCut(time)) {
+    if (!doExtractRoi(time)) {
         return false;
     }
 
     LogFile.writeToFile(ESP_LOG_DEBUG, TAG, "Process neural network");
-    if (!doNeuralNetwork(time)) {
+    if (!doInvokeCnn(time)) {
         return false;
     }
 
     removeOldLogs();
 
-    if (!getFlowState()->isSuccessful) {
-        return false;
-    }
-
-    return true;
+    return getFlowState()->isSuccessful;
 }
 
 
@@ -176,7 +141,7 @@ void ClassFlowCNNGeneral::doPostProcessEventHandling()
 }
 
 
-bool ClassFlowCNNGeneral::doAlignAndCut(std::string time)
+bool ClassFlowCNNGeneral::doExtractRoi(const std::string time)
 {
     CAlignAndCutImage *caic = flowalignment->getAlignAndCutImage();
 
@@ -185,8 +150,10 @@ bool ClassFlowCNNGeneral::doAlignAndCut(std::string time)
         return false;
     }
 
-    for (auto &sequence : sequenceDataInternal) {
-        for (auto &roi : sequence->roiData) {
+    for (const auto &sequence : sequenceData) {
+        const auto &roiList = sectionDigitPtr ? sequence->digitRoi : sequence->analogRoi;
+
+        for (const auto &roi : roiList) {
             caic->cutAndSaveImage(roi->param->x, roi->param->y, roi->param->dx, roi->param->dy, roi->imageRoi);
 
             if (saveAllFiles) {
@@ -207,277 +174,215 @@ bool ClassFlowCNNGeneral::doAlignAndCut(std::string time)
 
 bool ClassFlowCNNGeneral::resolveNetworkParameter()
 {
-    if (!tflite->LoadModel(formatFileName(cnnmodelfile))) {
-        LogFile.writeToFile(ESP_LOG_ERROR, TAG, "TFLITE: Failed to load model: " + cnnmodelfile);
-        LogFile.writeHeapInfo("getNetworkParameter-LoadModel");
+    if (!tflite->loadModel(formatFileName(cnnmodelfile))) {
+        LogFile.writeToFile(ESP_LOG_ERROR, TAG, "TFLite: Failed to load model: " + cnnmodelfile);
+        LogFile.writeHeapInfo("resolveNetworkParameter-LoadModel");
         return false;
     }
 
-    if (!tflite->MakeAllocate()) {
-        LogFile.writeToFile(ESP_LOG_ERROR, TAG, "TFLITE: Allocation of tensors failed");
-        LogFile.writeHeapInfo("getNetworkParameter-MakeAllocate");
+    if (!tflite->makeAllocate()) {
+        LogFile.writeToFile(ESP_LOG_ERROR, TAG, "TFLite: Allocation of tensors failed");
+        LogFile.writeHeapInfo("resolveNetworkParameter-MakeAllocate");
         return false;
     }
 
     if (cnnType == CNNTYPE_AUTODETECT) {
-        if (tflite->GetInputDimension(false)) {
-            modelxsize = tflite->ReadInputDimenstion(0);
-            modelysize = tflite->ReadInputDimenstion(1);
-            modelchannel = tflite->ReadInputDimenstion(2);
-        }
-        else {
-            LogFile.writeToFile(ESP_LOG_ERROR, TAG, "TFLITE: Failed to load input dimensions");
+        if (!tflite->parseInputDimension()) {
+            LogFile.writeToFile(ESP_LOG_ERROR, TAG, "TFLite: Failed to parse input dimensions from model");
             return false;
         }
-        int _anzoutputdimensions = tflite->GetAnzOutPut();
-        switch (_anzoutputdimensions) {
-            case -1:
-                LogFile.writeToFile(ESP_LOG_ERROR, TAG, "TFLITE: Failed to load output dimensions");
-                return false;
+
+        modelxsize = tflite->getInputDimension(0);
+        modelysize = tflite->getInputDimension(1);
+        modelchannel = tflite->getInputDimension(2);
+
+        int outputDims = tflite->getOutputDimension();
+        if (outputDims == -1) {
+            LogFile.writeToFile(ESP_LOG_ERROR, TAG, "TFLite: Failed to load output dimensions");
+            return false;
+        }
+
+        switch (outputDims) {
             case 2:
                 cnnType = CNNTYPE_ANALOG_CONT;
-                LogFile.writeToFile(ESP_LOG_DEBUG, TAG, "CNN-Type: Analog - Cont");
+                LogFile.writeToFile(ESP_LOG_DEBUG, TAG, "Type: Analog (ana-cont)");
                 break;
+
             case 10:
                 cnnType = CNNTYPE_DIGIT_DOUBLE_HYBRID10;
-                LogFile.writeToFile(ESP_LOG_DEBUG, TAG, "CNN-Type: Digit - DoubleHyprid10");
+                LogFile.writeToFile(ESP_LOG_DEBUG, TAG, "Type: Digit (dig-cont)");
                 break;
+
             case 11:
                 cnnType = CNNTYPE_DIGIT_CLASS11;
-                LogFile.writeToFile(ESP_LOG_DEBUG, TAG, "CNN-Type: Digit - Class11");
+                LogFile.writeToFile(ESP_LOG_DEBUG, TAG, "Type: Digit (dig-class11)");
                 break;
+
             case 100:
-                if (modelxsize == 32 && modelysize == 32) {
-                    cnnType = CNNTYPE_ANALOG_CLASS100;
-                    LogFile.writeToFile(ESP_LOG_DEBUG, TAG, "CNN-Type: Analog - Class100");
-                }
-                else {
-                    cnnType = CNNTYPE_DIGIT_CLASS100;
-                    LogFile.writeToFile(ESP_LOG_DEBUG, TAG, "CNN-Type: Digit - Class100");
-                }
+                cnnType = (modelxsize == 32 && modelysize == 32) ? CNNTYPE_ANALOG_CLASS100 : CNNTYPE_DIGIT_CLASS100;
+                LogFile.writeToFile(ESP_LOG_DEBUG, TAG,
+                                    "Type: " + std::string((cnnType == CNNTYPE_ANALOG_CLASS100) ? "Analog (ana-class100)"
+                                                                                                : "Digit (dig-class100)"));
                 break;
+
             default:
-                LogFile.writeToFile(ESP_LOG_ERROR, TAG,
-                                    "CNN-Type does not fit the firmware (output_dimension=" + std::to_string(_anzoutputdimensions) + ")");
+                LogFile.writeToFile(ESP_LOG_ERROR, TAG, "Type does not fit the firmware (outputDims=" + std::to_string(outputDims) + ")");
                 return false;
         }
     }
 
     LogFile.writeToFile(ESP_LOG_INFO, TAG, "Network parameter loaded: " + cnnmodelfile);
 
-    tflite->CTfLiteClassDeleteInterpreter();
+    tflite->deleteInterpreter();
 
     return true;
 }
 
 
-bool ClassFlowCNNGeneral::doNeuralNetwork(std::string time)
+bool ClassFlowCNNGeneral::doInvokeCnn(const std::string time)
 {
-    std::string logPath = createLogFolder(time);
+    const std::string logPath = createLogFolder(time);
 
-    if (!tflite->MakeAllocate()) {
-        LogFile.writeToFile(ESP_LOG_ERROR, TAG, "Allocation of TFLITE tensors failed");
-        LogFile.writeHeapInfo("doNeuralNetwork-MakeAllocate");
+    if (!tflite->makeAllocate()) {
+        LogFile.writeToFile(ESP_LOG_ERROR, TAG, "Allocation of TFLite tensors failed");
+        LogFile.writeHeapInfo("invokeCnn-MakeAllocate");
         return false;
     }
 
-    for (auto &sequence : sequenceDataInternal) {
+    for (const auto &sequence : sequenceData) {
         LogFile.writeToFile(ESP_LOG_DEBUG, TAG, "Processing number sequence: " + sequence->sequenceName);
-        for (auto &roi : sequence->roiData) {
-            LogFile.writeToFile(ESP_LOG_DEBUG, TAG, "ROI: " + roi->param->roiName);
+
+        const auto &roiList = sectionDigitPtr ? sequence->digitRoi : sequence->analogRoi;
+
+        for (const auto &roi : roiList) {
+            const std::string &roiName = roi->param->roiName;
+            LogFile.writeToFile(ESP_LOG_DEBUG, TAG, "ROI: " + roiName);
+
+            bool success = false;
+            std::string modelTypeMsg;
+            int logImageResult = 0;
 
             switch (cnnType) {
-                case CNNTYPE_DIGIT_CLASS11: { // for models dig-class11*
-                    LogFile.writeToFile(ESP_LOG_DEBUG, TAG, "Type: Digit (dig-class11)");
+                case CNNTYPE_DIGIT_CLASS100:    // Models dig-class100*
+                case CNNTYPE_ANALOG_CLASS100: { // Models ana-class100*
+                    modelTypeMsg = "Type: " +
+                                   std::string(cnnType == CNNTYPE_DIGIT_CLASS100 ? "Digit (dig-class100)" : "Analog (ana-class100)");
+                    success = tflite->loadInputImage(roi->imageRoiResized) && tflite->invoke();
 
-                    roi->CNNResult = tflite->GetClassFromImageBasis(roi->imageRoiResized); // 0-9 + 10 => NaN
+                    if (!success) {
+                        break;
+                    }
 
-                    if (roi->CNNResult == 10) {
-                        roi->sCNNResult = "N";
+                    int num = tflite->getOutClassification();
+                    roi->CNNResult = roi->param->ccw ? (100 - num) % 100 : num;
+                    roi->CNNResult = std::clamp(roi->CNNResult, 0, 99);
+                    roi->sCNNResult = to_stringWithPrecision(roi->CNNResult / 10.0, 1);
+                    logImageResult = roi->CNNResult;
+                    break;
+                }
+
+                case CNNTYPE_DIGIT_DOUBLE_HYBRID10: { // Models dig-cont*
+                    modelTypeMsg = "Type: Digit (dig-cont)";
+                    success = tflite->loadInputImage(roi->imageRoiResized) && tflite->invoke();
+
+                    if (!success) {
+                        break;
+                    }
+
+                    int num = tflite->getOutClassification(0, 9);
+                    int numplus = (num + 1) % 10;
+                    int numminus = (num + 9) % 10;
+
+                    float val = tflite->getOutputValue(num);
+                    float valplus = tflite->getOutputValue(numplus);
+                    float valminus = tflite->getOutputValue(numminus);
+
+                    float result = num;
+                    float fit;
+
+                    if (valplus > valminus) {
+                        result += valplus / (val + valplus);
+                        fit = val + valplus;
                     }
                     else {
-                        roi->sCNNResult = std::to_string(roi->CNNResult);
+                        result -= valminus / (val + valminus);
+                        fit = val + valminus;
                     }
 
-                    LogFile.writeToFile(ESP_LOG_DEBUG, TAG, "Result: " + roi->sCNNResult);
-
-                    if (saveImagesEnabled) {
-                        logImage(logPath, roi->param->roiName, CNNTYPE_DIGIT_CLASS11, roi->CNNResult, time, roi->imageRoi);
-                    }
-                } break;
-
-                case CNNTYPE_DIGIT_DOUBLE_HYBRID10: { // for models dig-cont*
-                    LogFile.writeToFile(ESP_LOG_DEBUG, TAG, "Type: Digit (dig-cont)");
-
-                    int LogImageResult;
-                    int _num, _numplus, _numminus;
-                    float _val, _valplus, _valminus, _fit;
-
-                    if (tflite->LoadInputImageBasis(roi->imageRoiResized)) {
-                        tflite->Invoke();
-                        LogFile.writeToFile(ESP_LOG_DEBUG, TAG, "Invoke done");
-                    }
-                    else {
-                        LogFile.writeToFile(ESP_LOG_ERROR, TAG, "Invoke aborted");
-                        return false;
-                    }
-
-                    _num = tflite->GetOutClassification(0, 9);
-                    _numplus = (_num + 1) % 10;
-                    _numminus = (_num - 1 + 10) % 10;
-
-                    _val = tflite->GetOutputValue(_num);
-                    _valplus = tflite->GetOutputValue(_numplus);
-                    _valminus = tflite->GetOutputValue(_numminus);
-
-                    float result = _num;
-
-                    if (_valplus > _valminus) {
-                        result = result + _valplus / (_valplus + _val);
-                        _fit = _val + _valplus;
-                    }
-                    else {
-                        result = result - _valminus / (_val + _valminus);
-                        _fit = _val + _valminus;
-                    }
-
-                    if (result >= 10) {
-                        result = result - 10;
-                    }
-                    if (result < 0) {
-                        result = result + 10;
-                    }
-
-                    roi->CNNResult = result * 10.0; //  result normalized to 0-99
-
-                    if (roi->CNNResult < 0) {
-                        roi->CNNResult = 0;
-                    }
-                    else if (roi->CNNResult >= 100) {
-                        roi->CNNResult = 99;
-                    }
-
+                    result = fmod(result + 10, 10); // Normalize
+                    roi->CNNResult = (int)std::clamp(result * 10.0f, 0.0f, 99.0f);
                     roi->sCNNResult = to_stringWithPrecision(roi->CNNResult / 10.0, 1);
 
-                    /*std::string zw = "num (p, m): " + std::to_string(_num) + " (" + std::to_string(_numplus) + " , " +
-                    std::to_string(_numminus) + "), val (p, m): " + std::to_string(_val) + " (" + std::to_string(_valplus) + " , " +
-                    std::to_string(_valminus) + "), result: " + roi->sCNNResult + ", fit: " + std::to_string(_fit);
-                    LogFile.writeToFile(ESP_LOG_DEBUG, TAG, zw);
-                    */
+                    roi->isRejected = (fit < CNNGoodThreshold);
+                    logImageResult = roi->isRejected ? -roi->CNNResult : roi->CNNResult;
 
-                    if (_fit < CNNGoodThreshold) {
-                        roi->isRejected = true;
-                        LogImageResult = -1 *
-                                         roi->CNNResult; // In case fit is not sufficient, the result should still be saved with "-x.y".
-                        std::string zw = "Result rejected - bad fit (Fit: " + std::to_string(_fit) +
-                                         ", Threshold: " + std::to_string(CNNGoodThreshold) + ")";
-                        LogFile.writeToFile(ESP_LOG_WARN, TAG, zw);
-                    }
-                    else {
-                        roi->isRejected = false;
-                        LogImageResult = roi->CNNResult;
+#ifdef DEBUG_DETAIL_ON
+                    std::string logData = "num (p, m): " + std::to_string(num) + " (" + std::to_string(numplus) + " , " +
+                                          std::to_string(numminus) + "), val (p, m): " + std::to_string(val) + " (" +
+                                          std::to_string(valplus) + " , " + std::to_string(valminus) + "), result: " + roi->sCNNResult +
+                                          ", fit: " + std::to_string(fit);
+                    LogFile.writeToFile(ESP_LOG_DEBUG, TAG, logData);
+#endif
+
+                    if (roi->isRejected) {
+                        LogFile.writeToFile(ESP_LOG_WARN, TAG,
+                                            "Result rejected - bad fit (Fit: " + std::to_string(fit) +
+                                                ", Threshold: " + std::to_string(CNNGoodThreshold) + ")");
                     }
 
-                    LogFile.writeToFile(ESP_LOG_DEBUG, TAG, "Result: " + roi->sCNNResult);
+                    break;
+                }
 
-                    if (saveImagesEnabled) {
-                        logImage(logPath, roi->param->roiName, CNNTYPE_DIGIT_DOUBLE_HYBRID10, LogImageResult, time, roi->imageRoi);
-                    }
-                } break;
+                case CNNTYPE_ANALOG_CONT: { // Models ana-cont*
+                    modelTypeMsg = "Type: Analog (ana-cont)";
+                    success = tflite->loadInputImage(roi->imageRoiResized) && tflite->invoke();
 
-                case CNNTYPE_ANALOG_CLASS100:  // for models ana-class100*
-                case CNNTYPE_DIGIT_CLASS100: { // for models dig-class100*
-                    LogFile.writeToFile(ESP_LOG_DEBUG, TAG, "Type: Analog / Digit (ana-class100 / dig-class100)");
-
-                    if (tflite->LoadInputImageBasis(roi->imageRoiResized)) {
-                        tflite->Invoke();
-                        LogFile.writeToFile(ESP_LOG_DEBUG, TAG, "Invoke done");
-                    }
-                    else {
-                        LogFile.writeToFile(ESP_LOG_ERROR, TAG, "Invoke aborted");
-                        return false;
+                    if (!success) {
+                        break;
                     }
 
-                    int _num = tflite->GetOutClassification();
+                    float result = fmod(atan2(tflite->getOutputValue(0), tflite->getOutputValue(1)) / (2 * M_PI) + 2, 1.0f);
+                    float scaled = roi->param->ccw ? 100.0f - result * 100.0f : result * 100.0f;
 
-                    if (roi->param->ccw) {
-                        if (_num == 0) {
-                            roi->CNNResult = 0;
-                        }
-                        else {
-                            roi->CNNResult = 100 - _num;
-                        }
-                    }
-                    else {
-                        roi->CNNResult = _num;
-                    }
-
-                    if (roi->CNNResult < 0) {
-                        roi->CNNResult = 0;
-                    }
-                    else if (roi->CNNResult >= 100) {
-                        roi->CNNResult = 99;
-                    }
-
+                    roi->CNNResult = std::clamp(static_cast<int>(scaled), 0, 99);
                     roi->sCNNResult = to_stringWithPrecision(roi->CNNResult / 10.0, 1);
+                    logImageResult = roi->CNNResult;
+                    break;
+                }
 
-                    LogFile.writeToFile(ESP_LOG_DEBUG, TAG, "Result: " + roi->sCNNResult);
+                case CNNTYPE_DIGIT_CLASS11: { // Models dig-class11*
+                    modelTypeMsg = "Type: Digit (dig-class11)";
+                    success = tflite->loadInputImage(roi->imageRoiResized) && tflite->invoke();
 
-                    if (saveImagesEnabled) {
-                        logImage(logPath, roi->param->roiName, CNNTYPE_DIGIT_CLASS100, roi->CNNResult, time, roi->imageRoi);
-                    }
-                } break;
-
-                case CNNTYPE_ANALOG_CONT: { // for models ana-cont*
-                    LogFile.writeToFile(ESP_LOG_DEBUG, TAG, "Type: Analog (ana-cont)");
-
-                    if (tflite->LoadInputImageBasis(roi->imageRoiResized)) {
-                        tflite->Invoke();
-                        LogFile.writeToFile(ESP_LOG_DEBUG, TAG, "Invoke done");
-                    }
-                    else {
-                        LogFile.writeToFile(ESP_LOG_ERROR, TAG, "Invoke aborted");
-                        return false;
+                    if (!success) {
+                        break;
                     }
 
-                    float result = fmod(atan2(tflite->GetOutputValue(0), tflite->GetOutputValue(1)) / (M_PI * 2) + 2, 1);
-
-                    if (roi->param->ccw) {
-                        if (result == 0.0) {
-                            roi->CNNResult = 0;
-                        }
-                        else {
-                            roi->CNNResult = 100 - (result * 100); // result normalized to 0-99
-                        }
-                    }
-                    else {
-                        roi->CNNResult = result * 100; // result normalized to 0-99
-                    }
-
-                    if (roi->CNNResult < 0) {
-                        roi->CNNResult = 0;
-                    }
-                    else if (roi->CNNResult >= 100) {
-                        roi->CNNResult = 99;
-                    }
-
-                    roi->sCNNResult = to_stringWithPrecision(roi->CNNResult / 10.0, 1);
-
-                    LogFile.writeToFile(ESP_LOG_DEBUG, TAG, "Result: " + roi->sCNNResult);
-
-                    if (saveImagesEnabled) {
-                        logImage(logPath, roi->param->roiName, CNNTYPE_ANALOG_CONT, roi->CNNResult, time, roi->imageRoi);
-                    }
-                } break;
+                    roi->CNNResult = tflite->getOutClassification();
+                    roi->sCNNResult = (roi->CNNResult == 10) ? "N" : std::to_string(roi->CNNResult);
+                    logImageResult = roi->CNNResult;
+                    break;
+                }
 
                 default:
                     break;
             }
+
+            if (!success) {
+                LogFile.writeToFile(ESP_LOG_ERROR, TAG, "Invoke aborted");
+                return false;
+            }
+
+            LogFile.writeToFile(ESP_LOG_DEBUG, TAG, modelTypeMsg);
+            LogFile.writeToFile(ESP_LOG_DEBUG, TAG, "Result: " + roi->sCNNResult);
+
+            if (saveImagesEnabled) {
+                logImage(logPath, roiName, cnnType, logImageResult, time, roi->imageRoi);
+            }
         }
     }
 
-    tflite->CTfLiteClassDeleteInterpreter();
-
+    tflite->deleteInterpreter();
     return true;
 }
 
@@ -830,41 +735,33 @@ int ClassFlowCNNGeneral::evalAnalogToDigitTransition(int _value, int _valuePrevi
 }
 
 
-bool ClassFlowCNNGeneral::cnnTypeAllowExtendedResolution()
+bool ClassFlowCNNGeneral::cnnTypeAllowExtendedResolution() const
 {
-    if (cnnType == CNNTYPE_DIGIT_CLASS11) {
-        return false;
-    }
-
-    return true;
+    return cnnType != CNNTYPE_DIGIT_CLASS11;
 }
 
 
 void ClassFlowCNNGeneral::drawROI(CImageBasis *image)
 {
     if (!image->imageOkay()) {
+        LogFile.writeToFile(ESP_LOG_ERROR, TAG, "drawROI: Invalid image");
         return;
     }
 
-    for (int i = 0; const auto &sequence : sequenceDataInternal) {
-        std::array<int, 3> color = {0, 255, 0};
-        if (i == 0) {
-            color = {0, 255, 0}; // Green
-        }
-        else if (i == 1) {
-            color = {0, 0, 255}; // Blue
-        }
-        else if (i == 2) {
-            color = {0, 255, 255}; // Cyan
-        }
-        else if (i == 3) {
-            color = {255, 0, 255}; // Pink
-        }
-        else if (i == 4) {
-            color = {255, 255, 0}; // Yellow
-        }
+    static const std::vector<std::array<int, 3>> colors = {
+        {0, 255, 0},   // Green
+        {0, 0, 255},   // Blue
+        {0, 255, 255}, // Cyan
+        {255, 0, 255}, // Pink
+        {255, 255, 0}  // Yellow
+    };
 
-        for (const auto &roi : sequence->roiData) {
+    int colorIndex = 0;
+    for (const auto &sequence : sequenceData) {
+        const auto &roiList = sectionDigitPtr ? sequence->digitRoi : sequence->analogRoi;
+        const auto &color = colors[colorIndex % colors.size()];
+
+        for (const auto &roi : roiList) {
             if (cnnType == CNNTYPE_ANALOG_CONT || cnnType == CNNTYPE_ANALOG_CLASS100) {
                 // image->drawRect(roi->param->x, roi->param->y, roi->param->dx, roi->param->dy, color[0], color[1], color[2], 1);
                 image->drawEllipse((int)(roi->param->x + roi->param->dx / 2), (int)(roi->param->y + roi->param->dy / 2),
@@ -878,7 +775,6 @@ void ClassFlowCNNGeneral::drawROI(CImageBasis *image)
                 image->drawRect(roi->param->x, roi->param->y, roi->param->dx, roi->param->dy, color[0], color[1], color[2], 2);
             }
         }
-        i++;
     }
 }
 
@@ -886,19 +782,19 @@ void ClassFlowCNNGeneral::drawROI(CImageBasis *image)
 ClassFlowCNNGeneral::~ClassFlowCNNGeneral()
 {
     delete tflite;
-    tflite = NULL;
+    tflite = nullptr;
 
-    for (auto &sequence : sequenceDataInternal) {
-        for (auto &roi : sequence->roiData) {
+    for (const auto &sequence : sequenceData) {
+        auto &roiList = sectionDigitPtr ? sequence->digitRoi : sequence->analogRoi;
+
+        for (auto &roi : roiList) {
             delete roi->imageRoiResized;
-            roi->imageRoiResized = NULL;
             delete roi->imageRoi;
-            roi->imageRoi = NULL;
+            roi->imageRoiResized = nullptr;
+            roi->imageRoi = nullptr;
         }
-        sequence->roiData.clear();
-        std::vector<RoiData *>().swap(sequence->roiData); // Ensure that memory gets freed (instead using shrink_to_fit())
-    }
 
-    sequenceDataInternal.clear();
-    std::vector<SequenceDataInternal *>().swap(sequenceDataInternal); // Ensure that memory gets freed (instead using shrink_to_fit())
+        roiList.clear();
+        std::vector<RoiData *>().swap(roiList); // Force deallocation
+    }
 }

--- a/code/components/mainprocess_ctrl/ClassFlowCNNGeneral.h
+++ b/code/components/mainprocess_ctrl/ClassFlowCNNGeneral.h
@@ -28,10 +28,10 @@ class ClassFlowCNNGeneral : public ClassLogImage
 
     bool saveAllFiles;
 
-    int evalAnalogNumber(int _value, int _resultPreviousNumber);
+    int evalAnalogNumber(int _value, int _resultPreviousNumber) const;
     int evalDigitNumber(int _value, int _valuePreviousNumber, int _resultPreviousNumber, bool isPreviousAnalog = false,
-                        int analogDigitSyncValue = 92);
-    int evalAnalogToDigitTransition(int _value, int _valuePreviousNumber, int _resultPreviousNumber, int analogDigitSyncValue);
+                        int analogDigitSyncValue = 92) const;
+    int evalAnalogToDigitTransition(int _value, int _valuePreviousNumber, int _resultPreviousNumber, int analogDigitSyncValue) const;
 
     bool resolveNetworkParameter();
     bool doExtractRoi(const std::string time);
@@ -45,7 +45,7 @@ class ClassFlowCNNGeneral : public ClassLogImage
     bool doFlow(std::string time);
     void doPostProcessEventHandling();
 
-    std::string getReadout(SequenceData *sequence, int _valuePreviousNumber = -1, int _resultPreviousNumber = -1);
+    std::string getReadout(SequenceData *sequence, int _valuePreviousNumber = -1, int _resultPreviousNumber = -1) const;
 
     void drawROI(CImageBasis *image);
 

--- a/code/components/mainprocess_ctrl/ClassFlowCNNGeneral.h
+++ b/code/components/mainprocess_ctrl/ClassFlowCNNGeneral.h
@@ -6,20 +6,14 @@
 #include "ClassFlowAlignment.h"
 #include "CTfLiteClass.h"
 #include "ClassLogImage.h"
+#include "configClass.h"
 
-
-// Helper struct to multiuse class without adapting variable names
-// @TODO: Not ideal, could this be done more effcient to avoid this helper?
-struct SequenceDataInternal {
-    int sequenceId;                 // Sequence ID
-    std::string sequenceName;       // Sequence Name
-    std::vector<RoiData *> roiData; // ROI Data
-};
 
 class ClassFlowCNNGeneral : public ClassLogImage
 {
   protected:
-    std::vector<SequenceDataInternal *> sequenceDataInternal;
+    const CfgData::SectionDigit *sectionDigitPtr = nullptr;
+    const CfgData::SectionAnalog *sectionAnalogPtr = nullptr;
 
     ClassFlowAlignment *flowalignment;
     std::string cnnname;
@@ -27,10 +21,10 @@ class ClassFlowCNNGeneral : public ClassLogImage
 
     CTfLiteClass *tflite;
     std::string cnnmodelfile;
-    float CNNGoodThreshold;
     int modelxsize;
     int modelysize;
     int modelchannel;
+    float CNNGoodThreshold;
 
     bool saveAllFiles;
 
@@ -40,11 +34,11 @@ class ClassFlowCNNGeneral : public ClassLogImage
     int evalAnalogToDigitTransition(int _value, int _valuePreviousNumber, int _resultPreviousNumber, int analogDigitSyncValue);
 
     bool resolveNetworkParameter();
-    bool doAlignAndCut(std::string time);
-    bool doNeuralNetwork(std::string time);
+    bool doExtractRoi(const std::string time);
+    bool doInvokeCnn(const std::string time);
 
   public:
-    ClassFlowCNNGeneral(ClassFlowAlignment *_flowalignment, std::string _cnnname, CNNType _cnntype = CNNTYPE_AUTODETECT);
+    ClassFlowCNNGeneral(ClassFlowAlignment *_flowalignment, const std::string _cnnname, const CNNType _cnntype = CNNTYPE_AUTODETECT);
     virtual ~ClassFlowCNNGeneral();
 
     bool loadParameter();
@@ -55,8 +49,8 @@ class ClassFlowCNNGeneral : public ClassLogImage
 
     void drawROI(CImageBasis *image);
 
-    CNNType getCNNType() { return cnnType; };
-    bool cnnTypeAllowExtendedResolution();
+    CNNType getCNNType() const { return cnnType; };
+    bool cnnTypeAllowExtendedResolution() const;
 
     std::string name() { return "ClassFlowCNNGeneral - " + cnnname; };
 };

--- a/code/components/mainprocess_ctrl/ClassFlowCNNGeneral.h
+++ b/code/components/mainprocess_ctrl/ClassFlowCNNGeneral.h
@@ -15,16 +15,16 @@ class ClassFlowCNNGeneral : public ClassLogImage
     const CfgData::SectionDigit *sectionDigitPtr = nullptr;
     const CfgData::SectionAnalog *sectionAnalogPtr = nullptr;
 
-    ClassFlowAlignment *flowalignment;
-    std::string cnnname;
+    ClassFlowAlignment *flowAlignment = nullptr;
+    std::string cnnName;
     CNNType cnnType;
 
-    CTfLiteClass *tflite;
-    std::string cnnmodelfile;
-    int modelxsize;
-    int modelysize;
-    int modelchannel;
-    float CNNGoodThreshold;
+    CTfLiteClass *tflite = nullptr;
+    std::string cnnModelFile;
+    int modelWidth;
+    int modelHeight;
+    int modelChannel;
+    float cnnGoodThreshold;
 
     bool saveAllFiles;
 
@@ -38,7 +38,7 @@ class ClassFlowCNNGeneral : public ClassLogImage
     bool doInvokeCnn(const std::string time);
 
   public:
-    ClassFlowCNNGeneral(ClassFlowAlignment *_flowalignment, const std::string _cnnname, const CNNType _cnntype = CNNTYPE_AUTODETECT);
+    ClassFlowCNNGeneral(ClassFlowAlignment *_flowAlignment, std::string _cnnName, CNNType _cnnType = CNNTYPE_AUTODETECT);
     virtual ~ClassFlowCNNGeneral();
 
     bool loadParameter();
@@ -52,7 +52,7 @@ class ClassFlowCNNGeneral : public ClassLogImage
     CNNType getCNNType() const { return cnnType; };
     bool cnnTypeAllowExtendedResolution() const;
 
-    std::string name() { return "ClassFlowCNNGeneral - " + cnnname; };
+    std::string name() { return "ClassFlowCNNGeneral - " + cnnName; };
 };
 
 #endif // CLASSFLOWCNNGENERAL_H

--- a/code/components/tflite_ctrl/CTfLiteClass.cpp
+++ b/code/components/tflite_ctrl/CTfLiteClass.cpp
@@ -70,7 +70,7 @@ bool CTfLiteClass::makeAllocate()
 }
 
 
-bool CTfLiteClass::readFileToModel(std::string fileName)
+bool CTfLiteClass::readFileToModel(const std::string &fileName)
 {
     LogFile.writeToFile(ESP_LOG_DEBUG, TAG, "readFileToModel: Read TFLite model file: " + fileName);
 
@@ -117,7 +117,7 @@ bool CTfLiteClass::readFileToModel(std::string fileName)
 }
 
 
-bool CTfLiteClass::loadModel(std::string fileName)
+bool CTfLiteClass::loadModel(const std::string &fileName)
 {
     LogFile.writeToFile(ESP_LOG_DEBUG, TAG, "Loading TFLite model");
 

--- a/code/components/tflite_ctrl/CTfLiteClass.cpp
+++ b/code/components/tflite_ctrl/CTfLiteClass.cpp
@@ -8,223 +8,22 @@
 
 static const char *TAG = "TFLITE";
 
-// #define DEBUG_DETAIL_ON
 
-
-float CTfLiteClass::GetOutputValue(int nr)
+CTfLiteClass::CTfLiteClass()
 {
-    TfLiteTensor *output2 = interpreter->output(0);
-
-    if (output2 == NULL) {
-        LogFile.writeToFile(ESP_LOG_ERROR, TAG, "GetOutputValue failed");
-        return -1000;
-    }
-
-    int numeroutput = output2->dims->data[1];
-    if ((nr + 1) > numeroutput) {
-        return -1000;
-    }
-    else {
-        return output2->data.f[nr];
-    }
+    modelFile = nullptr;
+    model = nullptr;
+    tensorArena = nullptr;
+    kTensorArenaSize = 800 * 1024;
+    interpreter = nullptr;
+    output = nullptr;
+    imHeight = 0;
+    imWidth = 0;
+    imChannel = 0;
 }
 
 
-int CTfLiteClass::GetClassFromImageBasis(CImageBasis *rs)
-{
-    if (!LoadInputImageBasis(rs)) {
-        return -1000;
-    }
-
-    Invoke();
-
-    return GetOutClassification();
-}
-
-
-int CTfLiteClass::GetOutClassification(int _von, int _bis)
-{
-    TfLiteTensor *output2 = interpreter->output(0);
-
-    if (output2 == NULL) {
-        LogFile.writeToFile(ESP_LOG_ERROR, TAG, "GetOutClassification failed");
-        return -1;
-    }
-
-    float zw_max;
-    float zw;
-    int zw_class;
-
-    int numeroutput = output2->dims->data[1];
-    // ESP_LOGD(TAG, "number output neurons: %d", numeroutput);
-
-    if (_bis == -1) {
-        _bis = numeroutput - 1;
-    }
-
-    if (_von == -1) {
-        _von = 0;
-    }
-
-    if (_bis >= numeroutput) {
-        LogFile.writeToFile(ESP_LOG_ERROR, TAG, "GetOutClassification: NUMBER OF OUTPUT NEURONS does not match required classification");
-        return -1;
-    }
-
-    zw_max = output2->data.f[_von];
-    zw_class = _von;
-    for (int i = _von + 1; i <= _bis; ++i) {
-        zw = output2->data.f[i];
-        if (zw > zw_max) {
-            zw_max = zw;
-            zw_class = i;
-        }
-    }
-    return (zw_class - _von);
-}
-
-
-bool CTfLiteClass::GetInputDimension(bool silent = false)
-{
-    TfLiteTensor *input2 = interpreter->input(0);
-
-    if (input2 == NULL) {
-        LogFile.writeToFile(ESP_LOG_ERROR, TAG, "GetInputDimension failed");
-        return false;
-    }
-
-    int numdim = input2->dims->size;
-    if (!silent) {
-        ESP_LOGD(TAG, "NumDimension: %d", numdim);
-    }
-
-    int sizeofdim;
-    for (int j = 0; j < numdim; ++j) {
-        sizeofdim = input2->dims->data[j];
-        if (!silent) {
-            ESP_LOGD(TAG, "SizeOfDimension %d: %d", j, sizeofdim);
-        }
-        if (j == 1) {
-            im_height = sizeofdim;
-        }
-        if (j == 2) {
-            im_width = sizeofdim;
-        }
-        if (j == 3) {
-            im_channel = sizeofdim;
-        }
-    }
-
-    return true;
-}
-
-
-int CTfLiteClass::ReadInputDimenstion(int _dim)
-{
-    if (_dim == 0) {
-        return im_width;
-    }
-    if (_dim == 1) {
-        return im_height;
-    }
-    if (_dim == 2) {
-        return im_channel;
-    }
-
-    return -1;
-}
-
-
-int CTfLiteClass::GetAnzOutPut(bool silent)
-{
-    TfLiteTensor *output2 = interpreter->output(0);
-
-    if (output2 == NULL) {
-        LogFile.writeToFile(ESP_LOG_ERROR, TAG, "GetAnzOutPut failed");
-        return -1;
-    }
-
-    int numdim = output2->dims->size;
-    if (!silent) {
-        ESP_LOGD(TAG, "NumDimension: %d", numdim);
-    }
-
-    int sizeofdim;
-    for (int j = 0; j < numdim; ++j) {
-        sizeofdim = output2->dims->data[j];
-        if (!silent) {
-            ESP_LOGD(TAG, "SizeOfDimension %d: %d", j, sizeofdim);
-        }
-    }
-
-    float fo;
-    // Process the inference results.
-    int numeroutput = output2->dims->data[1];
-    for (int i = 0; i < numeroutput; ++i) {
-        fo = output2->data.f[i];
-        if (!silent) {
-            ESP_LOGD(TAG, "Result %d: %f", i, fo);
-        }
-    }
-    return numeroutput;
-}
-
-
-void CTfLiteClass::Invoke()
-{
-    if (interpreter != nullptr) {
-        interpreter->Invoke();
-    }
-}
-
-
-bool CTfLiteClass::LoadInputImageBasis(CImageBasis *rs)
-{
-#ifdef DEBUG_DETAIL_ON
-    LogFile.writeHeapInfo("LoadInputImageBasis - Start");
-#endif // DEBUG_DETAIL_ON
-
-    if (rs == NULL) {
-        LogFile.writeToFile(ESP_LOG_ERROR, TAG, "LoadInputImageBasis: No image data");
-        return false;
-    }
-
-    unsigned int w = rs->width;
-    unsigned int h = rs->height;
-    unsigned char red, green, blue;
-    //    ESP_LOGD(TAG, "Image: %s size: %d x %d\n", _fn.c_str(), w, h);
-
-    input_i = 0;
-    float *input_data_ptr = (interpreter->input(0))->data.f;
-
-    if (input_data_ptr == NULL) {
-        LogFile.writeToFile(ESP_LOG_ERROR, TAG, "LoadInputImageBasis: No input data");
-        return false;
-    }
-
-    for (int y = 0; y < h; ++y) {
-        for (int x = 0; x < w; ++x) {
-            red = rs->getPixelColor(x, y, 0);
-            green = rs->getPixelColor(x, y, 1);
-            blue = rs->getPixelColor(x, y, 2);
-            *(input_data_ptr) = (float)red;
-            input_data_ptr++;
-            *(input_data_ptr) = (float)green;
-            input_data_ptr++;
-            *(input_data_ptr) = (float)blue;
-            input_data_ptr++;
-        }
-    }
-
-#ifdef DEBUG_DETAIL_ON
-    LogFile.writeHeapInfo("LoadInputImageBasis - done");
-#endif // DEBUG_DETAIL_ON
-
-    return true;
-}
-
-
-void CTfLiteClass::LoadOpResolver(void)
+void CTfLiteClass::loadOpResolver(void)
 {
     // Add only needed OP resolver to save memory (flash memory + RAM)
     // NOTE: Whenever used model gets extended by new ops, they need to be added here
@@ -241,28 +40,28 @@ void CTfLiteClass::LoadOpResolver(void)
 }
 
 
-bool CTfLiteClass::MakeAllocate()
+bool CTfLiteClass::makeAllocate()
 {
     LogFile.writeToFile(ESP_LOG_DEBUG, TAG, "Allocating tensors");
-    tensor_arena = (uint8_t *)malloc_psram_heap(std::string(TAG) + "->tensor_arena", kTensorArenaSize, MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
+    tensorArena = (uint8_t *)malloc_psram_heap(std::string(TAG) + "->tensor_arena", kTensorArenaSize, MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
 
-    if (tensor_arena == NULL) {
-        LogFile.writeToFile(ESP_LOG_ERROR, TAG, "Tensor arena: malloc failed");
-        LogFile.writeHeapInfo("MakeAllocate-Tensor arena: malloc failed");
+    if (!tensorArena) {
+        LogFile.writeToFile(ESP_LOG_ERROR, TAG, "makeAllocate: Failed to allocate tensor arena memory");
+        LogFile.writeHeapInfo("makeAllocate-Tensor arena: malloc failed");
         return false;
     }
 
-    interpreter = new tflite::MicroInterpreter(model, microOpResolver, tensor_arena, kTensorArenaSize);
+    interpreter = new tflite::MicroInterpreter(model, microOpResolver, tensorArena, kTensorArenaSize);
 
-    if (interpreter == NULL) {
-        LogFile.writeToFile(ESP_LOG_ERROR, TAG, "new tflite::MicroInterpreter failed");
-        LogFile.writeHeapInfo("MakeAllocate-new tflite::MicroInterpreter failed");
+    if (!interpreter) {
+        LogFile.writeToFile(ESP_LOG_ERROR, TAG, "makeAllocate: Failed to create interpreter");
+        LogFile.writeHeapInfo("makeAllocate-new tflite::MicroInterpreter failed");
         return false;
     }
 
-    TfLiteStatus allocate_status = interpreter->AllocateTensors();
-    if (allocate_status != kTfLiteOk) {
-        LogFile.writeToFile(ESP_LOG_ERROR, TAG, "Allocate tensors failed");
+    TfLiteStatus allocateStatus = interpreter->AllocateTensors();
+    if (allocateStatus != kTfLiteOk) {
+        LogFile.writeToFile(ESP_LOG_ERROR, TAG, "makeAllocate: Failed to allocate tensors");
         return false;
     }
 
@@ -271,108 +70,271 @@ bool CTfLiteClass::MakeAllocate()
 }
 
 
-void CTfLiteClass::GetInputTensorSize()
+bool CTfLiteClass::readFileToModel(std::string fileName)
 {
-#ifdef DEBUG_DETAIL_ON
-    float *zw = input;
-    int test = sizeof(zw);
-    ESP_LOGD(TAG, "Input Tensor Dimension: %d", test);
-#endif // DEBUG_DETAIL_ON
-}
-
-
-bool CTfLiteClass::ReadFileToModel(std::string _fn)
-{
-    LogFile.writeToFile(ESP_LOG_DEBUG, TAG, "Read TFLITE model file: " + _fn);
+    LogFile.writeToFile(ESP_LOG_DEBUG, TAG, "readFileToModel: Read TFLite model file: " + fileName);
 
 #ifdef DEBUG_DETAIL_ON
-    LogFile.writeHeapInfo("ReadFileToModel: start");
+    LogFile.writeHeapInfo("readFileToModel: start");
 #endif // DEBUG_DETAIL_ON
 
-    size_t size = getFileSize(_fn);
+    size_t size = getFileSize(fileName);
     if (size <= 0) {
-        LogFile.writeToFile(ESP_LOG_ERROR, TAG, "File not existing or zero size: " + _fn);
+        LogFile.writeToFile(ESP_LOG_ERROR, TAG, "readFileToModel: File not existing or zero size: " + fileName);
         return false;
     }
 
-    modelfile = (unsigned char *)malloc_psram_heap(std::string(TAG) + "->modelfile", size, MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
+    modelFile = (unsigned char *)malloc_psram_heap(std::string(TAG) + "->modelFile", size, MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
 
-    if (modelfile == NULL) {
-        LogFile.writeToFile(ESP_LOG_ERROR, TAG, "ReadFileToModel: Can't allocate enough memory: " + std::to_string(size));
-        LogFile.writeHeapInfo("ReadFileToModel: Allocation failed");
+    if (!modelFile) {
+        LogFile.writeToFile(ESP_LOG_ERROR, TAG, "readFileToModel: Can't allocate enough memory: " + std::to_string(size));
+        LogFile.writeHeapInfo("readFileToModel: Allocation failed");
         return false;
     }
 
-    FILE *f = fopen(_fn.c_str(), "rb"); // previously only "r
+    FILE *file = fopen(fileName.c_str(), "rb");
+    if (!file) {
+        LogFile.writeToFile(ESP_LOG_ERROR, TAG, "readFileToModel: Failed to open model file: " + fileName);
+        return false;
+    }
 
     /* Related to article: https://blog.drorgluska.com/2022/06/esp32-sd-card-optimization.html */
-    // Set buffer to SD card allocation size of 512 byte (newlib default: 128 byte) -> reduce system read/write calls
-    setvbuf(f, NULL, _IOFBF, 512);
+    setvbuf(file, nullptr, _IOFBF, 512);
 
-    if (fread(modelfile, 1, size, f) != size) {
-        LogFile.writeToFile(ESP_LOG_ERROR, TAG, "ReadFileToModel: Reading error: Size differs");
-        free_psram_heap(std::string(TAG) + "->modelfile", modelfile);
-        fclose(f);
+    if (fread(modelFile, 1, size, file) != size) {
+        LogFile.writeToFile(ESP_LOG_ERROR, TAG, "readFileToModel: Reading error: Size differs");
+        free_psram_heap(std::string(TAG) + "->modelFile", modelFile);
+        fclose(file);
         return false;
     }
-    fclose(f);
+    fclose(file);
 
 #ifdef DEBUG_DETAIL_ON
-    LogFile.writeHeapInfo("ReadFileToModel: done");
+    LogFile.writeHeapInfo("readFileToModel: done");
 #endif // DEBUG_DETAIL_ON
 
     return true;
 }
 
 
-bool CTfLiteClass::LoadModel(std::string _fn)
+bool CTfLiteClass::loadModel(std::string fileName)
 {
-    LogFile.writeToFile(ESP_LOG_DEBUG, TAG, "Loading TFLITE model");
+    LogFile.writeToFile(ESP_LOG_DEBUG, TAG, "Loading TFLite model");
 
-    if (!ReadFileToModel(_fn)) {
-        LogFile.writeToFile(ESP_LOG_ERROR, TAG, "LoadModel: TFLITE model file reading failed");
+    if (!readFileToModel(fileName)) {
+        LogFile.writeToFile(ESP_LOG_ERROR, TAG, "loadModel: TFLite model file reading failed");
         return false;
     }
 
-    model = tflite::GetModel(modelfile);
+    model = tflite::GetModel(modelFile);
 
-    if (model == nullptr) {
-        LogFile.writeToFile(ESP_LOG_ERROR, TAG, "LoadModel: GetModel failed");
+    if (!model) {
+        LogFile.writeToFile(ESP_LOG_ERROR, TAG, "loadModel: GetModel failed");
         return false;
     }
 
     if (model->version() != TFLITE_SCHEMA_VERSION) {
         LogFile.writeToFile(ESP_LOG_ERROR, TAG,
-                            "LoadModel: Model provided is schema version " + std::to_string(model->version()) +
+                            "loadModel: Model provided is schema version " + std::to_string(model->version()) +
                                 " not equal to supported version " + std::to_string(TFLITE_SCHEMA_VERSION));
         return false;
     }
 
-    LoadOpResolver(); // Preload operation resolver for tensor interpreter execution (make sure that this only gets called once)
+    loadOpResolver(); // Preload operation resolver for tensor interpreter execution (make sure that this only gets called once)
 
-    LogFile.writeToFile(ESP_LOG_DEBUG, TAG, "TFLITE model successfully loaded");
+    LogFile.writeToFile(ESP_LOG_DEBUG, TAG, "TFLite model successfully loaded");
     return true;
 }
 
 
-CTfLiteClass::CTfLiteClass()
+bool CTfLiteClass::loadInputImage(CImageBasis *image)
 {
-    model = nullptr;
-    modelfile = NULL;
-    interpreter = nullptr;
-    input = nullptr;
-    output = nullptr;
-    tensor_arena = nullptr;
-    kTensorArenaSize = 800 * 1024; // according to testfile: 108000 - so far 600;; 2021-09-11: 200 * 1024
+    if (!image || !image->getRgbImage()) {
+        LogFile.writeToFile(ESP_LOG_ERROR, TAG, "loadInputImage: No image data");
+        return false;
+    }
+
+    float *inputDataPtr = (interpreter->input(0))->data.f;
+
+    if (!inputDataPtr) {
+        LogFile.writeToFile(ESP_LOG_ERROR, TAG, "loadInputImage: No input data");
+        return false;
+    }
+
+    uint8_t *rgbImage = image->getRgbImage();
+    for (int i = 0; i < image->getMemsize(); ++i) {
+        inputDataPtr[i] = (float)rgbImage[i];
+    }
+
+    return true;
 }
 
 
-void CTfLiteClass::CTfLiteClassDeleteInterpreter()
+bool CTfLiteClass::invoke()
 {
-    if (tensor_arena != nullptr) {
-        LogFile.writeToFile(ESP_LOG_DEBUG, TAG, "TFLITE arena - Used bytes: " + std::to_string(interpreter->arena_used_bytes()));
-        free_psram_heap(std::string(TAG) + "->tensor_arena", tensor_arena);
-        tensor_arena = nullptr;
+    if (!interpreter) {
+        LogFile.writeToFile(ESP_LOG_ERROR, TAG, "invoke: No interpreter loaded");
+        return false;
+    }
+
+    TfLiteStatus status = interpreter->Invoke();
+    if (status != kTfLiteOk) {
+        LogFile.writeToFile(ESP_LOG_ERROR, TAG, "Failed to invoke | Error: " + std::to_string(status));
+        return false;
+    }
+
+    return true;
+}
+
+
+bool CTfLiteClass::parseInputDimension()
+{
+    TfLiteTensor *inputTensor = interpreter->input(0);
+
+    if (!inputTensor) {
+        LogFile.writeToFile(ESP_LOG_ERROR, TAG, "getInputDimension: Invalid inputTensor");
+        return false;
+    }
+
+#ifdef DEBUG_DETAIL_ON
+    ESP_LOGD(TAG, "Num Dimension: %d", inputTensor->dims->size);
+#endif // DEBUG_DETAIL_ON
+
+    for (int j = 0; j < inputTensor->dims->size; ++j) {
+        switch (j) {
+            case 1:
+                imHeight = inputTensor->dims->data[j];
+                break;
+            case 2:
+                imWidth = inputTensor->dims->data[j];
+                break;
+            case 3:
+                imChannel = inputTensor->dims->data[j];
+                break;
+            default:
+                break;
+        }
+
+#ifdef DEBUG_DETAIL_ON
+        ESP_LOGD(TAG, "Input Dimension %d: %d", j, inputTensor->dims->data[j]);
+#endif // DEBUG_DETAIL_ON
+    }
+
+    return true;
+}
+
+
+int CTfLiteClass::getInputDimension(int dim)
+{
+    switch (dim) {
+        case 0:
+            return imWidth;
+        case 1:
+            return imHeight;
+        case 2:
+            return imChannel;
+        default:
+            return -1;
+    }
+}
+
+
+int CTfLiteClass::getOutputDimension()
+{
+    TfLiteTensor *outputTensor = interpreter->output(0);
+
+    if (!outputTensor) {
+        LogFile.writeToFile(ESP_LOG_ERROR, TAG, "getOutputDimension: Invalid outputTensor");
+        return -1;
+    }
+
+#ifdef DEBUG_DETAIL_ON
+    int numDim = outputTensor->dims->size;
+    ESP_LOGD(TAG, "Num Dimension: %d", numDim);
+
+    for (int j = 0; j < numDim; ++j) {
+        int dimSize = outputTensor->dims->data[j];
+
+        ESP_LOGD(TAG, "Output Dimension %d: %d", j, dimSize);
+    }
+
+    int numOutput = outputTensor->dims->data[1];
+    for (int i = 0; i < numOutput; ++i) {
+        float val = outputTensor->data.f[i];
+
+        ESP_LOGD(TAG, "Result %d: %f", i, val);
+    }
+#endif // DEBUG_DETAIL_ON
+
+    return outputTensor->dims->data[1];
+}
+
+
+int CTfLiteClass::getOutClassification(int from, int to)
+{
+    TfLiteTensor *outputTensor = interpreter->output(0);
+
+    if (!outputTensor) {
+        LogFile.writeToFile(ESP_LOG_ERROR, TAG, "getOutClassification: Invalid outputTensor");
+        return -1;
+    }
+
+    int numOutputs = outputTensor->dims->data[1];
+
+    if (from < 0) {
+        from = 0;
+    }
+
+    if (to < 0) {
+        to = numOutputs - 1;
+    }
+
+    if (to >= numOutputs || from > to) {
+        LogFile.writeToFile(ESP_LOG_ERROR, TAG, "getOutClassification: Invalid range (from > to or to >= numOutputs)");
+        return -1;
+    }
+
+    const float *outputData = outputTensor->data.f;
+    int maxIndex = from;
+    float maxValue = outputData[from];
+
+    for (int i = from + 1; i <= to; ++i) {
+        if (outputData[i] > maxValue) {
+            maxValue = outputData[i];
+            maxIndex = i;
+        }
+    }
+
+    return maxIndex - from;
+}
+
+
+float CTfLiteClass::getOutputValue(int index)
+{
+    TfLiteTensor *outputTensor = interpreter->output(0);
+
+    if (!outputTensor) {
+        LogFile.writeToFile(ESP_LOG_ERROR, TAG, "getOutputValue: Invalid outputTensor");
+        return -1.0f;
+    }
+
+    int numOutputs = outputTensor->dims->data[1];
+
+    if (index < 0 || index >= numOutputs) {
+        LogFile.writeToFile(ESP_LOG_ERROR, TAG, "getOutputValue: Index out of range");
+        return -1.0f;
+    }
+
+    return outputTensor->data.f[index];
+}
+
+
+void CTfLiteClass::deleteInterpreter()
+{
+    if (tensorArena != nullptr) {
+        LogFile.writeToFile(ESP_LOG_DEBUG, TAG, "TFLite arena - Used bytes: " + std::to_string(interpreter->arena_used_bytes()));
+        free_psram_heap(std::string(TAG) + "->tensorArena", tensorArena);
+        tensorArena = nullptr;
     }
 
     if (interpreter != nullptr) {
@@ -384,13 +346,14 @@ void CTfLiteClass::CTfLiteClassDeleteInterpreter()
 
 CTfLiteClass::~CTfLiteClass()
 {
-    if (tensor_arena != nullptr) {
-        free_psram_heap(std::string(TAG) + "->tensor_arena", tensor_arena);
+    if (tensorArena != nullptr) {
+        free_psram_heap(std::string(TAG) + "->tensorArena", tensorArena);
     }
 
     if (interpreter != nullptr) {
         delete interpreter;
+        interpreter = nullptr;
     }
 
-    free_psram_heap(std::string(TAG) + "->modelfile", modelfile);
+    free_psram_heap(std::string(TAG) + "->modelFile", modelFile);
 }

--- a/code/components/tflite_ctrl/CTfLiteClass.cpp
+++ b/code/components/tflite_ctrl/CTfLiteClass.cpp
@@ -224,7 +224,7 @@ bool CTfLiteClass::parseInputDimension()
 }
 
 
-int CTfLiteClass::getInputDimension(int dim)
+int CTfLiteClass::getInputDimension(int dim) const
 {
     switch (dim) {
         case 0:
@@ -239,7 +239,7 @@ int CTfLiteClass::getInputDimension(int dim)
 }
 
 
-int CTfLiteClass::getOutputDimension()
+int CTfLiteClass::getOutputDimension() const
 {
     TfLiteTensor *outputTensor = interpreter->output(0);
 
@@ -270,7 +270,7 @@ int CTfLiteClass::getOutputDimension()
 }
 
 
-int CTfLiteClass::getOutClassification(int from, int to)
+int CTfLiteClass::getOutClassification(int from, int to) const
 {
     TfLiteTensor *outputTensor = interpreter->output(0);
 
@@ -309,7 +309,7 @@ int CTfLiteClass::getOutClassification(int from, int to)
 }
 
 
-float CTfLiteClass::getOutputValue(int index)
+float CTfLiteClass::getOutputValue(int index) const
 {
     TfLiteTensor *outputTensor = interpreter->output(0);
 

--- a/code/components/tflite_ctrl/CTfLiteClass.h
+++ b/code/components/tflite_ctrl/CTfLiteClass.h
@@ -11,16 +11,18 @@ class CTfLiteClass
 {
   protected:
     tflite::MicroMutableOpResolver<10> microOpResolver;
-    uint8_t *modelFile;
+    uint8_t *modelFile = nullptr;
     const tflite::Model *model;
-    int kTensorArenaSize;
-    uint8_t *tensorArena;
-    tflite::MicroInterpreter *interpreter;
-    TfLiteTensor *output;
+    int kTensorArenaSize = 0;
+    uint8_t *tensorArena = nullptr;
+    tflite::MicroInterpreter *interpreter = nullptr;
+    TfLiteTensor *output = nullptr;
 
-    int imHeight, imWidth, imChannel;
+    int imHeight = 0;
+    int imWidth = 0;
+    int imChannel = 0;
 
-    bool readFileToModel(std::string fileName);
+    bool readFileToModel(const std::string &fileName);
     void loadOpResolver(void);
 
   public:
@@ -29,7 +31,7 @@ class CTfLiteClass
     void deleteInterpreter();
 
     bool makeAllocate();
-    bool loadModel(std::string fileName);
+    bool loadModel(const std::string &fileName);
     bool loadInputImage(CImageBasis *image);
     bool invoke();
 

--- a/code/components/tflite_ctrl/CTfLiteClass.h
+++ b/code/components/tflite_ctrl/CTfLiteClass.h
@@ -36,11 +36,11 @@ class CTfLiteClass
     bool invoke();
 
     bool parseInputDimension();
-    int getInputDimension(int dim);
+    int getInputDimension(int dim) const;
 
-    int getOutputDimension();
-    int getOutClassification(int from = -1, int to = -1);
-    float getOutputValue(int index);
+    int getOutputDimension() const;
+    int getOutClassification(int from = -1, int to = -1) const;
+    float getOutputValue(int index) const;
 };
 
 #endif // CTFLITECLASS_H

--- a/code/components/tflite_ctrl/CTfLiteClass.h
+++ b/code/components/tflite_ctrl/CTfLiteClass.h
@@ -2,8 +2,8 @@
 #define CTFLITECLASS_H
 
 #include <tensorflow/lite/micro/micro_mutable_op_resolver.h>
-#include "tensorflow/lite/micro/micro_interpreter.h"
-#include "tensorflow/lite/schema/schema_generated.h"
+#include <tensorflow/lite/micro/micro_interpreter.h>
+#include <tensorflow/lite/schema/schema_generated.h>
 
 #include "CImageBasis.h"
 
@@ -11,37 +11,34 @@ class CTfLiteClass
 {
   protected:
     tflite::MicroMutableOpResolver<10> microOpResolver;
+    uint8_t *modelFile;
     const tflite::Model *model;
-    tflite::MicroInterpreter *interpreter;
-    TfLiteTensor *output = nullptr;
     int kTensorArenaSize;
-    uint8_t *tensor_arena;
-    unsigned char *modelfile = NULL;
+    uint8_t *tensorArena;
+    tflite::MicroInterpreter *interpreter;
+    TfLiteTensor *output;
 
-    float *input;
-    int input_i;
-    int im_height, im_width, im_channel;
+    int imHeight, imWidth, imChannel;
 
-    bool ReadFileToModel(std::string _fn);
-    void LoadOpResolver(void);
+    bool readFileToModel(std::string fileName);
+    void loadOpResolver(void);
 
   public:
     CTfLiteClass();
     ~CTfLiteClass();
-    void CTfLiteClassDeleteInterpreter();
-    bool LoadModel(std::string _fn);
-    bool MakeAllocate();
-    void GetInputTensorSize();
-    bool LoadInputImageBasis(CImageBasis *rs);
-    void Invoke();
-    int GetAnzOutPut(bool silent = true);
-    int GetOutClassification(int _von = -1, int _bis = -1);
+    void deleteInterpreter();
 
-    int GetClassFromImageBasis(CImageBasis *rs);
+    bool makeAllocate();
+    bool loadModel(std::string fileName);
+    bool loadInputImage(CImageBasis *image);
+    bool invoke();
 
-    float GetOutputValue(int nr);
-    bool GetInputDimension(bool silent);
-    int ReadInputDimenstion(int _dim);
+    bool parseInputDimension();
+    int getInputDimension(int dim);
+
+    int getOutputDimension();
+    int getOutClassification(int from = -1, int to = -1);
+    float getOutputValue(int index);
 };
 
 #endif // CTFLITECLASS_H

--- a/code/test/components/config_handling/config_json_default_expected.txt
+++ b/code/test/components/config_handling/config_json_default_expected.txt
@@ -73,7 +73,7 @@ Modify JSON elements accordingly to test lower limits and stringfy as compact ve
   "digit": {
     "enabled": true,
     "model": "dig-class100_0173_s2_q.tflite",
-    "cnngoodthreshold": "0.00",
+    "cnngoodthreshold": "0.50",
     "sequence": [
       {
         "sequenceid": 0,

--- a/code/test/components/config_handling/test_configClass.cpp
+++ b/code/test/components/config_handling/test_configClass.cpp
@@ -39,7 +39,7 @@ void test_configJsonParseAndSerialization()
         "source\",\"rawimagesretention\":3}},\"imagealignment\":{\"alignmentalgo\":0,\"searchfield\":{\"x\":20,\"y\":20},"
         "\"imagerotation\":\"0.0\",\"marker\":[{\"x\":1,\"y\":1},{\"x\":1,\"y\":1}],\"debug\":{\"savedebuginfo\":false}},"
         "\"numbersequences\":{\"sequence\":[{\"sequenceid\":0,\"sequencename\":\"main\"}]},\"digit\":{\"enabled\":true,\"model\":\"dig-"
-        "class100_0173_s2_q.tflite\",\"cnngoodthreshold\":\"0.00\",\"sequence\":[{\"sequenceid\":0,\"sequencename\":\"main\",\"roi\":[]}],"
+        "class100_0173_s2_q.tflite\",\"cnngoodthreshold\":\"0.50\",\"sequence\":[{\"sequenceid\":0,\"sequencename\":\"main\",\"roi\":[]}],"
         "\"debug\":{\"saveroiimages\":false,\"roiimageslocation\":\"/log/"
         "digit\",\"roiimagesretention\":3}},\"analog\":{\"enabled\":true,\"model\":\"ana-class100_0171_s1_q.tflite\",\"sequence\":[{"
         "\"sequenceid\":0,\"sequencename\":\"main\",\"roi\":[]}],\"debug\":{\"saveroiimages\":false,\"roiimageslocation\":\"/log/"

--- a/docs/Configuration/Parameter/Digit/CNNGoodThreshold.md
+++ b/docs/Configuration/Parameter/Digit/CNNGoodThreshold.md
@@ -3,8 +3,8 @@
 |                   | WebUI               | REST API
 |:---               |:---                 |:----
 | Parameter Name    | CNN Good Threshold  | cnngoodthreshold
-| Default Value     | `0.0`               | `0.0`
-| Input Options     | `0.0` .. `1.0`      | `0.0` .. `1.0`
+| Default Value     | `0.00`              | `0.00`
+| Input Options     | `0.00` .. `1.00`    | `0.00` .. `1.00`
 
 
 !!! Warning
@@ -19,6 +19,6 @@ Below this threshold CNN result gets rejected for further processing.
 
 !!! Note
     This parameter is only activated for `dig-cont-*.tflite` models! 
-    1.0 represents a 100% match. Best suitable value needs to be evaluated over a 
+    `1.00` represents a 100% match. Best suitable value needs to be evaluated over a 
     longer test period. If it's rejecting the value to often, lower the threshold 
     until you find the sweet spot of recognition.

--- a/docs/Configuration/Parameter/OperationMode/OpMode.md
+++ b/docs/Configuration/Parameter/OperationMode/OpMode.md
@@ -2,7 +2,7 @@
 
 |                   | WebUI               | REST API
 |:---               |:---                 |:----
-| Parameter Name    | Operation Mode | [sequence].maxratechecktype
+| Parameter Name    | Operation Mode      | opmode
 | Default Value     | `Automatic`         | `1`
 | Input Options     | `Setup`<br>`Manual`<br>`Automatic` | `-1`<br>`0`<br>`1`
 

--- a/docs/Configuration/Parameter/OperationMode/UseDemoImages.md
+++ b/docs/Configuration/Parameter/OperationMode/UseDemoImages.md
@@ -2,7 +2,7 @@
 
 |                   | WebUI               | REST API
 |:---               |:---                 |:----
-| Parameter Name    | Use Demo Images     | Usedemoimages
+| Parameter Name    | Use Demo Images     | usedemoimages
 | Default Value     | `false`             | `false`
 | Input Options     | `false`<br>`true`   | `false`<br>`true` 
 


### PR DESCRIPTION
- General refactoring of classes `ClassFlowCNNGeneral` and `CTfLite` to align to general coding style and better maintainability
- Avoid usage of internal helper struct in `ClassFlowCNNGeneral` to reduce dynamic heap usage
- Adapt default value for `cnnGoodThreshold` from `0.00` to `0.50` to reject results with low probability by default (only relevant for new setups with usage of `dig-cont` models)

---
### Usage stats

Before (based on ESP32):
RAM:   [==        ]  15.8% (used 51776 bytes from 327680 bytes)
Flash: [========= ]  86.9% (used 1690122 bytes from 1945600 bytes)


After:
RAM:   [==        ]  15.8% (used 51800 bytes from 327680 bytes)
Flash: [========= ]  86.8% (used 1689602 bytes from 1945600 bytes)