### PR TITLE
(tflite class): Fix memory leak during model file deallocation

### DIFF
--- a/code/components/tflite_ctrl/CTfLiteClass.cpp
+++ b/code/components/tflite_ctrl/CTfLiteClass.cpp
@@ -355,8 +355,6 @@ CTfLiteClass::~CTfLiteClass()
         interpreter = nullptr;
         delete interpreter;
     }
-    if (modelFile) {
-        modelFile = nullptr;
-        free_psram_heap(std::string(TAG) + "->modelFile", modelFile);
-    }
+    
+    free_psram_heap(std::string(TAG) + "->modelFile", modelFile);
 }


### PR DESCRIPTION
Model file was not deallocated properly anymore
--> Bug introduced with #247