### PR TITLE
fix(sdcard info): Fix 'getSDCardName': Return name with correct length

### DIFF
--- a/code/components/misc_helper/system.cpp
+++ b/code/components/misc_helper/system.cpp
@@ -565,7 +565,12 @@ std::string getSDCardName()
 {
     // ESP_LOGD(TAG, "SD Card Name: %s", SDCardCid.name);
 
-    return std::string(SDCardCid.name, 8);
+    size_t len = 0;
+    while (len < 8 && SDCardCid.name[len] != '\0') {
+        ++len;
+    }
+
+    return std::string(SDCardCid.name, len);
 }
 
 


### PR DESCRIPTION
Fix function 'getSDCardName' to return name with correct length (up to 8 character).

Previously fixed name length resulted in a truncated console output for sd card info:
```
Before: I (6544) MAIN: SD card info: Name: SD32G
After:  I (6544) MAIN: SD card info: Name: SD32G, Capacity: 29580MB, Free: 23507MB
```

---
Related to #248 

---
### Usage Stats

Before (based on ESP32):
RAM:   [==        ]  15.9% (used 52176 bytes from 327680 bytes)
Flash: [========= ]  87.0% (used 1692346 bytes from 1945600 bytes)

After:
RAM:   [==        ]  15.9% (used 52176 bytes from 327680 bytes)
Flash: [========= ]  87.0% (used 1692358 bytes from 1945600 bytes)