### PR TITLE
fix(home assistant discovery): Add device_class `duration` to `uptime` topic

### DIFF
--- a/code/components/mqtt_ctrl/server_mqtt.cpp
+++ b/code/components/mqtt_ctrl/server_mqtt.cpp
@@ -495,8 +495,10 @@ bool mqttServer_publishHADiscovery(int _qos)
         .topic = "/device/status/device_uptime",
         .topicName = "device_uptime",
         .friendlyName = "Uptime",
-        .icon = "clock-time-eight-outline",
+        .icon = "progress-clock",
         .unit = "s",
+        .deviceClass = "duration",
+        .stateClass = "measurement",
         .entityCategory = "diagnostic" //
     };
     publishOK &= publishHADiscoveryTopic(&HADiscoveryData, _qos);


### PR DESCRIPTION
Home Assistant discovery: Add device_class `duration` to `uptime` topic
--> Cherry-picked from #3659
