### PR TITLE
refactor(rest api): Refactor `main` + `img_tmp` handler (server-side)

### DIFF
--- a/code/components/fileserver_ota/server_file.cpp
+++ b/code/components/fileserver_ota/server_file.cpp
@@ -200,63 +200,72 @@ esp_err_t getCertFileList(httpd_req_t *req)
 }
 
 
-esp_err_t sendFile(httpd_req_t *req, std::string filename)
+esp_err_t IRAM_ATTR sendFile(httpd_req_t *req, std::string filename, bool disableCache)
 {
-    FILE *fd = fopen(filename.c_str(), "r");
+    FILE *fd = fopen(filename.c_str(), "rb");
     if (fd == NULL) {
         httpd_resp_send_err(req, HTTPD_404_NOT_FOUND, get404());
         return ESP_FAIL;
     }
 
-    /* Related to article: https://blog.drorgluska.com/2022/06/esp32-sd-card-optimization.html */
+    // Related to article: https://blog.drorgluska.com/2022/06/esp32-sd-card-optimization.html
     // Set buffer to SD card allocation size of 512 byte (newlib default: 128 byte) -> reduce system read/write calls
     setvbuf(fd, NULL, _IOFBF, 512);
 
-    // ESP_LOGI(TAG, "Sending file: %s", filename.c_str());
+    if (disableCache) {
+        httpd_resp_set_hdr(req, "Cache-Control", "max-age=0");
+    }
+    else {
+        bool cacheFile = false;
+        const char *cacheControl = "max-age=0";
 
-    // For all files with the following file extention tell the webbrowser to cache them for a long period
-    if (endsWith(filename, ".html") || endsWith(filename, ".htm") || endsWith(filename, ".css") || endsWith(filename, ".js") ||
-        endsWith(filename, ".map") || endsWith(filename, ".jpg") || endsWith(filename, ".jpeg") || endsWith(filename, ".ico") ||
-        endsWith(filename, ".gif") || endsWith(filename, ".svg") || endsWith(filename, ".png") || endsWith(filename, ".md") ||
-        endsWith(filename, ".webmanifest") || endsWith(filename, ".txt")) {
-        if (filename == "/sdcard/html/index.html") {
-            httpd_resp_set_hdr(req, "Cache-Control", "max-age=0");
+        const std::set<std::string> fileTypes = {".html", ".htm", ".css", ".js",  ".map", ".jpg",         ".jpeg",
+                                                 ".ico",  ".gif", ".svg", ".png", ".md",  ".webmanifest", ".txt"};
+
+        for (const auto &type : fileTypes) {
+            if (endsWith(filename, type)) {
+                cacheFile = true;
+                if (filename == "/sdcard/html/index.html") {
+                    cacheControl = "max-age=0"; // Do not cache index.html
+                }
+                else if (filename == "/sdcard/html/setup.html") {
+                    httpd_resp_set_hdr(req, "Clear-Site-Data", "\"*\"");
+                }
+                else {
+                    cacheControl = "max-age=31536000"; // Cache other assets for a long time
+                }
+                break;
+            }
         }
-        else if (filename == "/sdcard/html/setup.html") {
-            httpd_resp_set_hdr(req, "Clear-Site-Data", "\"*\"");
-        }
-        else {
-            httpd_resp_set_hdr(req, "Cache-Control", "max-age=31536000");
+
+        if (cacheFile) {
+            httpd_resp_set_hdr(req, "Cache-Control", cacheControl);
         }
     }
 
-    setContentTypeFromFile(req, filename.c_str());
+    setContentTypeFromFile(req, filename.c_str()); // Set the Content-Type based on file extension
 
-    /* Retrieve the pointer to scratch buffer for temporary storage */
     char *chunk = (char *)((struct HttpServerData *)req->user_ctx)->scratch;
     size_t chunksize;
+
     do {
-        /* Read file in chunks into the scratch buffer */
         chunksize = fread(chunk, 1, WEBSERVER_SCRATCH_BUFSIZE, fd);
 
-        /* Send the buffer contents as HTTP response chunk */
-        if (httpd_resp_send_chunk(req, chunk, chunksize) != ESP_OK) {
-            fclose(fd);
-            std::string msg_txt = "sendFile: Failed to send file: " + filename;
-            LogFile.writeToFile(ESP_LOG_DEBUG, TAG, msg_txt);
-            httpd_resp_sendstr_chunk(req, NULL);
-            httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, msg_txt.c_str());
-            return ESP_FAIL;
+        if (chunksize > 0) {
+            if (httpd_resp_send_chunk(req, chunk, chunksize) != ESP_OK) {
+                fclose(fd);
+                std::string msgTxt = "sendFile: Failed to send file: " + filename;
+                LogFile.writeToFile(ESP_LOG_DEBUG, TAG, msgTxt);
+                httpd_resp_sendstr_chunk(req, NULL); // Send empty chunk for closure
+                httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, msgTxt.c_str());
+                return ESP_FAIL;
+            }
         }
+    } while (chunksize > 0);
 
-        /* Keep looping till the whole file is sent */
-    } while (chunksize != 0);
-
-    /* Close file after sending complete */
     fclose(fd);
 
-    /* Respond with an empty chunk to signal HTTP response completion */
-    httpd_resp_send_chunk(req, NULL, 0);
+    httpd_resp_send_chunk(req, NULL, 0); // Respond with an empty chunk to signal HTTP response completion
     return ESP_OK;
 }
 

--- a/code/components/fileserver_ota/server_file.cpp
+++ b/code/components/fileserver_ota/server_file.cpp
@@ -202,58 +202,49 @@ esp_err_t getCertFileList(httpd_req_t *req)
 
 esp_err_t IRAM_ATTR sendFile(httpd_req_t *req, std::string filename, bool disableCache)
 {
-    FILE *fd = fopen(filename.c_str(), "rb");
-    if (fd == NULL) {
+    FILE *file = fopen(filename.c_str(), "rb");
+    if (file == NULL) {
         httpd_resp_send_err(req, HTTPD_404_NOT_FOUND, get404());
         return ESP_FAIL;
     }
 
     // Related to article: https://blog.drorgluska.com/2022/06/esp32-sd-card-optimization.html
     // Set buffer to SD card allocation size of 512 byte (newlib default: 128 byte) -> reduce system read/write calls
-    setvbuf(fd, NULL, _IOFBF, 512);
+    setvbuf(file, NULL, _IOFBF, 512);
 
-    if (disableCache) {
-        httpd_resp_set_hdr(req, "Cache-Control", "max-age=0");
-    }
-    else {
-        bool cacheFile = false;
-        const char *cacheControl = "max-age=0";
+    // Files listed are never be cached (declared static to avoid reallocation)
+    static const std::set<std::string> specialNoCacheFiles = {"/sdcard/html/index.html", "/sdcard/html/setup.html"};
+    bool doNotCacheFile = specialNoCacheFiles.count(filename) > 0;
 
-        const std::set<std::string> fileTypes = {".html", ".htm", ".css", ".js",  ".map", ".jpg",         ".jpeg",
-                                                 ".ico",  ".gif", ".svg", ".png", ".md",  ".webmanifest", ".txt"};
+    // Default cache behaviour -> no caching
+    const char *cacheControl = "max-age=0";
 
+    if (!disableCache && !doNotCacheFile) {
+        // Files types listed shall be cached (Declared static to avoid reallocation)
+        static const std::set<std::string> fileTypes = {".html", ".htm", ".css", ".js",  ".map", ".jpg",         ".jpeg",
+                                                        ".ico",  ".gif", ".svg", ".png", ".md",  ".webmanifest", ".txt"};
+
+        // Check if file type is matching
         for (const auto &type : fileTypes) {
             if (endsWith(filename, type)) {
-                cacheFile = true;
-                if (filename == "/sdcard/html/index.html") {
-                    cacheControl = "max-age=0"; // Do not cache index.html
-                }
-                else if (filename == "/sdcard/html/setup.html") {
-                    httpd_resp_set_hdr(req, "Clear-Site-Data", "\"*\"");
-                }
-                else {
-                    cacheControl = "max-age=31536000"; // Cache other assets for a long time
-                }
+                cacheControl = "max-age=31536000";
                 break;
             }
         }
-
-        if (cacheFile) {
-            httpd_resp_set_hdr(req, "Cache-Control", cacheControl);
-        }
     }
 
-    setContentTypeFromFile(req, filename.c_str()); // Set the Content-Type based on file extension
+    httpd_resp_set_hdr(req, "Cache-Control", cacheControl); // Set cache control header
+    setContentTypeFromFile(req, filename.c_str());          // Set content-type header based on file type (extention)
 
     char *chunk = (char *)((struct HttpServerData *)req->user_ctx)->scratch;
     size_t chunksize;
 
     do {
-        chunksize = fread(chunk, 1, WEBSERVER_SCRATCH_BUFSIZE, fd);
+        chunksize = fread(chunk, 1, WEBSERVER_SCRATCH_BUFSIZE, file);
 
         if (chunksize > 0) {
             if (httpd_resp_send_chunk(req, chunk, chunksize) != ESP_OK) {
-                fclose(fd);
+                fclose(file);
                 std::string msgTxt = "sendFile: Failed to send file: " + filename;
                 LogFile.writeToFile(ESP_LOG_DEBUG, TAG, msgTxt);
                 httpd_resp_sendstr_chunk(req, NULL); // Send empty chunk for closure
@@ -263,9 +254,9 @@ esp_err_t IRAM_ATTR sendFile(httpd_req_t *req, std::string filename, bool disabl
         }
     } while (chunksize > 0);
 
-    fclose(fd);
+    fclose(file);
 
-    httpd_resp_send_chunk(req, NULL, 0); // Respond with an empty chunk to signal HTTP response completion
+    httpd_resp_send_chunk(req, NULL); // Respond with an empty chunk to signal HTTP response completion
     return ESP_OK;
 }
 

--- a/code/components/fileserver_ota/server_file.cpp
+++ b/code/components/fileserver_ota/server_file.cpp
@@ -216,7 +216,7 @@ esp_err_t IRAM_ATTR sendFile(httpd_req_t *req, std::string filename, bool disabl
     static const std::set<std::string> specialNoCacheFiles = {"/sdcard/html/index.html", "/sdcard/html/setup.html"};
     bool doNotCacheFile = specialNoCacheFiles.count(filename) > 0;
 
-    // Default cache behaviour -> no caching
+    // Default cache behaviour -> disable caching
     const char *cacheControl = "max-age=0";
 
     if (!disableCache && !doNotCacheFile) {
@@ -227,7 +227,7 @@ esp_err_t IRAM_ATTR sendFile(httpd_req_t *req, std::string filename, bool disabl
         // Check if file type is matching
         for (const auto &type : fileTypes) {
             if (endsWith(filename, type)) {
-                cacheControl = "max-age=31536000";
+                cacheControl = "max-age=31536000"; // Cache for a long time (1 year)
                 break;
             }
         }
@@ -256,7 +256,7 @@ esp_err_t IRAM_ATTR sendFile(httpd_req_t *req, std::string filename, bool disabl
 
     fclose(file);
 
-    httpd_resp_send_chunk(req, NULL); // Respond with an empty chunk to signal HTTP response completion
+    httpd_resp_sendstr_chunk(req, NULL); // Respond with an empty chunk to signal HTTP response completion
     return ESP_OK;
 }
 

--- a/code/components/fileserver_ota/server_file.h
+++ b/code/components/fileserver_ota/server_file.h
@@ -9,7 +9,7 @@
 esp_err_t getDataFileList(httpd_req_t *req);
 esp_err_t getTfliteFileList(httpd_req_t *req);
 esp_err_t getCertFileList(httpd_req_t *req);
-esp_err_t sendFile(httpd_req_t *req, std::string filename);
+esp_err_t sendFile(httpd_req_t *req, std::string filename, bool disableCache = false);
 
 void registerFileserverUri(httpd_handle_t server, const char *basePath);
 

--- a/code/components/fileserver_ota/server_help.cpp
+++ b/code/components/fileserver_ota/server_help.cpp
@@ -2,6 +2,8 @@
 #include "../../include/defines.h"
 
 #include <stdio.h>
+#include <algorithm>
+#include <cctype>
 #include <sys/param.h>
 #include <sys/unistd.h>
 #include <sys/stat.h>
@@ -25,18 +27,18 @@ extern "C" {
 
 static const char *TAG = "SERVER_HELP";
 
-
+// Check file type (file extention, case-insensitive)
 bool endsWith(std::string const &str, std::string const &suffix)
 {
     if (str.length() < suffix.length()) {
         return false;
     }
-    return str.compare(str.length() - suffix.length(), suffix.length(), suffix) == 0;
+
+    return std::equal(suffix.rbegin(), suffix.rend(), str.rbegin(), [](char a, char b) { return std::tolower(a) == std::tolower(b); });
 }
 
 
-/* Copies the full path into destination buffer and returns
- * pointer to path (skipping the preceding base path) */
+// Copies the full path into destination buffer and returns pointer to path (skipping the preceding base path)
 const char *getPathFromUri(char *dest, const char *basePath, const char *uri, size_t destsize)
 {
     const size_t basePathLength = strlen(basePath);
@@ -65,7 +67,7 @@ const char *getPathFromUri(char *dest, const char *basePath, const char *uri, si
 }
 
 
-/* Set HTTP response content type according to file extension */
+// Set HTTP response content type according to file extension
 esp_err_t setContentTypeFromFile(httpd_req_t *req, const char *filename)
 {
     if (IS_FILE_EXT(filename, ".pdf")) {

--- a/code/components/webserver_softap/webserver.cpp
+++ b/code/components/webserver_softap/webserver.cpp
@@ -567,88 +567,56 @@ esp_err_t handler_get_info(httpd_req_t *req)
 
 esp_err_t handler_img_tmp(httpd_req_t *req)
 {
-    char filepath[50];
-    ESP_LOGD(TAG, "uri: %s", req->uri);
+    // Extract the file name from the URI after the '/img_tmp/' prefix
+    std::string fileName = std::string(req->uri).substr(strlen("/img_tmp/"));
 
-    char *basePath = (char *)((struct HttpServerData *)req->user_ctx)->basePathRoot;
-    std::string filetosend(basePath);
-
-    const char *filename = getPathFromUri(filepath, basePath, req->uri + sizeof("/img_tmp/") - 1, sizeof(filepath));
-    ESP_LOGD(TAG, "1 uri: %s, filename: %s, filepath: %s", req->uri, filename, filepath);
-
-    filetosend = filetosend + "/img_tmp/" + std::string(filename);
-    ESP_LOGD(TAG, "File to upload: %s", filetosend.c_str());
-
-    esp_err_t res = sendFile(req, filetosend);
-    if (res != ESP_OK) {
-        return res;
+    int pos = fileName.find("?");
+    if (pos != std::string::npos) {
+        fileName = fileName.substr(0, pos);
     }
 
-    /* Respond with an empty chunk to signal HTTP response completion */
-    httpd_resp_send_chunk(req, NULL, 0);
-    return ESP_OK;
-}
-
-
-esp_err_t handler_img_tmp_virtual(httpd_req_t *req)
-{
-    char filepath[50];
-
-    ESP_LOGD(TAG, "uri: %s", req->uri);
-
-    char *basePath = (char *)((struct HttpServerData *)req->user_ctx)->basePathRoot;
-    std::string filetosend(basePath);
-
-    const char *filename = getPathFromUri(filepath, basePath, req->uri + sizeof("/img_tmp/") - 1, sizeof(filepath));
-    ESP_LOGD(TAG, "1 uri: %s, filename: %s, filepath: %s", req->uri, filename, filepath);
-
-    filetosend = std::string(filename);
-    ESP_LOGD(TAG, "File to upload: %s", filetosend.c_str());
-
-    // Serve raw.jpg
-    if (filetosend == "raw.jpg") {
-        return flowctrl.sendRawJPG(req);
+    // Requesting raw.jpg, respond with a newly captured image
+    if (fileName == "raw.jpg") {
+        return cameraCtrl.captureToHTTP(req);
     }
 
-    // Serve alg.jpg, alg_roi.jpg or digit and analog ROIs
-    return flowctrl.getJPGStream(filetosend, req);
-
-    // File was not served already --> serve with img_tmp_handler
-    return handler_img_tmp(req);
+    // Serve process-related images (process state images, alg.jpg, alg_roi.jpg, ROIs)
+    return flowctrl.getJPGStream(fileName, req);
 }
 
 
 esp_err_t handler_main(httpd_req_t *req)
 {
-    char filepath[50];
-    char *basePath = (char *)((struct HttpServerData *)req->user_ctx)->basePathRoot;
-    std::string filetosend(basePath);
+    if (req->uri[0] == '\0') {
+        return httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST, "Invalid URI");
+    }
 
-    const char *filename = getPathFromUri(filepath, basePath, req->uri - 1, sizeof(filepath));
-    ESP_LOGD(TAG, "uri: %s, filename: %s, filepath: %s", req->uri, filename, filepath);
+    const std::string basePath = ((struct HttpServerData *)req->user_ctx)->basePathRoot;
+    std::string filepath = basePath;
 
-    if ((strcmp(req->uri, "/") == 0)) {
-        filetosend = filetosend + "/html/index.html";
+    if (strcmp(req->uri, "/") == 0) {
+        filepath.append("/html/index.html");
     }
     else {
-        filetosend += "/html" + std::string(req->uri);
-        int pos = filetosend.find("?");
-        if (pos != std::string::npos) {
-            filetosend = filetosend.substr(0, pos);
+        filepath.append("/html").append(req->uri);
+
+        // Remove query part from URI if present
+        size_t queryPos = filepath.find('?');
+        if (queryPos != std::string::npos) {
+            filepath = filepath.substr(0, queryPos);
         }
     }
 
-    if (filetosend == "/sdcard/html/index.html") {
-        // Check basic device initialization status:
-        // If critical error(s) occured which do not allow to start regular process and web interface, redirect to a reduced web interface
+    if (filepath == "/sdcard/html/index.html") {
+        // Check if critical errors prevent normal operation
         if (isSetSystemStatusFlag(SYSTEM_STATUS_PSRAM_BAD) || isSetSystemStatusFlag(SYSTEM_STATUS_HEAP_TOO_SMALL) ||
             isSetSystemStatusFlag(SYSTEM_STATUS_SDCARD_CHECK_BAD) || isSetSystemStatusFlag(SYSTEM_STATUS_FOLDER_CHECK_BAD)) {
-            LogFile.writeToFile(ESP_LOG_ERROR, TAG, "Critical error(s) occured, redirect to reduced web interface");
+            LogFile.writeToFile(ESP_LOG_ERROR, TAG, "Critical error(s) occurred, redirect to reduced web interface");
 
-            char buf[20];
-            std::string message = "<h1>AI on the Edge</h1><b>Critical error(s) occured, which do not allow to start regular process and "
+            std::string message = "<h1>AI on the Edge</h1><b>Critical error(s) occurred, which do not allow to start regular process and "
                                   "web interface:</b><br>";
 
+            char buf[20];
             for (int i = 0; i < 32; i++) {
                 if (isSetSystemStatusFlag((SystemStatusFlag_t)(1 << i))) {
                     snprintf(buf, sizeof(buf), "0x%08X", 1 << i);
@@ -666,23 +634,13 @@ esp_err_t handler_main(httpd_req_t *req)
             httpd_resp_send(req, message.c_str(), message.length());
             return ESP_OK;
         }
-        else if (flowctrl.getStatusSetupModus()) {
+        else if (flowctrl.getStatusSetupModus()) { // If in setup mode, redirect to setup page
             ESP_LOGD(TAG, "System is in setup mode. Redirect from index.html --> setup.html");
-            filetosend = "/sdcard/html/setup.html";
+            filepath = "/sdcard/html/setup.html";
         }
     }
 
-    ESP_LOGD(TAG, "Filename: %s", filename);
-    ESP_LOGD(TAG, "File requested: %s", filetosend.c_str());
-
-    if (!filename) {
-        ESP_LOGE(TAG, "Filename is too long");
-        /* Respond with 414 Error */
-        httpd_resp_send_err(req, HTTPD_414_URI_TOO_LONG, "Filename too long");
-        return ESP_FAIL;
-    }
-
-    return sendFile(req, filetosend);
+    return sendFile(req, filepath);
 }
 
 
@@ -738,7 +696,7 @@ void registerWebserverUri(httpd_handle_t server, const char *basePath)
     httpd_register_uri_handler(server, &camuri);
 
     camuri.uri = "/img_tmp/*";
-    camuri.handler = HTTP_AUTH_BASIC(handler_img_tmp_virtual);
+    camuri.handler = HTTP_AUTH_BASIC(handler_img_tmp);
     camuri.user_ctx = httpServerData; // Pass server data as context
     httpd_register_uri_handler(server, &camuri);
 


### PR DESCRIPTION
Refactor the following REST API handler (server-side) to align with actual coding style and simplify logic
- main (incl. underlaying `sendFile` function)
- img_tmp

---
### Usage stats

Before (based on ESP32):
RAM:   [==        ]  15.8% (used 51800 bytes from 327680 bytes)
Flash: [========= ]  86.8% (used 1689602 bytes from 1945600 bytes)

After:
RAM:   [==        ]  15.8% (used 51864 bytes from 327680 bytes)
Flash: [========= ]  86.8% (used 1689726 bytes from 1945600 bytes)