### PR TITLE
fix(mqtt): Fix keep alive not initialized properly

### DIFF
--- a/code/components/mainprocess_ctrl/ClassFlowMQTT.h
+++ b/code/components/mainprocess_ctrl/ClassFlowMQTT.h
@@ -17,7 +17,6 @@ class ClassFlowMQTT : public ClassFlow
 {
   protected:
     const CfgData::SectionMqtt *cfgDataPtr = NULL;
-    ClassFlowPostProcessing *flowpostprocessing;
     int keepAlive;
 
   public:

--- a/code/components/mqtt_ctrl/interface_mqtt.cpp
+++ b/code/components/mqtt_ctrl/interface_mqtt.cpp
@@ -222,10 +222,10 @@ static void mqtt_event_handler(void *handler_args, esp_event_base_t base, int32_
 }
 
 
-bool configureMqttClient(const CfgData::SectionMqtt *_param, int keepAlive)
+bool configureMqttClient(const CfgData::SectionMqtt *_param, int _keepAlive)
 {
     cfgDataPtr = _param;
-    keepAlive = keepAlive;
+    keepAlive = _keepAlive;
 
     if ((cfgDataPtr->uri.empty()) || (cfgDataPtr->mainTopic.empty()) || (cfgDataPtr->clientID.empty())) {
         LogFile.writeToFile(ESP_LOG_ERROR, TAG, "Init aborted! Config error (URI, MainTopic or ClientID missing)");

--- a/code/components/mqtt_ctrl/interface_mqtt.h
+++ b/code/components/mqtt_ctrl/interface_mqtt.h
@@ -12,7 +12,7 @@
 
 
 bool publishMqttData(std::string _key, std::string _content, int qos, bool _retainFlag = false);
-bool configureMqttClient(const CfgData::SectionMqtt *cfgDataPtr, int keepAlive);
+bool configureMqttClient(const CfgData::SectionMqtt *_param, int _keepAlive);
 esp_err_t startMqttClient(void);
 
 bool getMqttIsEnabled(void);


### PR DESCRIPTION
Fix keep alive not initialized properly (avoid shadowed class variable)

---
### Usage Stats

Before (based on ESP32):
RAM:   [==        ]  15.9% (used 52236 bytes from 327680 bytes)
Flash: [========= ]  87.1% (used 1695242 bytes from 1945600 bytes)

After:
RAM:   [==        ]  15.9% (used 52244 bytes from 327680 bytes)
Flash: [========= ]  87.1% (used 1695190 bytes from 1945600 bytes)