### PR TITLE
chore(dependency): Update mdns to 1.8.2 (e9d7350)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,6 +4,3 @@
 [submodule "code/components/smartleds"]
 	path = code/components/smartleds
 	url = https://github.com/RoboticsBrno/SmartLeds.git
-[submodule "code/components/esp-protocols"]
-	path = code/components/esp-protocols
-	url = https://github.com/espressif/esp-protocols/

--- a/code/CMakeLists.txt
+++ b/code/CMakeLists.txt
@@ -1,7 +1,5 @@
 cmake_minimum_required(VERSION 3.16.0)
 
-list(APPEND EXTRA_COMPONENT_DIRS components/esp-protocols/components/mdns)
-
 if(EXISTS "${SDKCONFIG}.defaults")
     if(EXISTS "sdkconfig.defaults")
         set(SDKCONFIG_DEFAULTS "${SDKCONFIG}.defaults;sdkconfig.defaults")

--- a/code/components/network_ctrl/CMakeLists.txt
+++ b/code/components/network_ctrl/CMakeLists.txt
@@ -1,7 +1,5 @@
 FILE(GLOB_RECURSE app_sources ${CMAKE_CURRENT_SOURCE_DIR}/*.*)
 
 idf_component_register(SRCS ${app_sources}
-                    INCLUDE_DIRS "." "../esp-protocols/components/mdns/include"
+                    INCLUDE_DIRS "."
                     REQUIRES esp_driver_uart esp_driver_usb_serial_jtag esp_wifi esp_eth nvs_flash wpa_supplicant mdns misc_helper mqtt_ctrl)
-
-

--- a/code/components/network_ctrl/idf_component.yml
+++ b/code/components/network_ctrl/idf_component.yml
@@ -1,0 +1,2 @@
+dependencies:
+  espressif/mdns: "1.8.2"


### PR DESCRIPTION
- Update dependency mDNS to [v1.8.2](https://github.com/espressif/esp-protocols/releases/tag/mdns-v1.8.2)
- Convert dependency from a github submodule to ESP-IDF managed component