### PR TITLE
(dependency): Convert esp-tflite-micro library to ESP-IDF managed component

### DIFF
--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -135,6 +135,7 @@ jobs:
 
         cp -f "./code/.pio/build/${{ matrix.plat }}/firmware.elf" "debug/firmware.elf"
         cp -f "./code/sdkconfig.${{ matrix.plat }}" "debug/sdkconfig.${{ matrix.plat }}"
+        cp -f "./code/dependencies.lock" "debug/dependencies.lock"
 
     - name: Debug files package - Upload artifact
       uses: actions/upload-artifact@v4

--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ code/.pio/
 sd-card/html_compiled
 AI-on-the-edge-device*
 dependencies.lock
+managed_components
 **/managed_components/**
 
 # Version files (generated)

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,6 @@
 [submodule "code/components/esp32-camera"]
 	path = code/components/esp32-camera
 	url = https://github.com/espressif/esp32-camera.git
-[submodule "code/components/esp-tflite-micro"]
-	path = code/components/esp-tflite-micro
-	url = https://github.com/espressif/esp-tflite-micro.git
 [submodule "code/components/smartleds"]
 	path = code/components/smartleds
 	url = https://github.com/RoboticsBrno/SmartLeds.git

--- a/code/components/tflite_ctrl/idf_component.yml
+++ b/code/components/tflite_ctrl/idf_component.yml
@@ -1,0 +1,2 @@
+dependencies:
+  espressif/esp-tflite-micro: "1.3.4"


### PR DESCRIPTION
Keep latest version [v.1.3.4](https://github.com/espressif/esp-tflite-micro/releases/tag/v1.3.4) (1171b51)