### PR TITLE
refactor(system): Log brownout reset as warning to highlight power-supply instability

### DIFF
--- a/code/components/misc_helper/system.cpp
+++ b/code/components/misc_helper/system.cpp
@@ -320,45 +320,31 @@ bool isSetSystemStatusFlag(SystemStatusFlag_t flag)
 
 std::string getResetReason(void)
 {
-    std::string reasonText;
-
     switch (esp_reset_reason()) {
         case ESP_RST_POWERON:
-            reasonText = "Power-on event (or reset button)";
-            break; //!< Reset due to power-on event
+            return "Power-on event (or reset button)"; // Reset due to power-on event
         case ESP_RST_EXT:
-            reasonText = "External pin";
-            break; //!< Reset by external pin (not applicable for ESP32)
+            return "External pin"; // Reset by external pin (not applicable for ESP32)
         case ESP_RST_SW:
-            reasonText = "Via esp_restart";
-            break; //!< Software reset via esp_restart
+            return "Software restart (via esp_restart)"; // Software reset via esp_restart
         case ESP_RST_PANIC:
-            reasonText = "Exception/panic";
-            break; //!< Software reset due to exception/panic
+            return "Exception or panic"; // Software reset due to panic/exception
         case ESP_RST_INT_WDT:
-            reasonText = "Interrupt watchdog";
-            break; //!< Reset (software or hardware) due to interrupt watchdog
+            return "Interrupt watchdog"; // Reset due to interrupt watchdog
         case ESP_RST_TASK_WDT:
-            reasonText = "Task watchdog";
-            break; //!< Reset due to task watchdog
+            return "Task watchdog"; // Reset due to task watchdog
         case ESP_RST_WDT:
-            reasonText = "Other watchdogs";
-            break; //!< Reset due to other watchdogs
+            return "Other watchdogs"; // Reset due to other watchdogs
         case ESP_RST_DEEPSLEEP:
-            reasonText = "Exiting deep sleep mode";
-            break; //!< Reset after exiting deep sleep mode
+            return "Wakeup from deep sleep"; // Reset after exiting deep sleep mode
         case ESP_RST_BROWNOUT:
-            reasonText = "Brownout";
-            break; //!< Brownout reset (software or hardware)
+            return "Brownout (voltage drop of power supply)"; // Brownout reset
         case ESP_RST_SDIO:
-            reasonText = "SDIO";
-            break; //!< Reset over SDIO
-
-        case ESP_RST_UNKNOWN: //!< Reset reason can not be determined
+            return "Reset via SDIO"; // Reset over SDIO
+        case ESP_RST_UNKNOWN:
         default:
-            reasonText = "Unknown";
+            return "Unknown reset reason"; // Fallback
     }
-    return reasonText;
 }
 
 

--- a/code/main/main.cpp
+++ b/code/main/main.cpp
@@ -206,6 +206,10 @@ extern "C" void app_main(void)
         LogFile.setLogLevel(ESP_LOG_DEBUG);
         setTaskAutoFlowState(FLOW_TASK_STATE_INIT_DELAYED);
     }
+    else if (esp_reset_reason() == ESP_RST_BROWNOUT) {
+        LogFile.writeToFile(ESP_LOG_WARN, TAG, "Reset reason: " + getResetReason());
+        LogFile.writeToFile(ESP_LOG_WARN, TAG, "System reset due to an insufficient or unstable power supply");
+    }
     else {
         LogFile.writeToFile(ESP_LOG_INFO, TAG, "Reset reason: " + getResetReason());
     }

--- a/code/main/main.cpp
+++ b/code/main/main.cpp
@@ -208,7 +208,7 @@ extern "C" void app_main(void)
     }
     else if (esp_reset_reason() == ESP_RST_BROWNOUT) {
         LogFile.writeToFile(ESP_LOG_WARN, TAG, "Reset reason: " + getResetReason());
-        LogFile.writeToFile(ESP_LOG_WARN, TAG, "System reset due to an insufficient or unstable power supply");
+        LogFile.writeToFile(ESP_LOG_WARN, TAG, "System reset caused by insufficient or unstable power supply");
     }
     else {
         LogFile.writeToFile(ESP_LOG_INFO, TAG, "Reset reason: " + getResetReason());


### PR DESCRIPTION
Refactor brownout system reset reason logging (log as warning) to clearly indicate that the event is caused by a hardware-level voltage drop due to an insufficient or unstable power supply. A supply-voltage drop is an abnormal condition and can lead to undefined device behavior.

Follow-up of discussion #321, #323