### PR TITLE
feat(roi saving): Configurable digit / analog ROI image saving size

### DIFF
--- a/code/components/config_handling/cfgDataStruct.h
+++ b/code/components/config_handling/cfgDataStruct.h
@@ -40,6 +40,13 @@ enum AlignmentAlgo {
 };
 
 
+enum RoiImageSavingSize {
+    ROI_SAVE_FULL_SIZE = 0,
+    ROI_SAVE_RESIZED = 1,
+    ROI_SAVE_FULL_SIZE_AND_RESIZED = 2,
+};
+
+
 enum MaxRateCheckType {
     RATE_CHECK_OFF = 0,
     RATE_PER_MIN = 1,
@@ -274,6 +281,7 @@ struct CfgData {
             bool saveRoiImages = false;
             std::string roiImagesLocation = "/log/digit";
             int roiImagesRetention = 3;
+            int roiSavingSize = ROI_SAVE_FULL_SIZE;
             bool saveDebugInfo = false;
             bool saveAllFiles = false;
         } debug;
@@ -288,6 +296,7 @@ struct CfgData {
             bool saveRoiImages = false;
             std::string roiImagesLocation = "/log/analog";
             int roiImagesRetention = 3;
+            int roiSavingSize = ROI_SAVE_FULL_SIZE;
             bool saveDebugInfo = false;
             bool saveAllFiles = false;
         } debug;

--- a/code/components/config_handling/configClass.cpp
+++ b/code/components/config_handling/configClass.cpp
@@ -759,6 +759,11 @@ esp_err_t ConfigClass::parseConfig(httpd_req_t *req, bool init, bool unityTest)
         cfgDataTemp.sectionDigit.debug.roiImagesRetention = std::max(objEl->valueint, 0);
     }
 
+    objEl = cJSON_GetObjectItem(cJSON_GetObjectItem(cJSON_GetObjectItem(cJsonObject, "digit"), "debug"), "roisavingsize");
+    if (cJSON_IsNumber(objEl)) {
+        cfgDataTemp.sectionDigit.debug.roiSavingSize = objEl->valueint;
+    }
+
 
     // Analog
     // ***************************
@@ -859,6 +864,11 @@ esp_err_t ConfigClass::parseConfig(httpd_req_t *req, bool init, bool unityTest)
     objEl = cJSON_GetObjectItem(cJSON_GetObjectItem(cJSON_GetObjectItem(cJsonObject, "analog"), "debug"), "roiimagesretention");
     if (cJSON_IsNumber(objEl)) {
         cfgDataTemp.sectionAnalog.debug.roiImagesRetention = std::max(objEl->valueint, 0);
+    }
+
+    objEl = cJSON_GetObjectItem(cJSON_GetObjectItem(cJSON_GetObjectItem(cJsonObject, "analog"), "debug"), "roisavingsize");
+    if (cJSON_IsNumber(objEl)) {
+        cfgDataTemp.sectionAnalog.debug.roiSavingSize = objEl->valueint;
     }
 
 
@@ -1975,6 +1985,9 @@ esp_err_t ConfigClass::serializeConfig(bool unityTest)
     if (cJSON_AddNumberToObject(digitDebug, "roiimagesretention", cfgDataTemp.sectionDigit.debug.roiImagesRetention) == NULL) {
         retVal = ESP_FAIL;
     }
+    if (cJSON_AddNumberToObject(digitDebug, "roisavingsize", cfgDataTemp.sectionDigit.debug.roiSavingSize) == NULL) {
+        retVal = ESP_FAIL;
+    }
 
 
     // Analog
@@ -2032,6 +2045,9 @@ esp_err_t ConfigClass::serializeConfig(bool unityTest)
         retVal = ESP_FAIL;
     }
     if (cJSON_AddNumberToObject(analogDebug, "roiimagesretention", cfgDataTemp.sectionAnalog.debug.roiImagesRetention) == NULL) {
+        retVal = ESP_FAIL;
+    }
+    if (cJSON_AddNumberToObject(analogDebug, "roisavingsize", cfgDataTemp.sectionAnalog.debug.roiSavingSize) == NULL) {
         retVal = ESP_FAIL;
     }
 

--- a/code/components/mainprocess_ctrl/ClassFlowCNNGeneral.cpp
+++ b/code/components/mainprocess_ctrl/ClassFlowCNNGeneral.cpp
@@ -232,7 +232,8 @@ bool ClassFlowCNNGeneral::resolveNetworkParameter()
 
 bool ClassFlowCNNGeneral::doInvokeCnn(const std::string time)
 {
-    const std::string logPath = createLogFolder(time);
+    const auto roiSavingSize = sectionDigitPtr ? sectionDigitPtr->debug.roiSavingSize : sectionAnalogPtr->debug.roiSavingSize;
+    const std::string logPath = createLogFolder(time, roiSavingSize == ROI_SAVE_FULL_SIZE_AND_RESIZED);
 
     if (!tflite->makeAllocate()) {
         LogFile.writeToFile(ESP_LOG_ERROR, TAG, "Allocation of TFLite tensors failed");
@@ -368,7 +369,18 @@ bool ClassFlowCNNGeneral::doInvokeCnn(const std::string time)
             LogFile.writeToFile(ESP_LOG_DEBUG, TAG, "Result: " + roi->sCNNResult);
 
             if (saveImagesEnabled) {
-                logImage(logPath, roiName, cnnType, logImageResult, time, roi->imageRoi, 100);
+                const std::string roiNameResized = roiName + "_resized";
+
+                if (roiSavingSize == ROI_SAVE_FULL_SIZE_AND_RESIZED) {
+                    logImage(logPath, roiName, cnnType, logImageResult, time, roi->imageRoi, 100);
+                    logImage(logPath + "/resized", roiNameResized, cnnType, logImageResult, time, roi->imageRoiResized, 100);
+                }
+                else if (roiSavingSize == ROI_SAVE_RESIZED) { // Special case: Save to default log path for backward compatibility
+                    logImage(logPath, roiNameResized, cnnType, logImageResult, time, roi->imageRoiResized, 100);
+                }
+                else {
+                    logImage(logPath, roiName, cnnType, logImageResult, time, roi->imageRoi, 100);
+                }
             }
         }
     }
@@ -569,7 +581,7 @@ int ClassFlowCNNGeneral::evalDigitNumber(int _value, int _valuePreviousNumber, i
     int resultIntergerPart = _value / 10;
     int resultDecimalPlace = _value % 10;
 
-    if (_resultPreviousNumber <= -1) { // no previous number -> no correction logic for transition needed, use value as is (integer part)
+    if (_resultPreviousNumber <= -1) { // no previous number -> no correction logic for transition, use value as is (integer part)
         result = resultIntergerPart;
         LogFile.writeToFile(ESP_LOG_DEBUG, TAG,
                             "evalDigitNumber (No previous number): Result: " + std::to_string(result) +
@@ -680,8 +692,7 @@ int ClassFlowCNNGeneral::evalAnalogToDigitTransition(int _value, int _valuePrevi
     // Value within the digit inequalities
     if (resultDecimalPlace >= (10 - ANALOG_DIGIT_ZERO_CROSSING_UNCERTAINTY) // Band around the zero crossing -> Round, as number reaches
                                                                             // inaccuracy zone
-        ||
-        (_resultPreviousNumber <= 4 && resultDecimalPlace >= 6)) // or number runs after (previous result <= 4, actucal decimal place >= 6)
+        || (_resultPreviousNumber <= 4 && resultDecimalPlace >= 6)) // or number runs after (previous result <= 4, act. decimal place >= 6)
     {
         if (resultDecimalPlace >= 5) { // "Round up"
             result = resultIntergerPart + 1;

--- a/code/components/mainprocess_ctrl/ClassLogImage.cpp
+++ b/code/components/mainprocess_ctrl/ClassLogImage.cpp
@@ -28,7 +28,8 @@ ClassLogImage::ClassLogImage(const char *logTag)
     this->imagesRetention = 5;
 }
 
-std::string ClassLogImage::createLogFolder(std::string time)
+
+std::string ClassLogImage::createLogFolder(std::string time, bool createResizedFolder)
 {
     if (!saveImagesEnabled) {
         return "";
@@ -36,7 +37,7 @@ std::string ClassLogImage::createLogFolder(std::string time)
 
     std::string logPath = imagesLocation + "/" + time.DEFAULT_TIME_FORMAT_DATE_EXTR + "/" + time.DEFAULT_TIME_FORMAT_HOUR_EXTR;
 
-    if (makeDirRecursive(logPath.c_str(), S_IRWXU) != 0) {
+    if (makeDirRecursive(createResizedFolder ? std::string(logPath + "/resized").c_str() : logPath.c_str(), S_IRWXU) != 0) {
         LogFile.writeToFile(ESP_LOG_ERROR, logTag, "createLogFolder: failed to create folder. Path: " + logPath);
         return "";
     }
@@ -45,40 +46,38 @@ std::string ClassLogImage::createLogFolder(std::string time)
 }
 
 
-void ClassLogImage::logImage(std::string _logPath, std::string _sequenceName, CNNType _type, int _value, std::string _time, CImage *_img,
-                             uint8_t _quality)
+void ClassLogImage::logImage(std::string logPath, std::string name, CNNType cnnType, int value, std::string timestamp, CImage *image,
+                             uint8_t quality)
 {
     if (!saveImagesEnabled) {
         return;
     }
 
-    if (_logPath.empty()) {
+    if (logPath.empty()) {
         LogFile.writeToFile(ESP_LOG_ERROR, logTag, "logImage: logPath empty");
         return;
     }
 
     char valueBuf[10];
-
-    if (_type == CNNTYPE_NONE) { // log with no label -> raw image
+    if (cnnType == CNNTYPE_NONE) { // log with no label -> raw image
         valueBuf[0] = '\0';
     }
-    else if (_type == CNNTYPE_DIGIT_CLASS11) { // dig-class10 (0-9 + NaN)
-        sprintf(valueBuf, "%d_", _value);
+    else if (cnnType == CNNTYPE_DIGIT_CLASS11) { // dig-class10 (0-9 + NaN)
+        sprintf(valueBuf, "%d_", value);
     }
     else { // ana-class100, dig-class100, dig-cont
-        sprintf(valueBuf, "%.1f_", _value / 10.0);
+        sprintf(valueBuf, "%.1f_", value / 10.0);
     }
 
-    std::string nm = _logPath + "/" + valueBuf + _sequenceName + "_" + _time + ".jpg";
-    nm = formatFileName(nm);
-    std::string output = "/sdcard/img_tmp/" + _sequenceName + ".jpg";
-    output = formatFileName(output);
-    ESP_LOGD(logTag, "save to file: %s", nm.c_str());
-    if (!_img) {
-        LogFile.writeToFile(ESP_LOG_ERROR, logTag, "logImage: rawImage not initialized");
+    std::string imagePath = logPath + "/" + valueBuf + name + "_" + timestamp + ".jpg";
+    imagePath = formatFileName(imagePath);
+
+    if (!image) {
+        LogFile.writeToFile(ESP_LOG_ERROR, logTag, "logImage: image not initialized");
         return;
     }
-    _img->saveJpgToFile(nm, _quality);
+
+    image->saveJpgToFile(imagePath, quality);
 }
 
 

--- a/code/components/mainprocess_ctrl/ClassLogImage.h
+++ b/code/components/mainprocess_ctrl/ClassLogImage.h
@@ -15,9 +15,9 @@ class ClassLogImage : public ClassFlow
     std::string imagesLocation;
     int imagesRetention;
 
-    std::string createLogFolder(std::string time);
-    void logImage(std::string _logPath, std::string _sequenceName, CNNType _type, int _value, std::string _time, CImage *_img,
-                  uint8_t _quality = 90);
+    std::string createLogFolder(std::string time, bool createResizedFolder = false);
+    void logImage(std::string logPath, std::string name, CNNType cnnType, int value, std::string timestamp, CImage *img,
+                  uint8_t quality = 90);
     void removeOldLogs();
 
   public:

--- a/docs/Configuration/Parameter/Analog/Debug_ROISavingSize.md
+++ b/docs/Configuration/Parameter/Analog/Debug_ROISavingSize.md
@@ -1,0 +1,21 @@
+# Parameter: ROI Saving Size
+
+|                   | WebUI               | REST API
+|:---               |:---                 |:----
+| Parameter Name    | ROI Saving Size     | roisavingsize
+| Default Value     | `Full`              | `0`
+| Input Options     | `Full`<br>`Resized`<br>`Full + Resized` | `0`<br>`1`<br>`2`
+
+
+## Description
+
+Defines in which size the analog ROI images are saved to SD card
+
+
+### Input Options
+
+| Input Option     | Description
+|:---              |:---
+| `Full`           | Save original image size (Size depending on configured ROI size)<br>Path: `/log/analog/{DATE}/{HOUR}/`<br>Name: `x.y_sequenceName_roiName_dateTime.jpg`
+| `Resized`        | Save ROI image resized to model input size<br>Path: `/log/analog/{DATE}/{HOUR}/`<br>Name: `x.y_sequenceName_roiName_resized_dateTime.jpg`
+| `Full + Resized` | Save both sizes<br>Path: `/log/analog/{DATE}/{HOUR}/` + subfolder `/resized`<br>Names: `x.y_sequenceName_roiName_dateTime.jpg` + `x.y_sequenceName_roiName_resized_dateTime.jpg`

--- a/docs/Configuration/Parameter/Analog/Debug_ROISavingSize.md
+++ b/docs/Configuration/Parameter/Analog/Debug_ROISavingSize.md
@@ -1,8 +1,8 @@
-# Parameter: ROI Saving Size
+# Parameter: ROI Images Saving Size
 
 |                   | WebUI               | REST API
 |:---               |:---                 |:----
-| Parameter Name    | ROI Saving Size     | roisavingsize
+| Parameter Name    | ROI Images Saving Size | roisavingsize
 | Default Value     | `Full`              | `0`
 | Input Options     | `Full`<br>`Resized`<br>`Full + Resized` | `0`<br>`1`<br>`2`
 
@@ -16,6 +16,6 @@ Defines in which size the analog ROI images are saved to SD card
 
 | Input Option     | Description
 |:---              |:---
-| `Full`           | Save original image size (Size depending on configured ROI size)<br>Path: `/log/analog/{DATE}/{HOUR}/`<br>Name: `x.y_sequenceName_roiName_dateTime.jpg`
-| `Resized`        | Save ROI image resized to model input size<br>Path: `/log/analog/{DATE}/{HOUR}/`<br>Name: `x.y_sequenceName_roiName_resized_dateTime.jpg`
-| `Full + Resized` | Save both sizes<br>Path: `/log/analog/{DATE}/{HOUR}/` + subfolder `/resized`<br>Names: `x.y_sequenceName_roiName_dateTime.jpg` + `x.y_sequenceName_roiName_resized_dateTime.jpg`
+| `Full`           | Saves the image in its original size (as defined by the configured ROI)<br>Path: `/log/analog/{DATE}/{HOUR}/`<br>Filename: `x.y_sequenceName_roiName_dateTime.jpg`
+| `Resized`        | Saves the image resized to the model's input dimensions<br>Path: `/log/analog/{DATE}/{HOUR}/`<br>Filename: `x.y_sequenceName_roiName_resized_dateTime.jpg`
+| `Full + Resized` | Saves both the original and resized versions<br>Path: `/log/analog/{DATE}/{HOUR}/` + subfolder `/resized`<br>Filenames: `x.y_sequenceName_roiName_dateTime.jpg` and `/resized/x.y_sequenceName_roiName_resized_dateTime.jpg`

--- a/docs/Configuration/Parameter/Digit/Debug_ROISavingSize.md
+++ b/docs/Configuration/Parameter/Digit/Debug_ROISavingSize.md
@@ -1,8 +1,8 @@
-# Parameter: ROI Saving Size
+# Parameter: ROI Images Saving Size
 
 |                   | WebUI               | REST API
 |:---               |:---                 |:----
-| Parameter Name    | ROI Saving Size     | roisavingsize
+| Parameter Name    | ROI Images Saving Size | roisavingsize
 | Default Value     | `Full`              | `0`
 | Input Options     | `Full`<br>`Resized`<br>`Full + Resized` | `0`<br>`1`<br>`2`
 
@@ -16,7 +16,7 @@ Defines in which size the digit ROI images are saved to SD card
 
 | Input Option     | Description
 |:---              |:---
-| `Full`           | Save original image size (Size depending on configured ROI size)<br>Path: e.g. `/log/digit/{DATE}/{HOUR}/`<br>Name: `x.y_sequenceName_roiName_dateTime.jpg`
-| `Resized`        | Save ROI image resized to model input size<br>Path: `/log/digit/{DATE}/{HOUR}/`<br>Name: `x.y_sequenceName_roiName_resized_dateTime.jpg`
-| `Full + Resized` | Save both sizes<br>Path: e.g. `/log/digit/{DATE}/{HOUR}/` + subfolder `/resized`<br>Names: `x.y_sequenceName_roiName_dateTime.jpg` + `x.y_sequenceName_roiName_resized_dateTime.jpg`
+| `Full`           | Saves the image in its original size (as defined by the configured ROI)<br>Path: `/log/digit/{DATE}/{HOUR}/`<br>Filename: `x.y_sequenceName_roiName_dateTime.jpg`
+| `Resized`        | Saves the image resized to the model's input dimensions<br>Path: `/log/digit/{DATE}/{HOUR}/`<br>Filename: `x.y_sequenceName_roiName_resized_dateTime.jpg`
+| `Full + Resized` | Saves both the original and resized versions<br>Path: `/log/digit/{DATE}/{HOUR}/` + subfolder `/resized`<br>Filenames: `x.y_sequenceName_roiName_dateTime.jpg` and `/resized/x.y_sequenceName_roiName_resized_dateTime.jpg`
 

--- a/docs/Configuration/Parameter/Digit/Debug_ROISavingSize.md
+++ b/docs/Configuration/Parameter/Digit/Debug_ROISavingSize.md
@@ -1,0 +1,22 @@
+# Parameter: ROI Saving Size
+
+|                   | WebUI               | REST API
+|:---               |:---                 |:----
+| Parameter Name    | ROI Saving Size     | roisavingsize
+| Default Value     | `Full`              | `0`
+| Input Options     | `Full`<br>`Resized`<br>`Full + Resized` | `0`<br>`1`<br>`2`
+
+
+## Description
+
+Defines in which size the digit ROI images are saved to SD card
+
+
+### Input Options
+
+| Input Option     | Description
+|:---              |:---
+| `Full`           | Save original image size (Size depending on configured ROI size)<br>Path: e.g. `/log/digit/{DATE}/{HOUR}/`<br>Name: `x.y_sequenceName_roiName_dateTime.jpg`
+| `Resized`        | Save ROI image resized to model input size<br>Path: `/log/digit/{DATE}/{HOUR}/`<br>Name: `x.y_sequenceName_roiName_resized_dateTime.jpg`
+| `Full + Resized` | Save both sizes<br>Path: e.g. `/log/digit/{DATE}/{HOUR}/` + subfolder `/resized`<br>Names: `x.y_sequenceName_roiName_dateTime.jpg` + `x.y_sequenceName_roiName_resized_dateTime.jpg`
+

--- a/sd-card/html/edit_config_param.html
+++ b/sd-card/html/edit_config_param.html
@@ -943,6 +943,24 @@
 			</td>
 			<td style="visibility:hidden">$TOOLTIP_digit_debug_roiimagesretention</td>
 		</tr>
+
+		<tr class="classvisibility_digit_enabled classvisibility_digit_debug_saveroiimages expert">
+			<td class="indent2">
+				<span>ROI Images Saving Size</span>
+			</td>
+			<td>
+				<form id="digit_debug_roisavingsize_form">
+					<select name="digit.debug.roisavingsize" id="digit_debug_roisavingsize_value"
+							onchange='setClassVisibility("classvisibility_digit_debug_roisavingsize", this.value);
+								gatherChangedParameter(this.form, true)'>
+						<option value="0" selected>Full</option>
+						<option value="1">Resized</option>
+						<option value="2">Full + Resized</option>
+					</select>
+				</form>
+			</td>
+			<td style="visibility:hidden">$TOOLTIP_digit_debug_roisavingsize</td>
+		</tr>
 	</table>
 
 
@@ -1035,6 +1053,24 @@
 				</form>
 			</td>
 			<td style="visibility:hidden">$TOOLTIP_analog_debug_roiimagesretention</td>
+		</tr>
+
+		<tr class="classvisibility_analog_enabled classvisibility_analog_debug_saveroiimages expert">
+			<td class="indent2">
+				<span>ROI Images Saving Size</span>
+			</td>
+			<td>
+				<form id="analog_debug_roisavingsize_form">
+					<select name="analog.debug.roisavingsize" id="analog_debug_roisavingsize_value"
+							onchange='setClassVisibility("classvisibility_analog_debug_roisavingsize", this.value);
+								gatherChangedParameter(this.form, true)'>
+						<option value="0" selected>Full</option>
+						<option value="1">Resized</option>
+						<option value="2">Full + Resized</option>
+					</select>
+				</form>
+			</td>
+			<td style="visibility:hidden">$TOOLTIP_analog_debug_roisavingsize</td>
 		</tr>
 	</table>
 


### PR DESCRIPTION
## Saving size of digit / analog ROI images can be configured via WebUI

The following options can be configured in sections `Digit` / `Analog`, parameter `ROI Images Saving Size`:
- **Full (DEFAULT)**: Original image size (Size depending on configured ROI size) is saved to SD card
  - Saving path: `/log/{ROI TYPE}/{DATE}/{HOUR}/`
  - File name: `x.y_sequenceName_roiName_dateTime.jpg`
- **Resized**: ROI image resized to model input dimensions is saved to SD card
  - Saving path: `/log/{ROI TYPE}/{DATE}/{HOUR}/`
    NOTE: Backward compatibility: Resized image is also saved to full image size path, indicated with `_resized` in file name
  - File name: `x.y_sequenceName_roiName_resized_dateTime.jpg`
- **Full + Resized**: Both sizes are saved to SD card
  - Saving path `Full`: `/log/{ROI TYPE}/{DATE}/{HOUR}/`
      - File name: `x.y_sequenceName_roiName_dateTime.jpg`
  - Saving path `Resized`: Subfolder `...\resized` nested into path of full size images
      - File name: `x.y_sequenceName_roiName_resized_dateTime.jpg`

### Benefit / Intention
Resized images from target device can help to verify TFLite model performance under real-world conditions

---
### Usage Stats

Before (based on ESP32)
RAM:   [==        ]  15.9% (used 52132 bytes from 327680 bytes)
Flash: [========= ]  87.1% (used 1694142 bytes from 1945600 bytes)

After
RAM:   [==        ]  15.9% (used 52148 bytes from 327680 bytes)
Flash: [========= ]  87.1% (used 1694786 bytes from 1945600 bytes)