### PR TITLE
chore(framework): Upgrade platformio-espressif32 to 6.11.0 (ESP-IDF 5.4.1)

### DIFF
--- a/code/platformio.ini
+++ b/code/platformio.ini
@@ -19,7 +19,7 @@ lib_deps =
 
 [common:esp32-idf]
 extends = common:idf
-platform = platformio/espressif32 @ 6.10.0
+platform = platformio/espressif32 @ 6.11.0
 framework = espidf
 lib_deps =
     ${common:idf.lib_deps}


### PR DESCRIPTION
Upgrading [platform-espressif32](https://github.com/platformio/platform-espressif32) from 6.10.0 (ESP-IDF 5.4.0) to 6.11.0 (ESP-IDF 5.4.1)

- Platformio-espressif32: https://github.com/platformio/platform-espressif32/releases/tag/v6.11.0
- ESP-IDF: https://github.com/espressif/esp-idf/releases/tag/v5.4.1

---
### Known issue (since ESP-IDF v5.4.0 - not yet fixed)
`W (xxxx) ledc: GPIO x is not usable, maybe conflict with others`
- Attaching an previously already attached GPIO pin after any deinit / reinit / stopping procedure to an LEDC channel leads to this message. With actual ESP-IDF version it seems not possible to revoke an initial attached GPIO pin by LEDC component and reattach the same pin again.
- It's only a warning without any impact to functionality 

---
### Usage stats

Before (based on ESP32)
RAM:   [==        ]  15.9% (used 52176 bytes from 327680 bytes)
Flash: [========= ]  87.0% (used 1692342 bytes from 1945600 bytes)

After
RAM:   [==        ]  15.9% (used 52108 bytes from 327680 bytes)
Flash: [========= ]  87.1% (used 1694642 bytes from 1945600 bytes)