### PR TITLE
chore(build): release-please-action: Disable always-update feature

### DIFF
--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -9,6 +9,7 @@
                           {"type":"refactor","section":"Refactoring / Style Changes"},
                           {"type":"chore","section":"Other Changes"}],
   "draft-pull-request": true,
+  "always-update": false,
   "pull-request-header": ":robot: Gather changes for upcoming release",
   "pull-request-footer": "**Testing this not yet officially released version? [Download](https://github.com/Slider0007/AI-on-the-edge-device/actions/workflows/build-release.yaml?query=branch%3Adevelop+is%3Asuccess) the latest successful compilation of the branch 'develop'.** <br>The handling and update process of this version is identical to any official release version."
 


### PR DESCRIPTION
release-please action - Disable 'always update' feature
--> Feature added with this commit: https://github.com/googleapis/release-please/commit/72d40df677b08fd52654a4c3b320649f63b9c635

Explaination:
If always-update is `true`, the action always updates existing release PRs whenever any change occurs — not just when release notes change. This can help keep PRs in sync with the base branch. Absence in config shall be defaulting to `false`

Explicitly set always-update to `false` to prevent unnecessary PR updates. Although the default should be false, behavior is inconsistent without it.