### PR TITLE
chore(roi image logging): Save roi images with max. jpeg quality

### DIFF
--- a/code/components/mainprocess_ctrl/ClassFlowCNNGeneral.cpp
+++ b/code/components/mainprocess_ctrl/ClassFlowCNNGeneral.cpp
@@ -368,7 +368,7 @@ bool ClassFlowCNNGeneral::doInvokeCnn(const std::string time)
             LogFile.writeToFile(ESP_LOG_DEBUG, TAG, "Result: " + roi->sCNNResult);
 
             if (saveImagesEnabled) {
-                logImage(logPath, roiName, cnnType, logImageResult, time, roi->imageRoi);
+                logImage(logPath, roiName, cnnType, logImageResult, time, roi->imageRoi, 100);
             }
         }
     }

--- a/code/components/mainprocess_ctrl/ClassFlowControl.cpp
+++ b/code/components/mainprocess_ctrl/ClassFlowControl.cpp
@@ -729,19 +729,19 @@ esp_err_t ClassFlowControl::sendProcessImages(httpd_req_t *req, const char *file
         for (const auto &sequence : sequenceData) {
             for (const auto &roi : sequence->digitRoi) {
                 if (strcmp(std::string(roi->param->roiName + "_org.jpg").c_str(), filename) == 0) {
-                    return roi->imageRoi->sendJpgToHttp(req);
+                    return roi->imageRoi->sendJpgToHttp(req, 100);
                 }
                 else if (strcmp(std::string(roi->param->roiName + ".jpg").c_str(), filename) == 0) {
-                    return roi->imageRoiResized->sendJpgToHttp(req);
+                    return roi->imageRoiResized->sendJpgToHttp(req, 100);
                 }
             }
 
             for (const auto &roi : sequence->analogRoi) {
                 if (strcmp(std::string(roi->param->roiName + "_org.jpg").c_str(), filename) == 0) {
-                    return roi->imageRoi->sendJpgToHttp(req);
+                    return roi->imageRoi->sendJpgToHttp(req, 100);
                 }
                 else if (strcmp(std::string(roi->param->roiName + ".jpg").c_str(), filename) == 0) {
-                    return roi->imageRoiResized->sendJpgToHttp(req);
+                    return roi->imageRoiResized->sendJpgToHttp(req, 100);
                 }
             }
         }

--- a/code/components/mainprocess_ctrl/ClassLogImage.cpp
+++ b/code/components/mainprocess_ctrl/ClassLogImage.cpp
@@ -45,7 +45,8 @@ std::string ClassLogImage::createLogFolder(std::string time)
 }
 
 
-void ClassLogImage::logImage(std::string _logPath, std::string _sequenceName, CNNType _type, int _value, std::string _time, CImage *_img)
+void ClassLogImage::logImage(std::string _logPath, std::string _sequenceName, CNNType _type, int _value, std::string _time, CImage *_img,
+                             uint8_t _quality)
 {
     if (!saveImagesEnabled) {
         return;
@@ -77,7 +78,7 @@ void ClassLogImage::logImage(std::string _logPath, std::string _sequenceName, CN
         LogFile.writeToFile(ESP_LOG_ERROR, logTag, "logImage: rawImage not initialized");
         return;
     }
-    _img->saveJpgToFile(nm);
+    _img->saveJpgToFile(nm, _quality);
 }
 
 

--- a/code/components/mainprocess_ctrl/ClassLogImage.h
+++ b/code/components/mainprocess_ctrl/ClassLogImage.h
@@ -16,7 +16,8 @@ class ClassLogImage : public ClassFlow
     int imagesRetention;
 
     std::string createLogFolder(std::string time);
-    void logImage(std::string _logPath, std::string _sequenceName, CNNType _type, int _value, std::string _time, CImage *_img);
+    void logImage(std::string _logPath, std::string _sequenceName, CNNType _type, int _value, std::string _time, CImage *_img,
+                  uint8_t _quality = 90);
     void removeOldLogs();
 
   public:


### PR DESCRIPTION
- Digit / Analog ROI image logging: Save ROI images with max. JPEG quality (100) to sd card (`/log/digit/`, `/log/analog/`) to ensure best possible input quality for further image processing (e.g. for tflite model training)
- REST API `http://IP/img_tmp/...`: Provide digit / analog ROI images also with max. JPEG quality (100)