### PR TITLE
fix(version check): Fix commit hash availability check

### DIFF
--- a/code/main/main.cpp
+++ b/code/main/main.cpp
@@ -183,7 +183,7 @@ extern "C" void app_main(void)
     // ********************************************
     LogFile.writeToFile(ESP_LOG_INFO, TAG, getFwVersion() + " | Build time: " + std::string(BUILD_TIME) + " | WebUI: " + getHTMLversion());
 
-    if (getHTMLcommit().substr(0, 7) == "?") {
+    if (getHTMLcommit().starts_with("?")) {
         LogFile.writeToFile(ESP_LOG_WARN, TAG, std::string("Failed to read file html/version.txt to parse WebUI version"));
     }
 


### PR DESCRIPTION
Fix commit hash availability check -> Proper check of first string character

---
### Usage Stats

Before (based on ESP32)
RAM:   [==        ]  15.9% (used 52236 bytes from 327680 bytes)
Flash: [========= ]  87.1% (used 1695306 bytes from 1945600 bytes)

After
RAM:   [==        ]  15.9% (used 52236 bytes from 327680 bytes)
Flash: [========= ]  87.1% (used 1695222 bytes from 1945600 bytes)