### PR TITLE
refactor(alignment): Improve logging for alignment failure with detailed guidance

### DIFF
--- a/code/components/mainprocess_ctrl/ClassFlowAlignment.cpp
+++ b/code/components/mainprocess_ctrl/ClassFlowAlignment.cpp
@@ -139,8 +139,10 @@ bool ClassFlowAlignment::doFlow(std::string time)
         if (AlignRetval == TPL_MATCH_OK_SIMILAR) { // Alignment with similarity check successful
             saveAlignmentMarkerData();
         }
-        else if (AlignRetval == TPL_MATCH_FAILED) { // Alignment failed
-            LogFile.writeToFile(ESP_LOG_ERROR, TAG, "Alignment by algorithm failed. Verify image rotation and alignment marker");
+        else if (AlignRetval == TPL_MATCH_FAILED) { // Alignment not successful
+            LogFile.writeToFile(ESP_LOG_ERROR, TAG,
+                                "Fine alignment unsuccessful. Use alignment marker areas with sharp edges, unique shapes and high contrast "
+                                "on a sharply focused image");
             setFlowStateHandlerEvent(-1); // Set error event code for post cycle error handler 'doPostProcessEventHandling'
         }
 
@@ -196,7 +198,7 @@ void ClassFlowAlignment::doPostProcessEventHandling()
             drawAlignmentMarker(*flowImageData->imgProcess);
             flowImageData->imgProcess->saveJpgToFile(formatFileName(destination + "/alg_misalign.jpg"));
 
-            LogFile.writeToFile(ESP_LOG_DEBUG, TAG, "Alignment failed, debug infos saved: " + destination);
+            LogFile.writeToFile(ESP_LOG_DEBUG, TAG, "Fine alignment unsuccessful, debug infos saved: " + destination);
         }
     }
 }

--- a/code/components/mainprocess_ctrl/ClassFlowAlignment.cpp
+++ b/code/components/mainprocess_ctrl/ClassFlowAlignment.cpp
@@ -139,8 +139,10 @@ bool ClassFlowAlignment::doFlow(std::string time)
         if (AlignRetval == TPL_MATCH_OK_SIMILAR) { // Alignment with similarity check successful
             saveAlignmentMarkerData();
         }
-        else if (AlignRetval == TPL_MATCH_FAILED) { // Alignment failed
-            LogFile.writeToFile(ESP_LOG_ERROR, TAG, "Alignment by algorithm failed. Verify image rotation and alignment marker");
+        else if (AlignRetval == TPL_MATCH_FAILED) { // Alignment not successful
+            LogFile.writeToFile(
+                ESP_LOG_ERROR, TAG,
+                "Fine alignment unsuccessful. Use alignment marker areas with sharp edges, unique shapes and high contrast");
             setFlowStateHandlerEvent(-1); // Set error event code for post cycle error handler 'doPostProcessEventHandling'
         }
 
@@ -196,7 +198,7 @@ void ClassFlowAlignment::doPostProcessEventHandling()
             drawAlignmentMarker(*flowImageData->imgProcess);
             flowImageData->imgProcess->saveJpgToFile(formatFileName(destination + "/alg_misalign.jpg"));
 
-            LogFile.writeToFile(ESP_LOG_DEBUG, TAG, "Alignment failed, debug infos saved: " + destination);
+            LogFile.writeToFile(ESP_LOG_DEBUG, TAG, "Fine alignment unsuccessful, debug infos saved: " + destination);
         }
     }
 }


### PR DESCRIPTION
As a follow up of this discussion: https://github.com/Slider0007/AI-on-the-edge-device/discussions/305:

Adapted the fine alignment failure message to clarify that it is not a system error and to guide the user toward improving alignment marker selection.

**It is important to use alignment marker areas with sharp edges, unique shapes and high contrast on a sharply focused image!**


