### PR TITLE
fix(mqtt): Use fixed keepalive interval + improve device availability detection

### DIFF
--- a/code/components/mainprocess_ctrl/ClassFlowMQTT.cpp
+++ b/code/components/mainprocess_ctrl/ClassFlowMQTT.cpp
@@ -22,7 +22,6 @@ static const char *TAG = "MQTT";
 ClassFlowMQTT::ClassFlowMQTT()
 {
     presetFlowStateHandler(true);
-    keepAlive = 25 * 60;
 }
 
 
@@ -55,13 +54,7 @@ bool ClassFlowMQTT::initMqttService(float _processingInterval)
         mqttServer_schedulePublishHADiscovery();
     }
 
-    keepAlive = _processingInterval * 60 * 2.5; // Seconds, make sure it is greater than 2 processing cycles!
-
-    stream << std::fixed << std::setprecision(1) << "Process interval: " << _processingInterval
-           << "min -> MQTT keepAlive: " << ((float)keepAlive / 60) << "min";
-    LogFile.writeToFile(ESP_LOG_DEBUG, TAG, stream.str());
-
-    if (configureMqttClient(cfgDataPtr, keepAlive)) {
+    if (configureMqttClient(cfgDataPtr)) {
         startMqttClient();
         return true;
     }

--- a/code/components/mainprocess_ctrl/ClassFlowMQTT.h
+++ b/code/components/mainprocess_ctrl/ClassFlowMQTT.h
@@ -17,7 +17,6 @@ class ClassFlowMQTT : public ClassFlow
 {
   protected:
     const CfgData::SectionMqtt *cfgDataPtr = NULL;
-    int keepAlive;
 
   public:
     ClassFlowMQTT();

--- a/code/components/mqtt_ctrl/interface_mqtt.cpp
+++ b/code/components/mqtt_ctrl/interface_mqtt.cpp
@@ -222,10 +222,9 @@ static void mqtt_event_handler(void *handler_args, esp_event_base_t base, int32_
 }
 
 
-bool configureMqttClient(const CfgData::SectionMqtt *_param, int _keepAlive)
+bool configureMqttClient(const CfgData::SectionMqtt *_param)
 {
     cfgDataPtr = _param;
-    keepAlive = _keepAlive;
 
     if ((cfgDataPtr->uri.empty()) || (cfgDataPtr->mainTopic.empty()) || (cfgDataPtr->clientID.empty())) {
         LogFile.writeToFile(ESP_LOG_ERROR, TAG, "Init aborted! Config error (URI, MainTopic or ClientID missing)");
@@ -233,6 +232,7 @@ bool configureMqttClient(const CfgData::SectionMqtt *_param, int _keepAlive)
     }
 
     LWTTopic = cfgDataPtr->mainTopic + MQTT_STATUS_TOPIC;
+    keepAlive = MQTT_KEEPALIVE_INTERVAL;
 
     LogFile.writeToFile(ESP_LOG_DEBUG, TAG,
                         "URI: " + cfgDataPtr->uri + ", clientID: " + cfgDataPtr->clientID + ", username: " + cfgDataPtr->username +

--- a/code/components/mqtt_ctrl/interface_mqtt.cpp
+++ b/code/components/mqtt_ctrl/interface_mqtt.cpp
@@ -533,7 +533,7 @@ void isConnectedState(void)
 {
     if (mqttState.mqttConnected) {
         LogFile.writeToFile(ESP_LOG_INFO, TAG, "Connected to broker");
-        publishMqttData(cfgDataPtr->mainTopic + MQTT_STATUS_TOPIC, MQTT_STATUS_ONLINE, 1, false); // Send MQTT birth message "online"
+        publishMqttData(cfgDataPtr->mainTopic + MQTT_STATUS_TOPIC, MQTT_STATUS_ONLINE, 1, true); // Send MQTT birth message "online"
 
         if (connectFunctionMap != NULL) {
             for (std::map<std::string, std::function<void()>>::iterator it = connectFunctionMap->begin(); it != connectFunctionMap->end();

--- a/code/components/mqtt_ctrl/interface_mqtt.h
+++ b/code/components/mqtt_ctrl/interface_mqtt.h
@@ -12,7 +12,7 @@
 
 
 bool publishMqttData(std::string _key, std::string _content, int qos, bool _retainFlag = false);
-bool configureMqttClient(const CfgData::SectionMqtt *_param, int _keepAlive);
+bool configureMqttClient(const CfgData::SectionMqtt *_param);
 esp_err_t startMqttClient(void);
 
 bool getMqttIsEnabled(void);

--- a/code/components/mqtt_ctrl/server_mqtt.cpp
+++ b/code/components/mqtt_ctrl/server_mqtt.cpp
@@ -178,7 +178,7 @@ bool mqttServer_publishDeviceStatus(int _qos)
     const std::string deviceStatusTopic = "/device/status/";
     bool retVal = true;
 
-    retVal &= publishMqttData(cfgDataPtr->mainTopic + MQTT_STATUS_TOPIC, MQTT_STATUS_ONLINE, _qos, false);
+    retVal &= publishMqttData(cfgDataPtr->mainTopic + MQTT_STATUS_TOPIC, MQTT_STATUS_ONLINE, _qos, true);
     retVal &= publishMqttData(cfgDataPtr->mainTopic + deviceStatusTopic + "device_uptime", std::to_string(getUptime()), _qos, false);
 
     // Publish only, if network mode WLAN / WLAN AP

--- a/code/include/defines.h
+++ b/code/include/defines.h
@@ -174,12 +174,13 @@
 #define READOUT_TYPE_RATE_PER_INTERVAL       7
 
 
-// ClassFlowMQTT
+// ClassFlowMQTT + interface_mqtt.cpp
 //******************************
 #define MQTT_STATUS_TOPIC           "/device/status/connection"
 #define MQTT_STATUS_ONLINE          "online"
 #define MQTT_STATUS_OFFLINE         "offline"
 #define MQTT_QOS                    1
+#define MQTT_KEEPALIVE_INTERVAL     120 // [s]; Message sent every half this value
 
 
 // CImage


### PR DESCRIPTION
- Use a fixed keepalive interval (120s, ESP-IDF framework default) instead of calculating it based on configured processing interval to maintain connection to broker even using quite large processing cycle times (MQTT broker accepted keep alive value is limited to 65535 seconds)
--> Related to issue described here: #3797

- Retain connection status message to improve device availability detection in various scenarios

---
### Usage Stats

Before (based on ESP32)
RAM:   [==        ]  16.3% (used 53296 bytes from 327680 bytes)
Flash: [========= ]  88.0% (used 1711458 bytes from 1945600 bytes)

After
RAM:   [==        ]  16.3% (used 53296 bytes from 327680 bytes)
Flash: [========= ]  87.9% (used 1711098 bytes from 1945600 bytes)