### PR TITLE
fix(influxdbv2): Fix typo in config validation handling

### DIFF
--- a/code/components/mainprocess_ctrl/ClassFlowInfluxDBv2.cpp
+++ b/code/components/mainprocess_ctrl/ClassFlowInfluxDBv2.cpp
@@ -42,7 +42,7 @@ bool ClassFlowInfluxDBv2::loadParameter()
             }
         }
 
-        if (sequence->paramInfluxDBv1 == NULL) {
+        if (sequence->paramInfluxDBv2 == NULL) {
             LogFile.writeToFile(ESP_LOG_ERROR, TAG, "Invalid sequence config");
             return false;
         }


### PR DESCRIPTION
This typo prevented having a valid InfluxDBv2 config.