### PR TITLE
fix(flowctrl): Preserve process error value during cycle reinit

### DIFF
--- a/code/components/mainprocess_ctrl/MainFlowControl.cpp
+++ b/code/components/mainprocess_ctrl/MainFlowControl.cpp
@@ -995,8 +995,6 @@ void task_autodoFlow(void *pvParameter)
         else if (taskAutoFlowState == FLOW_TASK_STATE_INIT) {
             LogFile.writeToFile(ESP_LOG_INFO, TAG, "Process state: " + std::string(FLOW_INIT));
             flowctrl.setActualProcessState(std::string(FLOW_INIT));
-            // Right now, it's not possible to provide state via MQTT because mqtt service is not yet started
-            flowctrl.clearFlowStateEventInRowCounter();
 
             if (!doInit()) {
                 LogFile.writeToFile(ESP_LOG_ERROR, TAG, "Process state: " + std::string(FLOW_INIT_FAILED));
@@ -1062,9 +1060,6 @@ void task_autodoFlow(void *pvParameter)
                 else {
                     taskAutoFlowState = FLOW_TASK_STATE_IDLE_NO_AUTOSTART; // Continue to test if AUTOSTART is TRUE
                 }
-
-                flowctrl.clearFlowStateEventInRowCounter();
-                taskYIELD();
             }
         }
 


### PR DESCRIPTION
Ensure the current process error value is retained during cycle reinitialization (e.g., after parameter changes)
--> The error value is now only reset once a cycle completes successfully

---
### Usage Stats

Before
RAM:   [==        ]  16.3% (used 53296 bytes from 327680 bytes)
Flash: [========= ]  87.9% (used 1711038 bytes from 1945600 bytes)

After
RAM:   [==        ]  16.3% (used 53296 bytes from 327680 bytes)
Flash: [========= ]  87.9% (used 1711006 bytes from 1945600 bytes)
