### PR TITLE
chore(system info): Update sd-card manufacturer list

### DIFF
--- a/code/components/misc_helper/system.cpp
+++ b/code/components/misc_helper/system.cpp
@@ -17,12 +17,12 @@
 
 static const char *TAG = "SYSTEM";
 
-unsigned int systemStatus = 0;
+static unsigned int systemStatus = 0;
 static bool isPlannedReboot = false;
 static SPIRAMCategory_t SPIRAMCategory = SPIRAMCategory_4MB;
 
-sdmmc_cid_t SDCardCid;
-sdmmc_csd_t SDCardCsd;
+static sdmmc_cid_t SDCardCid;
+static sdmmc_csd_t SDCardCsd;
 
 
 std::string getBoardType(void)
@@ -390,7 +390,6 @@ void saveSDCardInfo(sdmmc_card_t *card)
 }
 
 
-/////////////////////////////////////////////////////////////////////////////////////////////
 // SD Card Manufacturer Database
 // Source: https://git.kernel.org/pub/scm/utils/mmc/mmc-utils.git/tree/lsmmc.c
 struct SDCardManufacturerDatabase {

--- a/code/components/misc_helper/system.cpp
+++ b/code/components/misc_helper/system.cpp
@@ -555,14 +555,17 @@ std::string parseSDCardManufacturerID(int id)
 
 std::string getSDCardManufacturer()
 {
-    std::string manufacturer = parseSDCardManufacturerID(SDCardCid.mfg_id);
+    std::string SDCardManufacturer = parseSDCardManufacturerID(SDCardCid.mfg_id);
+    // ESP_LOGD(TAG, "SD Card Manufacturer: %s", SDCardManufacturer.c_str());
 
-    return manufacturer + " (ID: " + std::to_string(SDCardCid.mfg_id) + ")";
+    return SDCardManufacturer + " (ID: " + std::to_string(SDCardCid.mfg_id) + ")";
 }
 
 
 std::string getSDCardName()
 {
+    // ESP_LOGD(TAG, "SD Card Name: %s", SDCardCid.name);
+
     return std::string(SDCardCid.name, 8);
 }
 
@@ -571,24 +574,18 @@ int getSDCardPartitionSize()
 {
     FATFS *fs;
     uint32_t freeClusters;
-    unsigned long long totalBytes;
-    int totalMB;
 
     // Get volume information and free clusters of drive 0
     if (f_getfree("0:", (DWORD *)&freeClusters, &fs) != FR_OK || fs == nullptr) {
         return -1; // Error case
     }
 
-    // Total sectors = number of clusters * sectors per cluster
-    unsigned long totalSectors = (fs->n_fatent - 2) * fs->csize;
+    // Corrected by SD Card sector size (usually 512 bytes) and convert to MB
+    const uint32_t totalSectors = ((fs->n_fatent - 2) * fs->csize) / 1024 / (1024 / SDCardCsd.sector_size);
 
-    // Total bytes = total sectors * bytes per sector
-    totalBytes = (unsigned long long)totalSectors * SDCardCsd.sector_size;
+    // ESP_LOGD(TAG, "%d MB total drive space (Sector size [bytes]: %d)", (int)totalSectors, (int)fs->ssize);
 
-    // Convert bytes to MB
-    totalMB = (int)(totalBytes / (1024 * 1024));
-
-    return totalMB;
+    return totalSectors;
 }
 
 
@@ -596,21 +593,18 @@ int getSDCardFreePartitionSpace()
 {
     FATFS *fs;
     uint32_t freeClusters;
-    unsigned long long freeBytes;
-    int freeMB;
 
-    // Get volume info and free cluster of drive 0
+    // Get volume information and free clusters of drive 0
     if (f_getfree("0:", (DWORD *)&freeClusters, &fs) != FR_OK || fs == nullptr) {
         return -1; // Error case
     }
 
-    // Free space in bytes = free clusters * sectors per cluster * bytes per sector
-    freeBytes = (unsigned long long)freeClusters * fs->csize * SDCardCsd.sector_size;
+    // Corrected by SD Card sector size (usually 512 bytes) and convert to MB
+    const uint32_t freeSectors = (freeClusters * fs->csize) / 1024 / (1024 / SDCardCsd.sector_size);
 
-    // Convert bytes to MB
-    freeMB = (int)(freeBytes / (1024 * 1024));
+    // ESP_LOGD(TAG, "%d MB free drive space (Sector size [bytes]: %d)", (int)freeSectors, (int)fs->ssize);
 
-    return freeMB;
+    return freeSectors;
 }
 
 
@@ -624,14 +618,18 @@ int getSDCardPartitionAllocationSize()
         return -1; // Error case
     }
 
-    return (int)fs->ssize;
+    // ESP_LOGD(TAG, "SD Card Partition Allocation Size: %d bytes", fs->ssize);
+
+    return fs->ssize;
 }
 
 
 int getSDCardCapacity()
 {
-    // Total sectors * sector size  --> Byte to MB (1024 * 1024)
+    // Total sectors * sector size  --> Byte to MB (1024*1024)
     const int sdCardCapacity = SDCardCsd.capacity / (1024 / SDCardCsd.sector_size) / 1024;
+
+    // ESP_LOGD(TAG, "SD Card Capacity: %d", sdCardCapacity);
 
     return sdCardCapacity;
 }
@@ -639,5 +637,7 @@ int getSDCardCapacity()
 
 int getSDCardSectorSize()
 {
+    // ESP_LOGD(TAG, "SD Card Sector Size: %d bytes", SDCardCsd.sector_size);
+
     return SDCardCsd.sector_size;
 }

--- a/code/components/misc_helper/system.cpp
+++ b/code/components/misc_helper/system.cpp
@@ -391,221 +391,253 @@ void saveSDCardInfo(sdmmc_card_t *card)
 
 
 /////////////////////////////////////////////////////////////////////////////////////////////
-/* Source: https://git.kernel.org/pub/scm/utils/mmc/mmc-utils.git/tree/lsmmc.c */
-/* SD Card Manufacturer Database */
-struct SDCard_Manufacturer_database {
+// SD Card Manufacturer Database
+// Source: https://git.kernel.org/pub/scm/utils/mmc/mmc-utils.git/tree/lsmmc.c
+struct SDCardManufacturerDatabase {
     std::string type;
     int id;
     std::string manufacturer;
 };
 
 
-/* Source: https://git.kernel.org/pub/scm/utils/mmc/mmc-utils.git/tree/lsmmc.c */
-/* SD Card Manufacturer Database */
-struct SDCard_Manufacturer_database database[] = {{
-                                                      .type = "sd",
-                                                      .id = 0x01,
-                                                      .manufacturer = "Panasonic",
-                                                  },
-                                                  {
-                                                      .type = "sd",
-                                                      .id = 0x02,
-                                                      .manufacturer = "Toshiba/Kingston/Viking",
-                                                  },
-                                                  {
-                                                      .type = "sd",
-                                                      .id = 0x03,
-                                                      .manufacturer = "SanDisk",
-                                                  },
-                                                  {
-                                                      .type = "sd",
-                                                      .id = 0x08,
-                                                      .manufacturer = "Silicon Power",
-                                                  },
-                                                  {
-                                                      .type = "sd",
-                                                      .id = 0x18,
-                                                      .manufacturer = "Infineon",
-                                                  },
-                                                  {
-                                                      .type = "sd",
-                                                      .id = 0x1b,
-                                                      .manufacturer = "Transcend/Samsung",
-                                                  },
-                                                  {
-                                                      .type = "sd",
-                                                      .id = 0x1c,
-                                                      .manufacturer = "Transcend",
-                                                  },
-                                                  {
-                                                      .type = "sd",
-                                                      .id = 0x1d,
-                                                      .manufacturer = "Corsair/AData",
-                                                  },
-                                                  {
-                                                      .type = "sd",
-                                                      .id = 0x1e,
-                                                      .manufacturer = "Transcend",
-                                                  },
-                                                  {
-                                                      .type = "sd",
-                                                      .id = 0x1f,
-                                                      .manufacturer = "Kingston",
-                                                  },
-                                                  {
-                                                      .type = "sd",
-                                                      .id = 0x27,
-                                                      .manufacturer = "Delkin/Phison",
-                                                  },
-                                                  {
-                                                      .type = "sd",
-                                                      .id = 0x28,
-                                                      .manufacturer = "Lexar",
-                                                  },
-                                                  {
-                                                      .type = "sd",
-                                                      .id = 0x30,
-                                                      .manufacturer = "SanDisk",
-                                                  },
-                                                  {
-                                                      .type = "sd",
-                                                      .id = 0x31,
-                                                      .manufacturer = "Silicon Power",
-                                                  },
-                                                  {
-                                                      .type = "sd",
-                                                      .id = 0x33,
-                                                      .manufacturer = "STMicroelectronics",
-                                                  },
-                                                  {
-                                                      .type = "sd",
-                                                      .id = 0x41,
-                                                      .manufacturer = "Kingston",
-                                                  },
-                                                  {
-                                                      .type = "sd",
-                                                      .id = 0x6f,
-                                                      .manufacturer = "STMicroelectronics",
-                                                  },
-                                                  {
-                                                      .type = "sd",
-                                                      .id = 0x74,
-                                                      .manufacturer = "Transcend",
-                                                  },
-                                                  {
-                                                      .type = "sd",
-                                                      .id = 0x76,
-                                                      .manufacturer = "Patriot",
-                                                  },
-                                                  {
-                                                      .type = "sd",
-                                                      .id = 0x82,
-                                                      .manufacturer = "Gobe/Sony",
-                                                  },
-                                                  {
-                                                      .type = "sd",
-                                                      .id = 0x89,
-                                                      .manufacturer = "Unknown",
-                                                  }};
+static const SDCardManufacturerDatabase database[] = {
+    {
+        .type = "sd",
+        .id = 0x01,
+        .manufacturer = "Panasonic",
+    },
+    {
+        .type = "sd",
+        .id = 0x02,
+        .manufacturer = "Toshiba/Kingston/Viking",
+    },
+    {
+        .type = "sd",
+        .id = 0x03,
+        .manufacturer = "SanDisk",
+    },
+    {
+        .type = "sd",
+        .id = 0x05,
+        .manufacturer = "Lenovo",
+    },
+    {
+        .type = "sd",
+        .id = 0x08,
+        .manufacturer = "Silicon Power",
+    },
+    {
+        .type = "sd",
+        .id = 0x09,
+        .manufacturer = "ATP",
+    },
+    {
+        .type = "sd",
+        .id = 0x18,
+        .manufacturer = "Infineon",
+    },
+    {
+        .type = "sd",
+        .id = 0x1b,
+        .manufacturer = "Transcend/Samsung",
+    },
+    {
+        .type = "sd",
+        .id = 0x1c,
+        .manufacturer = "Transcend",
+    },
+    {
+        .type = "sd",
+        .id = 0x1d,
+        .manufacturer = "Corsair/AData",
+    },
+    {
+        .type = "sd",
+        .id = 0x1e,
+        .manufacturer = "Transcend",
+    },
+    {
+        .type = "sd",
+        .id = 0x1f,
+        .manufacturer = "Kingston",
+    },
+    {
+        .type = "sd",
+        .id = 0x27,
+        .manufacturer = "Delkin/Phison",
+    },
+    {
+        .type = "sd",
+        .id = 0x28,
+        .manufacturer = "Lexar",
+    },
+    {
+        .type = "sd",
+        .id = 0x30,
+        .manufacturer = "SanDisk",
+    },
+    {
+        .type = "sd",
+        .id = 0x31,
+        .manufacturer = "Silicon Power",
+    },
+    {
+        .type = "sd",
+        .id = 0x33,
+        .manufacturer = "STMicroelectronics",
+    },
+    {
+        .type = "sd",
+        .id = 0x41,
+        .manufacturer = "Kingston",
+    },
+    {
+        .type = "sd",
+        .id = 0x6f,
+        .manufacturer = "STMicroelectronics",
+    },
+    {
+        .type = "sd",
+        .id = 0x74,
+        .manufacturer = "Transcend",
+    },
+    {
+        .type = "sd",
+        .id = 0x76,
+        .manufacturer = "Patriot",
+    },
+    {
+        .type = "sd",
+        .id = 0x82,
+        .manufacturer = "Gobe/Sony",
+    },
+    {
+        .type = "sd",
+        .id = 0x89,
+        .manufacturer = "Netac",
+    },
+    {
+        .type = "sd",
+        .id = 0x9f,
+        .manufacturer = "Kingston/Kodak/Silicon Power",
+    },
+    {
+        .type = "sd",
+        .id = 0xad,
+        .manufacturer = "Amazon Basics/Lexar/OV",
+    },
+    {
+        .type = "sd",
+        .id = 0xdf,
+        .manufacturer = "Lenovo",
+    },
+    {
+        .type = "sd",
+        .id = 0xfe,
+        .manufacturer = "Bekit/Cloudisk/HP/Reletech",
+    } //
+};
 
 
-/* Parse SD Card Manufacturer Database */
 std::string parseSDCardManufacturerID(int id)
 {
-    unsigned int id_cnt = sizeof(database) / sizeof(struct SDCard_Manufacturer_database);
-    std::string ret_val = "";
+    const size_t idCnt = sizeof(database) / sizeof(struct SDCardManufacturerDatabase);
 
-    for (int i = 0; i < id_cnt; i++) {
+    for (size_t i = 0; i < idCnt; i++) {
         if (database[i].id == id) {
             return database[i].manufacturer;
         }
-        else {
-            ret_val = "ID unknown (not in DB)";
-        }
     }
-    return ret_val;
+
+    return "Unknown";
 }
 
 
 std::string getSDCardManufacturer()
 {
-    std::string SDCardManufacturer = parseSDCardManufacturerID(SDCardCid.mfg_id);
-    // ESP_LOGD(TAG, "SD Card Manufacturer: %s", SDCardManufacturer.c_str());
+    std::string manufacturer = parseSDCardManufacturerID(SDCardCid.mfg_id);
 
-    return (SDCardManufacturer + " (ID: " + std::to_string(SDCardCid.mfg_id) + ")");
+    return manufacturer + " (ID: " + std::to_string(SDCardCid.mfg_id) + ")";
 }
 
 
 std::string getSDCardName()
 {
-    char *SDCardName = SDCardCid.name;
-    // ESP_LOGD(TAG, "SD Card Name: %s", SDCardName);
-
-    return std::string(SDCardName);
+    return std::string(SDCardCid.name, 8);
 }
 
 
 int getSDCardPartitionSize()
 {
     FATFS *fs;
-    uint32_t fre_clust, tot_sect;
+    uint32_t freeClusters;
+    unsigned long long totalBytes;
+    int totalMB;
 
-    /* Get volume information and free clusters of drive 0 */
-    f_getfree("0:", (DWORD *)&fre_clust, &fs);
-    tot_sect = ((fs->n_fatent - 2) * fs->csize) / 1024 /
-               (1024 / SDCardCsd.sector_size); // corrected by SD Card sector size (usually 512 bytes) and convert to MB
+    // Get volume information and free clusters of drive 0
+    if (f_getfree("0:", (DWORD *)&freeClusters, &fs) != FR_OK || fs == nullptr) {
+        return -1; // Error case
+    }
 
-    // ESP_LOGD(TAG, "%d MB total drive space (Sector size [bytes]: %d)", (int)tot_sect, (int)fs->ssize);
+    // Total sectors = number of clusters * sectors per cluster
+    unsigned long totalSectors = (fs->n_fatent - 2) * fs->csize;
 
-    return tot_sect;
+    // Total bytes = total sectors * bytes per sector
+    totalBytes = (unsigned long long)totalSectors * SDCardCsd.sector_size;
+
+    // Convert bytes to MB
+    totalMB = (int)(totalBytes / (1024 * 1024));
+
+    return totalMB;
 }
 
 
 int getSDCardFreePartitionSpace()
 {
     FATFS *fs;
-    uint32_t fre_clust, fre_sect;
+    uint32_t freeClusters;
+    unsigned long long freeBytes;
+    int freeMB;
 
-    /* Get volume information and free clusters of drive 0 */
-    f_getfree("0:", (DWORD *)&fre_clust, &fs);
-    fre_sect = (fre_clust * fs->csize) / 1024 /
-               (1024 / SDCardCsd.sector_size); // corrected by SD Card sector size (usually 512 bytes) and convert to MB
+    // Get volume info and free cluster of drive 0
+    if (f_getfree("0:", (DWORD *)&freeClusters, &fs) != FR_OK || fs == nullptr) {
+        return -1; // Error case
+    }
 
-    // ESP_LOGD(TAG, "%d MB free drive space (Sector size [bytes]: %d)", (int)fre_sect, (int)fs->ssize);
+    // Free space in bytes = free clusters * sectors per cluster * bytes per sector
+    freeBytes = (unsigned long long)freeClusters * fs->csize * SDCardCsd.sector_size;
 
-    return fre_sect;
+    // Convert bytes to MB
+    freeMB = (int)(freeBytes / (1024 * 1024));
+
+    return freeMB;
 }
 
 
 int getSDCardPartitionAllocationSize()
 {
     FATFS *fs;
-    uint32_t fre_clust, allocation_size;
+    uint32_t freeClusters;
 
-    /* Get volume information and free clusters of drive 0 */
-    f_getfree("0:", (DWORD *)&fre_clust, &fs);
-    allocation_size = fs->ssize;
+    // Get volume information and free clusters of drive 0
+    if (f_getfree("0:", (DWORD *)&freeClusters, &fs) != FR_OK || fs == nullptr) {
+        return -1; // Error case
+    }
 
-    // ESP_LOGD(TAG, "SD Card Partition Allocation Size: %d bytes", allocation_size);
-
-    return allocation_size;
+    return (int)fs->ssize;
 }
 
 
 int getSDCardCapacity()
 {
-    int SDCardCapacity = SDCardCsd.capacity / (1024 / SDCardCsd.sector_size) /
-                         1024; // total sectors * sector size  --> Byte to MB (1024*1024)
-    // ESP_LOGD(TAG, "SD Card Capacity: %s", std::to_string(SDCardCapacity).c_str());
+    // Total sectors * sector size  --> Byte to MB (1024 * 1024)
+    const int sdCardCapacity = SDCardCsd.capacity / (1024 / SDCardCsd.sector_size) / 1024;
 
-    return SDCardCapacity;
+    return sdCardCapacity;
 }
 
 
 int getSDCardSectorSize()
 {
-    int SDCardSectorSize = SDCardCsd.sector_size;
-    // ESP_LOGD(TAG, "SD Card Sector Size: %s bytes", std::to_string(SDCardSectorSize).c_str());
-
-    return SDCardSectorSize;
+    return SDCardCsd.sector_size;
 }


### PR DESCRIPTION
- Update SD card manufacturer list 
  --> Cherry-picked from #3730
- Refactor SD card info related functions and align with actual coding style

---
### Usage Stats:

Before (based on ESP32):
RAM:   [==        ]  15.8% (used 51864 bytes from 327680 bytes)
Flash: [========= ]  87.0% (used 1691938 bytes from 1945600 bytes)

After:
RAM:   [==        ]  15.9% (used 52176 bytes from 327680 bytes)
Flash: [========= ]  87.0% (used 1692230 bytes from 1945600 bytes)