### PR TITLE
fix(post-processing): Fix extended resolution (using digits only + decimal shift)

### DIFF
--- a/code/components/config_handling/cfgDataStruct.h
+++ b/code/components/config_handling/cfgDataStruct.h
@@ -282,7 +282,7 @@ struct CfgData {
     struct SectionDigit {
         bool enabled = true;
         std::string model = "dig-class100_0182_s2_q.tflite"; // with extention, but without path
-        float cnnGoodThreshold = 0.50;
+        float cnnGoodThreshold = 0.80;
         std::vector<RoiPerSequence> sequence;
         struct Debug {
             bool saveRoiImages = false;

--- a/code/components/mainprocess_ctrl/ClassFlowCNNGeneral.cpp
+++ b/code/components/mainprocess_ctrl/ClassFlowCNNGeneral.cpp
@@ -442,7 +442,7 @@ std::string ClassFlowCNNGeneral::getReadout(SequenceData *sequence, int valuePre
 
         // Evaluate last ROI of number sequence (and potentially correct)
         LogFile.writeToFile(ESP_LOG_DEBUG, TAG, "ROI: " + sequence->digitRoi[lastROI]->param->roiName);
-        const int resultTemp = sequence->digitRoi[lastROI]->CNNResult;
+        int resultTemp = sequence->digitRoi[lastROI]->CNNResult;
 
         // Valid result (e.g. model 'dig-cont*' --> bad fit) or not used for other models (ensure isRejected is not set)
         if (!sequence->digitRoi[lastROI]->isRejected) {

--- a/code/components/mainprocess_ctrl/ClassFlowCNNGeneral.cpp
+++ b/code/components/mainprocess_ctrl/ClassFlowCNNGeneral.cpp
@@ -438,18 +438,19 @@ std::string ClassFlowCNNGeneral::getReadout(SequenceData *sequence, int valuePre
         }
 
         std::string result = "";
-        int resultTemp = -1;
-        int lastROI = sequence->digitRoi.size() - 1;
+        const int lastROI = sequence->digitRoi.size() - 1;
 
         // Evaluate last ROI of number sequence (and potentially correct)
         LogFile.writeToFile(ESP_LOG_DEBUG, TAG, "ROI: " + sequence->digitRoi[lastROI]->param->roiName);
-        resultTemp = sequence->digitRoi[lastROI]->CNNResult;
+        const int resultTemp = sequence->digitRoi[lastROI]->CNNResult;
 
         // Valid result (e.g. model 'dig-cont*' --> bad fit) or not used for other models (ensure isRejected is not set)
         if (!sequence->digitRoi[lastROI]->isRejected) {
             // NOTE: Ensure that this flag is only set if no analog previous number is available
             if (sequence->paramPostProc->extendedResolution && valuePreviousNumber == -1) {
-                result = std::to_string(resultTemp);
+                // Pad numbers 0–9 with a leading zero to ensure 2-digit output
+                result = (resultTemp >= 0 && resultTemp < 10 ? "0" : "") + std::to_string(resultTemp);
+
                 LogFile.writeToFile(ESP_LOG_DEBUG, TAG,
                                     "Digit Number (No previous number, Extended Resolution): Result: " + result +
                                         ", Value: " + to_stringWithPrecision((resultTemp / 10.0), 1));

--- a/code/components/mainprocess_ctrl/ClassFlowCNNGeneral.cpp
+++ b/code/components/mainprocess_ctrl/ClassFlowCNNGeneral.cpp
@@ -444,7 +444,7 @@ std::string ClassFlowCNNGeneral::getReadout(SequenceData *sequence, int valuePre
         LogFile.writeToFile(ESP_LOG_DEBUG, TAG, "ROI: " + sequence->digitRoi[lastROI]->param->roiName);
         int resultTemp = sequence->digitRoi[lastROI]->CNNResult;
 
-        // Valid result (e.g. model 'dig-cont*' --> bad fit) or not used for other models (ensure isRejected is not set)
+        // Valid result ('isRejected' is not set)
         if (!sequence->digitRoi[lastROI]->isRejected) {
             // NOTE: Ensure that this flag is only set if no analog previous number is available
             if (sequence->paramPostProc->extendedResolution && valuePreviousNumber == -1) {
@@ -469,12 +469,8 @@ std::string ClassFlowCNNGeneral::getReadout(SequenceData *sequence, int valuePre
             }
         }
         else {
-            result = "N";
-            if (sequence->paramPostProc->extendedResolution) {
-                result = "NN";
-            }
-
-            LogFile.writeToFile(ESP_LOG_DEBUG, TAG, "getReadout Digit (dig-cont): Rejected, substitute with N");
+            sequence->paramPostProc->extendedResolution ? result = "NN" : result = "N";
+            LogFile.writeToFile(ESP_LOG_DEBUG, TAG, "getReadout Digit (dig-cont): Rejected, substitute with N (extended resolution: NN)");
         }
 
         // Evaluate all remaining ROI of number sequence (and potentially correct)
@@ -487,7 +483,7 @@ std::string ClassFlowCNNGeneral::getReadout(SequenceData *sequence, int valuePre
             else {
                 resultTemp = -1;
                 result = "N" + result;
-                LogFile.writeToFile(ESP_LOG_DEBUG, TAG, "getReadout Digit (dig-cont/dig-class100): Rejected, substitute with N");
+                LogFile.writeToFile(ESP_LOG_DEBUG, TAG, "getReadout Digit (dig-cont): Rejected, substitute with N");
             }
         }
 

--- a/code/components/mainprocess_ctrl/ClassFlowPostProcessing.cpp
+++ b/code/components/mainprocess_ctrl/ClassFlowPostProcessing.cpp
@@ -322,7 +322,7 @@ bool ClassFlowPostProcessing::doFlow(std::string zwtime)
                         }
 
                         sequence->sValueStatus +=
-                            " | Rate: " + to_stringWithPrecision(RatePerSelection, sequence->decimalPlaceCount) +
+                            ", Rate: " + to_stringWithPrecision(RatePerSelection, sequence->decimalPlaceCount) +
                             ", Discarded value: " + to_stringWithPrecision(sequence->actualValue, sequence->decimalPlaceCount) +
                             ", Using fallback: " + to_stringWithPrecision(sequence->fallbackValue, sequence->decimalPlaceCount + 1);
 
@@ -348,7 +348,7 @@ bool ClassFlowPostProcessing::doFlow(std::string zwtime)
                         LogFile.writeToFile(
                             ESP_LOG_DEBUG, TAG,
                             "Sequence: " + sequence->sequenceName + " | Status: " + sequence->sValueStatus +
-                                " | Rate: " + to_stringWithPrecision(RatePerSelection, sequence->decimalPlaceCount) +
+                                ", Rate: " + to_stringWithPrecision(RatePerSelection, sequence->decimalPlaceCount) +
                                 ", Discarded value: " + to_stringWithPrecision(sequence->actualValue, sequence->decimalPlaceCount) +
                                 ", Using fallback: " + to_stringWithPrecision(sequence->fallbackValue, sequence->decimalPlaceCount + 1));
                         sequence->isActualValueConfirmed = false;

--- a/code/components/mainprocess_ctrl/ClassFlowPostProcessing.cpp
+++ b/code/components/mainprocess_ctrl/ClassFlowPostProcessing.cpp
@@ -79,7 +79,7 @@ bool ClassFlowPostProcessing::loadParameter()
         }
 
         LogFile.writeToFile(ESP_LOG_DEBUG, TAG,
-                            "Number sequence: " + sequence->sequenceName + ", Digits: " + std::to_string(sequence->digitRoi.size()) +
+                            "Sequence: " + sequence->sequenceName + " | Digits: " + std::to_string(sequence->digitRoi.size()) +
                                 ", Analogs: " + std::to_string(sequence->analogRoi.size()));
     }
 
@@ -125,7 +125,7 @@ bool ClassFlowPostProcessing::doFlow(std::string zwtime)
 
         /* Process analog numbers of sequence */
         if (!sequence->analogRoi.empty()) {
-            LogFile.writeToFile(ESP_LOG_DEBUG, TAG, "doFlow: Get analog ROI results");
+            LogFile.writeToFile(ESP_LOG_DEBUG, TAG, "Get analog ROI results");
             sRawValue = flowAnalog->getReadout(sequence);
 
             if (sRawValue.length() > 0) {
@@ -146,7 +146,7 @@ bool ClassFlowPostProcessing::doFlow(std::string zwtime)
 
         /* Process digit numbers of sequence */
         if (!sequence->digitRoi.empty()) {
-            LogFile.writeToFile(ESP_LOG_DEBUG, TAG, "doFlow: Get digit ROI results");
+            LogFile.writeToFile(ESP_LOG_DEBUG, TAG, "Get digit ROI results");
             if (!sequence->analogRoi.empty()) { // If analog numbers available
                 sRawValue = flowDigit->getReadout(sequence, sequence->analogRoi[0]->CNNResult, resultPreviousNumberAnalog) + sRawValue;
             }
@@ -167,7 +167,7 @@ bool ClassFlowPostProcessing::doFlow(std::string zwtime)
             sequence->isActualValueANumber = false;
             sequence->isActualValueConfirmed = false;
             sequence->sValueStatus = std::string(VALUE_STATUS_W01_EMPTY_DATA);
-            LogFile.writeToFile(ESP_LOG_WARN, TAG, "Sequence: " + sequence->sequenceName + ": Status: " + sequence->sValueStatus);
+            LogFile.writeToFile(ESP_LOG_WARN, TAG, "Sequence: " + sequence->sequenceName + " | Status: " + sequence->sValueStatus);
             continue; // Stop here, no data
         }
 
@@ -197,7 +197,7 @@ bool ClassFlowPostProcessing::doFlow(std::string zwtime)
 
         /* Substitute any N position with last valid number if available */
         if (findDelimiterPos(sActualValue, "N") != std::string::npos) {
-            LogFile.writeToFile(ESP_LOG_DEBUG, TAG, "Substitute N positions for number sequence: " + sequence->sequenceName);
+            LogFile.writeToFile(ESP_LOG_DEBUG, TAG, "Sequence: " + sequence->sequenceName + " | Checking for N position substitution");
             // FallbackValue can be used to replace the N
             if (sequence->paramPostProc->useFallbackValue && sequence->isFallbackValueValid) {
                 sActualValue = substituteN(sActualValue, sequence->fallbackValue);
@@ -219,7 +219,7 @@ bool ClassFlowPostProcessing::doFlow(std::string zwtime)
                 sequence->isActualValueANumber = false;
                 sequence->isActualValueConfirmed = false;
 
-                LogFile.writeToFile(ESP_LOG_WARN, TAG, "Sequence: " + sequence->sequenceName + ": Status: " + sequence->sValueStatus);
+                LogFile.writeToFile(ESP_LOG_WARN, TAG, "Sequence: " + sequence->sequenceName + " | Status: " + sequence->sValueStatus);
 
                 writeDataLog(sequence->sequenceName);
                 continue; // Stop here, no valid number because there are still N.
@@ -249,7 +249,7 @@ bool ClassFlowPostProcessing::doFlow(std::string zwtime)
             sequence->isActualValueANumber = false;
             sequence->isActualValueConfirmed = false;
             sequence->sValueStatus = std::string(VALUE_STATUS_W01_EMPTY_DATA);
-            LogFile.writeToFile(ESP_LOG_WARN, TAG, "Sequence: " + sequence->sequenceName + ": Status: " + sequence->sValueStatus);
+            LogFile.writeToFile(ESP_LOG_WARN, TAG, "Sequence: " + sequence->sequenceName + " | Status: " + sequence->sValueStatus);
             continue; // Stop here, invalid number
         }
 
@@ -270,7 +270,7 @@ bool ClassFlowPostProcessing::doFlow(std::string zwtime)
                 if (flowDigit->getCNNType() == CNNTYPE_DIGIT_CLASS11) {
                     if (sequence->paramPostProc->checkDigitIncreaseConsistency) {
                         LogFile.writeToFile(ESP_LOG_DEBUG, TAG,
-                                            "Check digit increase consistency for number sequence: " + sequence->sequenceName);
+                                            "Sequence: " + sequence->sequenceName + " | Checking for digit increase consistency");
                         sequence->actualValue = checkDigitConsistency(sequence->actualValue, sequence->correctedDecimalShift,
                                                                       !sequence->analogRoi.empty(), sequence->fallbackValue);
                     }
@@ -307,7 +307,7 @@ bool ClassFlowPostProcessing::doFlow(std::string zwtime)
 
                 /* Check for rate too high */
                 if (sequence->paramPostProc->maxRateCheckType > RATE_CHECK_OFF) {
-                    LogFile.writeToFile(ESP_LOG_DEBUG, TAG, "Max. rate check for number sequence: " + sequence->sequenceName);
+                    LogFile.writeToFile(ESP_LOG_DEBUG, TAG, "Sequence: " + sequence->sequenceName + " | Checking for max. rate deviation");
                     if (abs(RatePerSelection) > abs((double)sequence->paramPostProc->maxRate)) {
                         if (RatePerSelection < 0) {
                             sequence->sValueStatus = std::string(VALUE_STATUS_003_RATE_TOO_HIGH_NEG);
@@ -322,12 +322,13 @@ bool ClassFlowPostProcessing::doFlow(std::string zwtime)
                         }
 
                         sequence->sValueStatus +=
-                            " | Discard processed value: " + to_stringWithPrecision(sequence->actualValue, sequence->decimalPlaceCount) +
-                            " | Fallback: " + to_stringWithPrecision(sequence->fallbackValue, sequence->decimalPlaceCount + 1) +
-                            ", Rate: " + to_stringWithPrecision(RatePerSelection, sequence->decimalPlaceCount);
+                            " | Rate: " + to_stringWithPrecision(RatePerSelection, sequence->decimalPlaceCount) +
+                            ", Discarded value: " + to_stringWithPrecision(sequence->actualValue, sequence->decimalPlaceCount) +
+                            ", Using fallback: " + to_stringWithPrecision(sequence->fallbackValue, sequence->decimalPlaceCount + 1);
+
 
                         LogFile.writeToFile(ESP_LOG_WARN, TAG,
-                                            "Sequence: " + sequence->sequenceName + ", Status: " + sequence->sValueStatus);
+                                            "Sequence: " + sequence->sequenceName + " | Status: " + sequence->sValueStatus);
                         sequence->isActualValueConfirmed = false;
                         setFlowStateHandlerEvent(1); // Set warning event code for post cycle error handler 'doPostProcessEventHandling'
                                                      // (only warning level)
@@ -340,16 +341,16 @@ bool ClassFlowPostProcessing::doFlow(std::string zwtime)
 
                 /* Check for negative rate */
                 if (!sequence->paramPostProc->allowNegativeRate && sequence->isActualValueConfirmed) {
-                    LogFile.writeToFile(ESP_LOG_DEBUG, TAG, "Negative rate check for number sequence: " + sequence->sequenceName);
+                    LogFile.writeToFile(ESP_LOG_DEBUG, TAG, "Sequence: " + sequence->sequenceName + " | Checking for negative rate");
                     if (sequence->actualValue < sequence->fallbackValue) {
                         sequence->sValueStatus = std::string(VALUE_STATUS_002_RATE_NEGATIVE);
 
                         LogFile.writeToFile(
                             ESP_LOG_DEBUG, TAG,
-                            "Sequence: " + sequence->sequenceName + ", Status: " + sequence->sValueStatus + " | Discard processed value: " +
-                                to_stringWithPrecision(sequence->actualValue, sequence->decimalPlaceCount) +
-                                " | Fallback: " + to_stringWithPrecision(sequence->fallbackValue, sequence->decimalPlaceCount + 1) +
-                                ", Rate: " + to_stringWithPrecision(RatePerSelection, sequence->decimalPlaceCount));
+                            "Sequence: " + sequence->sequenceName + " | Status: " + sequence->sValueStatus +
+                                " | Rate: " + to_stringWithPrecision(RatePerSelection, sequence->decimalPlaceCount) +
+                                ", Discarded value: " + to_stringWithPrecision(sequence->actualValue, sequence->decimalPlaceCount) +
+                                ", Using fallback: " + to_stringWithPrecision(sequence->fallbackValue, sequence->decimalPlaceCount + 1));
                         sequence->isActualValueConfirmed = false;
 
                         /* Update timestamp of fallback value to be prepared to identify every negative movement larger than max. rate
@@ -363,10 +364,10 @@ bool ClassFlowPostProcessing::doFlow(std::string zwtime)
                 ESP_LOGI(TAG, "After allowNegativeRates: actualValue %f", sequence->actualValue);
 #endif // DEBUG_DETAIL_ON
             }
-            else { // Fallback value is outdated or age indeterminable (could be the case after a reboot) -> force rates to zero
+            else { // Fallback value is outdated or age not determinable (could be the case after a reboot) -> force rates to zero
                 sequence->ratePerMin = 0;
                 sequence->ratePerInterval = 0;
-                LogFile.writeToFile(ESP_LOG_DEBUG, TAG, "Fallback value outdated or age indeterminable");
+                LogFile.writeToFile(ESP_LOG_DEBUG, TAG, "Fallback value outdated or age not determinable");
             }
 
             /* Update fallback value + set status */
@@ -402,8 +403,8 @@ bool ClassFlowPostProcessing::doFlow(std::string zwtime)
 
         /* Write log file entry */
         LogFile.writeToFile(ESP_LOG_INFO, TAG,
-                            sequence->sequenceName + ": Value: " + sequence->sActualValue + ", Rate per min: " + sequence->sRatePerMin +
-                                ", Status: " + sequence->sValueStatus);
+                            "Sequence: " + sequence->sequenceName + " | Value: " + sequence->sActualValue +
+                                " | Rate per min: " + sequence->sRatePerMin + " | Status: " + sequence->sValueStatus);
 
         writeDataLog(sequence->sequenceName);
     }
@@ -702,7 +703,7 @@ bool ClassFlowPostProcessing::setFallbackValue(double value, std::string sequenc
                 double ReturnRawValueAsDouble = strtod(sequence->sRawValue.c_str(), &p);
                 if (ReturnRawValueAsDouble == 0) {
                     LogFile.writeToFile(ESP_LOG_WARN, TAG,
-                                        "setFallbackValue: RawValue not a valid value for further processing: " + sequence->sRawValue);
+                                        "setFallbackValue: Raw value not a valid value for further processing: " + sequence->sRawValue);
                     return false;
                 }
                 sequence->fallbackValue = ReturnRawValueAsDouble;
@@ -715,14 +716,14 @@ bool ClassFlowPostProcessing::setFallbackValue(double value, std::string sequenc
             updateFallbackValue = true;
             saveFallbackValue();
 
-            LogFile.writeToFile(ESP_LOG_INFO, TAG, sequence->sequenceName + ": Set FallbackValue to: " + sequence->sFallbackValue);
+            LogFile.writeToFile(ESP_LOG_INFO, TAG, sequence->sequenceName + ": Set fallback value to: " + sequence->sFallbackValue);
 
             return true;
         }
     }
 
-    LogFile.writeToFile(ESP_LOG_WARN, TAG, "setFallbackValue: Numbersname not found or not valid");
-    return false; // No new value was set (e.g. wrong numbersname, no numbers at all)
+    LogFile.writeToFile(ESP_LOG_WARN, TAG, "setFallbackValue: Failed to set fallback value | Error: No sequence found");
+    return false;
 }
 
 
@@ -737,7 +738,7 @@ bool ClassFlowPostProcessing::loadFallbackValue(void)
 
     err = nvs_open("fallbackvalue", NVS_READONLY, &fallbackvalue_nvshandle);
     if (err != ESP_OK && err != ESP_ERR_NVS_NOT_FOUND) {
-        LogFile.writeToFile(ESP_LOG_ERROR, TAG, "loadFallbackValue: nvs_open | error: " + intToHexString(err));
+        LogFile.writeToFile(ESP_LOG_ERROR, TAG, "loadFallbackValue: nvs_open | Error: " + intToHexString(err));
         return false;
     }
     else if (err != ESP_OK && (err == ESP_ERR_NVS_NOT_FOUND || err == ESP_ERR_NVS_INVALID_HANDLE)) {
@@ -749,7 +750,7 @@ bool ClassFlowPostProcessing::loadFallbackValue(void)
     int16_t sequence_size = 0;
     err = nvs_get_i16(fallbackvalue_nvshandle, "sequence_size", &sequence_size);
     if (err != ESP_OK && err != ESP_ERR_NVS_NOT_FOUND) {
-        LogFile.writeToFile(ESP_LOG_ERROR, TAG, "loadFallbackValue: nvs_get_i16 sequence_size - error: " + intToHexString(err));
+        LogFile.writeToFile(ESP_LOG_ERROR, TAG, "loadFallbackValue: nvs_get_i16 sequence_size | Error: " + intToHexString(err));
         nvs_close(fallbackvalue_nvshandle);
         return false;
     }
@@ -759,7 +760,7 @@ bool ClassFlowPostProcessing::loadFallbackValue(void)
         size_t required_size = 0;
         err = nvs_get_str(fallbackvalue_nvshandle, ("name" + std::to_string(i)).c_str(), NULL, &required_size);
         if (err != ESP_OK && err != ESP_ERR_NVS_NOT_FOUND) {
-            LogFile.writeToFile(ESP_LOG_ERROR, TAG, "loadFallbackValue: nvs_get_str name size - error: " + intToHexString(err));
+            LogFile.writeToFile(ESP_LOG_ERROR, TAG, "loadFallbackValue: nvs_get_str name size | Error: " + intToHexString(err));
             nvs_close(fallbackvalue_nvshandle);
             return false;
         }
@@ -768,7 +769,7 @@ bool ClassFlowPostProcessing::loadFallbackValue(void)
         if (required_size > 0) {
             err = nvs_get_str(fallbackvalue_nvshandle, ("name" + std::to_string(i)).c_str(), cName, &required_size);
             if (err != ESP_OK) {
-                LogFile.writeToFile(ESP_LOG_ERROR, TAG, "loadFallbackValue: nvs_get_str name - error: " + intToHexString(err));
+                LogFile.writeToFile(ESP_LOG_ERROR, TAG, "loadFallbackValue: nvs_get_str name | Error: " + intToHexString(err));
                 nvs_close(fallbackvalue_nvshandle);
                 return false;
             }
@@ -778,7 +779,7 @@ bool ClassFlowPostProcessing::loadFallbackValue(void)
         required_size = 0;
         err = nvs_get_str(fallbackvalue_nvshandle, ("time" + std::to_string(i)).c_str(), NULL, &required_size);
         if (err != ESP_OK && err != ESP_ERR_NVS_NOT_FOUND) {
-            LogFile.writeToFile(ESP_LOG_ERROR, TAG, "loadFallbackValue: nvs_get_str timestamp size - error: " + intToHexString(err));
+            LogFile.writeToFile(ESP_LOG_ERROR, TAG, "loadFallbackValue: nvs_get_str timestamp size | Error: " + intToHexString(err));
             nvs_close(fallbackvalue_nvshandle);
             return false;
         }
@@ -787,7 +788,7 @@ bool ClassFlowPostProcessing::loadFallbackValue(void)
         if (required_size > 0) {
             err = nvs_get_str(fallbackvalue_nvshandle, ("time" + std::to_string(i)).c_str(), cTime, &required_size);
             if (err != ESP_OK) {
-                LogFile.writeToFile(ESP_LOG_ERROR, TAG, "loadFallbackValue: nvs_get_str timestamp - error: " + intToHexString(err));
+                LogFile.writeToFile(ESP_LOG_ERROR, TAG, "loadFallbackValue: nvs_get_str timestamp | Error: " + intToHexString(err));
                 nvs_close(fallbackvalue_nvshandle);
                 return false;
             }
@@ -797,7 +798,7 @@ bool ClassFlowPostProcessing::loadFallbackValue(void)
         required_size = 0;
         err = nvs_get_str(fallbackvalue_nvshandle, ("value" + std::to_string(i)).c_str(), NULL, &required_size);
         if (err != ESP_OK && err != ESP_ERR_NVS_NOT_FOUND) {
-            LogFile.writeToFile(ESP_LOG_ERROR, TAG, "loadFallbackValue: nvs_get_str fallbackvalue size - error: " + intToHexString(err));
+            LogFile.writeToFile(ESP_LOG_ERROR, TAG, "loadFallbackValue: nvs_get_str fallbackvalue size | Error: " + intToHexString(err));
             nvs_close(fallbackvalue_nvshandle);
             return false;
         }
@@ -806,7 +807,7 @@ bool ClassFlowPostProcessing::loadFallbackValue(void)
         if (required_size > 0) {
             err = nvs_get_str(fallbackvalue_nvshandle, ("value" + std::to_string(i)).c_str(), cValue, &required_size);
             if (err != ESP_OK) {
-                LogFile.writeToFile(ESP_LOG_ERROR, TAG, "loadFallbackValue: nvs_get_str fallbackvalue - error: " + intToHexString(err));
+                LogFile.writeToFile(ESP_LOG_ERROR, TAG, "loadFallbackValue: nvs_get_str fallbackvalue | Error: " + intToHexString(err));
                 nvs_close(fallbackvalue_nvshandle);
                 return false;
             }
@@ -848,7 +849,7 @@ bool ClassFlowPostProcessing::loadFallbackValue(void)
                     LogFile.writeToFile(ESP_LOG_INFO, TAG,
                                         sequence->sequenceName + ": Fallback value outdated | Timestamp: " + sequence->sTimeFallbackValue);
                 }
-                // Start time is older than fallback value timestamp -> age indeterminable
+                // Start time is older than fallback value timestamp -> age not determinable
                 else if (AgeInMinutes < 0) {
                     sequence->isFallbackValueValid = false;
                     sequence->fallbackValue = 0;
@@ -889,14 +890,14 @@ bool ClassFlowPostProcessing::saveFallbackValue()
 
     err = nvs_open("fallbackvalue", NVS_READWRITE, &fallbackvalue_nvshandle);
     if (err != ESP_OK) {
-        LogFile.writeToFile(ESP_LOG_ERROR, TAG, "saveFallbackValue: No valid NVS handle - error: " + intToHexString(err));
+        LogFile.writeToFile(ESP_LOG_ERROR, TAG, "saveFallbackValue: No valid NVS handle | Error: " + intToHexString(err));
         return false;
     }
 
     // Save number sequence size to ensure that only already saved data will be loaded
     err = nvs_set_i16(fallbackvalue_nvshandle, "sequence_size", (int16_t)sequenceData.size());
     if (err != ESP_OK) {
-        LogFile.writeToFile(ESP_LOG_ERROR, TAG, "saveFallbackValue: nvs_set_i16 sequence_size - error: " + intToHexString(err));
+        LogFile.writeToFile(ESP_LOG_ERROR, TAG, "saveFallbackValue: nvs_set_i16 sequence_size | Error: " + intToHexString(err));
         nvs_close(fallbackvalue_nvshandle);
         return false;
     }
@@ -914,20 +915,20 @@ bool ClassFlowPostProcessing::saveFallbackValue()
 
         err = nvs_set_str(fallbackvalue_nvshandle, ("name" + std::to_string(i)).c_str(), sequenceData[i]->sequenceName.c_str());
         if (err != ESP_OK) {
-            LogFile.writeToFile(ESP_LOG_ERROR, TAG, "saveFallbackValue: nvs_set_str name - error: " + intToHexString(err));
+            LogFile.writeToFile(ESP_LOG_ERROR, TAG, "saveFallbackValue: nvs_set_str name | Error: " + intToHexString(err));
             nvs_close(fallbackvalue_nvshandle);
             return false;
         }
         err = nvs_set_str(fallbackvalue_nvshandle, ("time" + std::to_string(i)).c_str(), sequenceData[i]->sTimeFallbackValue.c_str());
         if (err != ESP_OK) {
-            LogFile.writeToFile(ESP_LOG_ERROR, TAG, "saveFallbackValue: nvs_set_str timestamp - error: " + intToHexString(err));
+            LogFile.writeToFile(ESP_LOG_ERROR, TAG, "saveFallbackValue: nvs_set_str timestamp | Error: " + intToHexString(err));
             nvs_close(fallbackvalue_nvshandle);
             return false;
         }
         err = nvs_set_str(fallbackvalue_nvshandle, ("value" + std::to_string(i)).c_str(),
                           to_stringWithPrecision(sequenceData[i]->fallbackValue, sequenceData[i]->decimalPlaceCount).c_str());
         if (err != ESP_OK) {
-            LogFile.writeToFile(ESP_LOG_ERROR, TAG, "saveFallbackValue: nvs_set_str fallbackvalue - error: " + intToHexString(err));
+            LogFile.writeToFile(ESP_LOG_ERROR, TAG, "saveFallbackValue: nvs_set_str fallbackvalue | Error: " + intToHexString(err));
             nvs_close(fallbackvalue_nvshandle);
             return false;
         }
@@ -937,7 +938,7 @@ bool ClassFlowPostProcessing::saveFallbackValue()
     nvs_close(fallbackvalue_nvshandle);
 
     if (err != ESP_OK) {
-        LogFile.writeToFile(ESP_LOG_ERROR, TAG, "saveFallbackValue: nvs_commit - error: " + intToHexString(err));
+        LogFile.writeToFile(ESP_LOG_ERROR, TAG, "saveFallbackValue: nvs_commit | Error: " + intToHexString(err));
         return false;
     }
 

--- a/code/components/mainprocess_ctrl/ClassFlowPostProcessing.cpp
+++ b/code/components/mainprocess_ctrl/ClassFlowPostProcessing.cpp
@@ -179,15 +179,17 @@ bool ClassFlowPostProcessing::doFlow(std::string zwtime)
 #endif // DEBUG_DETAIL_ON
 
         /* Remove leading N */
-        if (sequence->paramPostProc->ignoreLeadingNaN) {
-            while ((sRawValue.length() > 1) && (sRawValue[0] == 'N')) {
-                sRawValue.erase(0, 1);
+        if (flowDigit->getCNNType() == CNNTYPE_DIGIT_CLASS11) {
+            if (sequence->paramPostProc->ignoreLeadingNaN) {
+                while ((sRawValue.length() > 1) && (sRawValue[0] == 'N')) {
+                    sRawValue.erase(0, 1);
+                }
             }
-        }
 
 #ifdef DEBUG_DETAIL_ON
-        ESP_LOGI(TAG, "After IgnoreLeadingNaN: RawValue %s", sRawValue.c_str());
+            ESP_LOGI(TAG, "After IgnoreLeadingNaN: RawValue %s", sRawValue.c_str());
 #endif // DEBUG_DETAIL_ON
+        }
 
         /* Use fully processed "Raw Value" and transfer to "Value" for further processing */
 
@@ -267,11 +269,7 @@ bool ClassFlowPostProcessing::doFlow(std::string zwtime)
                 /* Check digit plausibility (only support and necessary for class-11 models (0-9 + NaN)) */
                 if (sequence->paramPostProc->checkDigitIncreaseConsistency) {
                     if (flowDigit) {
-                        if (flowDigit->getCNNType() != CNNTYPE_DIGIT_CLASS11) {
-                            LogFile.writeToFile(ESP_LOG_WARN, TAG,
-                                                "Skip \'Digit Increase Consistency\' check, only applicable for dig-class11 models");
-                        }
-                        else {
+                        if (flowDigit->getCNNType() == CNNTYPE_DIGIT_CLASS11) {
                             LogFile.writeToFile(ESP_LOG_DEBUG, TAG,
                                                 "Check digit increase consistency for number sequence: " + sequence->sequenceName);
                             sequence->actualValue = checkDigitConsistency(sequence->actualValue, sequence->correctedDecimalShift,
@@ -328,9 +326,9 @@ bool ClassFlowPostProcessing::doFlow(std::string zwtime)
                             sequence->sValueStatus = std::string(VALUE_STATUS_004_RATE_TOO_HIGH_POS);
                         }
 
-                        sequence->sValueStatus += " | Value: " +
+                        sequence->sValueStatus += " | Discard processed value: " +
                                                   to_stringWithPrecision(sequence->actualValue, sequence->decimalPlaceCount) +
-                                                  ", Fallback: " + sequence->sFallbackValue +
+                                                  " | Fallback: " + sequence->sFallbackValue +
                                                   ", Rate: " + to_stringWithPrecision(RatePerSelection, sequence->decimalPlaceCount);
 
                         LogFile.writeToFile(ESP_LOG_WARN, TAG,
@@ -353,8 +351,8 @@ bool ClassFlowPostProcessing::doFlow(std::string zwtime)
 
                         LogFile.writeToFile(ESP_LOG_DEBUG, TAG,
                                             "Sequence: " + sequence->sequenceName + ", Status: " + sequence->sValueStatus +
-                                                " | Value: " + std::to_string(sequence->actualValue) +
-                                                ", Fallback: " + std::to_string(sequence->fallbackValue) +
+                                                " | Discard processed value: " + std::to_string(sequence->actualValue) +
+                                                " | Fallback: " + std::to_string(sequence->fallbackValue) +
                                                 ", Rate: " + to_stringWithPrecision(RatePerSelection, sequence->decimalPlaceCount));
                         sequence->isActualValueConfirmed = false;
 

--- a/code/components/mainprocess_ctrl/ClassFlowPostProcessing.cpp
+++ b/code/components/mainprocess_ctrl/ClassFlowPostProcessing.cpp
@@ -125,7 +125,7 @@ bool ClassFlowPostProcessing::doFlow(std::string zwtime)
 
         /* Process analog numbers of sequence */
         if (!sequence->analogRoi.empty()) {
-            LogFile.writeToFile(ESP_LOG_DEBUG, TAG, "Get analog ROI results");
+            LogFile.writeToFile(ESP_LOG_DEBUG, TAG, "Sequence: " + sequence->sequenceName + " | Get analog ROI results");
             sRawValue = flowAnalog->getReadout(sequence);
 
             if (sRawValue.length() > 0) {
@@ -146,7 +146,7 @@ bool ClassFlowPostProcessing::doFlow(std::string zwtime)
 
         /* Process digit numbers of sequence */
         if (!sequence->digitRoi.empty()) {
-            LogFile.writeToFile(ESP_LOG_DEBUG, TAG, "Get digit ROI results");
+            LogFile.writeToFile(ESP_LOG_DEBUG, TAG, "Sequence: " + sequence->sequenceName + " | Get digit ROI results");
             if (!sequence->analogRoi.empty()) { // If analog numbers available
                 sRawValue = flowDigit->getReadout(sequence, sequence->analogRoi[0]->CNNResult, resultPreviousNumberAnalog) + sRawValue;
             }
@@ -322,7 +322,7 @@ bool ClassFlowPostProcessing::doFlow(std::string zwtime)
                         }
 
                         sequence->sValueStatus +=
-                            ", Rate: " + to_stringWithPrecision(RatePerSelection, sequence->decimalPlaceCount) +
+                            " | Rate: " + to_stringWithPrecision(RatePerSelection, sequence->decimalPlaceCount) +
                             ", Discarded value: " + to_stringWithPrecision(sequence->actualValue, sequence->decimalPlaceCount) +
                             ", Using fallback: " + to_stringWithPrecision(sequence->fallbackValue, sequence->decimalPlaceCount + 1);
 
@@ -348,7 +348,7 @@ bool ClassFlowPostProcessing::doFlow(std::string zwtime)
                         LogFile.writeToFile(
                             ESP_LOG_DEBUG, TAG,
                             "Sequence: " + sequence->sequenceName + " | Status: " + sequence->sValueStatus +
-                                ", Rate: " + to_stringWithPrecision(RatePerSelection, sequence->decimalPlaceCount) +
+                                " | Rate: " + to_stringWithPrecision(RatePerSelection, sequence->decimalPlaceCount) +
                                 ", Discarded value: " + to_stringWithPrecision(sequence->actualValue, sequence->decimalPlaceCount) +
                                 ", Using fallback: " + to_stringWithPrecision(sequence->fallbackValue, sequence->decimalPlaceCount + 1));
                         sequence->isActualValueConfirmed = false;

--- a/code/components/mainprocess_ctrl/ClassFlowPostProcessing.cpp
+++ b/code/components/mainprocess_ctrl/ClassFlowPostProcessing.cpp
@@ -322,9 +322,8 @@ bool ClassFlowPostProcessing::doFlow(std::string zwtime)
                         }
 
                         sequence->sValueStatus +=
-                            " | Discard processed value: " +
-                            to_stringWithPrecision(std::to_string(sequence->actualValue), sequence->decimalPlaceCount) + " | Fallback: " +
-                            to_stringWithPrecision(std::to_string(sequence->fallbackValue), sequence->decimalPlaceCount + 1) +
+                            " | Discard processed value: " + to_stringWithPrecision(sequence->actualValue, sequence->decimalPlaceCount) +
+                            " | Fallback: " + to_stringWithPrecision(sequence->fallbackValue, sequence->decimalPlaceCount + 1) +
                             ", Rate: " + to_stringWithPrecision(RatePerSelection, sequence->decimalPlaceCount);
 
                         LogFile.writeToFile(ESP_LOG_WARN, TAG,
@@ -348,9 +347,8 @@ bool ClassFlowPostProcessing::doFlow(std::string zwtime)
                         LogFile.writeToFile(
                             ESP_LOG_DEBUG, TAG,
                             "Sequence: " + sequence->sequenceName + ", Status: " + sequence->sValueStatus + " | Discard processed value: " +
-                                to_stringWithPrecision(std::to_string(sequence->actualValue), sequence->decimalPlaceCount) +
-                                " | Fallback: " +
-                                to_stringWithPrecision(std::to_string(sequence->fallbackValue), sequence->decimalPlaceCount + 1) +
+                                to_stringWithPrecision(sequence->actualValue, sequence->decimalPlaceCount) +
+                                " | Fallback: " + to_stringWithPrecision(sequence->fallbackValue, sequence->decimalPlaceCount + 1) +
                                 ", Rate: " + to_stringWithPrecision(RatePerSelection, sequence->decimalPlaceCount));
                         sequence->isActualValueConfirmed = false;
 

--- a/code/components/mainprocess_ctrl/ClassFlowPostProcessing.cpp
+++ b/code/components/mainprocess_ctrl/ClassFlowPostProcessing.cpp
@@ -266,18 +266,13 @@ bool ClassFlowPostProcessing::doFlow(std::string zwtime)
                 /* Update fallbackValue */
                 sequence->sFallbackValue = to_stringWithPrecision(sequence->fallbackValue, sequence->decimalPlaceCount);
 
-                /* Check digit plausibility (only support and necessary for class-11 models (0-9 + NaN)) */
-                if (sequence->paramPostProc->checkDigitIncreaseConsistency) {
-                    if (flowDigit) {
-                        if (flowDigit->getCNNType() == CNNTYPE_DIGIT_CLASS11) {
-                            LogFile.writeToFile(ESP_LOG_DEBUG, TAG,
-                                                "Check digit increase consistency for number sequence: " + sequence->sequenceName);
-                            sequence->actualValue = checkDigitConsistency(sequence->actualValue, sequence->correctedDecimalShift,
-                                                                          !sequence->analogRoi.empty(), sequence->fallbackValue);
-                        }
-                    }
-                    else {
-                        LogFile.writeToFile(ESP_LOG_WARN, TAG, "Skip \'Digit Increase Consistency\' check, no digit numbers configured");
+                /* Check digit plausibility (only supported when using class-11 model (0-9 + NaN)) */
+                if (flowDigit->getCNNType() == CNNTYPE_DIGIT_CLASS11) {
+                    if (sequence->paramPostProc->checkDigitIncreaseConsistency) {
+                        LogFile.writeToFile(ESP_LOG_DEBUG, TAG,
+                                            "Check digit increase consistency for number sequence: " + sequence->sequenceName);
+                        sequence->actualValue = checkDigitConsistency(sequence->actualValue, sequence->correctedDecimalShift,
+                                                                      !sequence->analogRoi.empty(), sequence->fallbackValue);
                     }
                 }
 
@@ -326,10 +321,11 @@ bool ClassFlowPostProcessing::doFlow(std::string zwtime)
                             sequence->sValueStatus = std::string(VALUE_STATUS_004_RATE_TOO_HIGH_POS);
                         }
 
-                        sequence->sValueStatus += " | Discard processed value: " +
-                                                  to_stringWithPrecision(sequence->actualValue, sequence->decimalPlaceCount) +
-                                                  " | Fallback: " + sequence->sFallbackValue +
-                                                  ", Rate: " + to_stringWithPrecision(RatePerSelection, sequence->decimalPlaceCount);
+                        sequence->sValueStatus +=
+                            " | Discard processed value: " +
+                            to_stringWithPrecision(std::to_string(sequence->actualValue), sequence->decimalPlaceCount) + " | Fallback: " +
+                            to_stringWithPrecision(std::to_string(sequence->fallbackValue), sequence->decimalPlaceCount + 1) +
+                            ", Rate: " + to_stringWithPrecision(RatePerSelection, sequence->decimalPlaceCount);
 
                         LogFile.writeToFile(ESP_LOG_WARN, TAG,
                                             "Sequence: " + sequence->sequenceName + ", Status: " + sequence->sValueStatus);
@@ -349,11 +345,13 @@ bool ClassFlowPostProcessing::doFlow(std::string zwtime)
                     if (sequence->actualValue < sequence->fallbackValue) {
                         sequence->sValueStatus = std::string(VALUE_STATUS_002_RATE_NEGATIVE);
 
-                        LogFile.writeToFile(ESP_LOG_DEBUG, TAG,
-                                            "Sequence: " + sequence->sequenceName + ", Status: " + sequence->sValueStatus +
-                                                " | Discard processed value: " + std::to_string(sequence->actualValue) +
-                                                " | Fallback: " + std::to_string(sequence->fallbackValue) +
-                                                ", Rate: " + to_stringWithPrecision(RatePerSelection, sequence->decimalPlaceCount));
+                        LogFile.writeToFile(
+                            ESP_LOG_DEBUG, TAG,
+                            "Sequence: " + sequence->sequenceName + ", Status: " + sequence->sValueStatus + " | Discard processed value: " +
+                                to_stringWithPrecision(std::to_string(sequence->actualValue), sequence->decimalPlaceCount) +
+                                " | Fallback: " +
+                                to_stringWithPrecision(std::to_string(sequence->fallbackValue), sequence->decimalPlaceCount + 1) +
+                                ", Rate: " + to_stringWithPrecision(RatePerSelection, sequence->decimalPlaceCount));
                         sequence->isActualValueConfirmed = false;
 
                         /* Update timestamp of fallback value to be prepared to identify every negative movement larger than max. rate

--- a/docs/Configuration/Parameter/PostProcessing/Sequence_CheckDigitIncreaseConsistency.md
+++ b/docs/Configuration/Parameter/PostProcessing/Sequence_CheckDigitIncreaseConsistency.md
@@ -7,13 +7,21 @@
 | Input Options     | `Disabled`<br>`Enabled` | `false`<br>`true` 
 
 
+!!! Warning
+    This is an **Expert Parameter**! Only change it if you understand what it does!<br>
+
+
 ## Description
 
-An additional post-processing consistency check to improve zero crossing of rolling digit numbers.
+A post-processing consistency check to improve zero crossing detection of **rolling digits**.
 
 
 !!! Warning
-    It's not recommended to use with LCD digit numbers!<br>
+    It's not recommended at all to use with LCD digits.<br>
+    It's recommended to use alternative models than `dig-class11` for rolling digit processing.
+
+
+!!! Note
     Only useable for `dig-class11` models (0-9 + NaN).
 
 

--- a/docs/Configuration/Parameter/PostProcessing/Sequence_ExtendedResolution.md
+++ b/docs/Configuration/Parameter/PostProcessing/Sequence_ExtendedResolution.md
@@ -14,9 +14,7 @@ decimal place of the result by one.
 
 
 !!! Note
-    This parameter is only supported by `*-class*` and `*-cont*` models! 
-    See [Choosing-the-Model](https://jomjol.github.io/AI-on-the-edge-device-docs/Choosing-the-Model) 
-    for more details.
+    This parameter is only supported when using `ana-/ dig-class100*` or `ana-/ dig-cont*` models! 
 
 
 !!! Note

--- a/docs/Configuration/Parameter/PostProcessing/Sequence_IgnoreLeadingNaN.md
+++ b/docs/Configuration/Parameter/PostProcessing/Sequence_IgnoreLeadingNaN.md
@@ -7,16 +7,18 @@
 | Input Options     | `Disabled`<br>`Enabled` | `false`<br>`true` 
 
 
+!!! Warning
+    This is an **Expert Parameter**! Only change it if you understand what it does!<br>
+    For regular use cases, it is not recommended to use at all, because it can disturb post-processing. 
+
+
 ## Description
 
-Leading `N` will be deleted before further post-processing. 
+Leading `N`s in raw value will be deleted before further post-processing
 
 
 !!! Note
-    This is only relevant for `dig-class-11*` models or `dig-cont*` models 
-    (result fit < CNN Good Threshold) which use `N` presentation! 
-    See [Choosing-the-Model](https://jomjol.github.io/AI-on-the-edge-device-docs/Choosing-the-Model)
-    for details.
+    This parameter is only supported when using `dig-class-11*` models
 
 
 !!! Note

--- a/sd-card/html/edit_config_param.html
+++ b/sd-card/html/edit_config_param.html
@@ -1137,7 +1137,7 @@
 			<td style="visibility:hidden">$TOOLTIP_postprocessing_sequence_analogdigitsyncvalue</td>
 		</tr>
 
-		<tr class="classvisibility_postprocessing_extended_resolution hidden">
+		<tr class="classvisibility_postprocessing_extended_resolution">
 			<td class="indent1">
 				<span>Extended Resolution</span>
 			</td>

--- a/sd-card/html/edit_config_param.html
+++ b/sd-card/html/edit_config_param.html
@@ -869,9 +869,11 @@
 				<form id="digit_model_form">
 					<select required class="select_large" name="digit.model" id="digit_model_value"
 						onchange="setClassVisibility('classvisibility_digit_model_class11',
-														$(digit_enabled_value).val() && this.value.includes('class11'));
-							setClassVisibility('classvisibility_digit_model_cont',
-														$(digit_enabled_value).val() && this.value.includes('cont'));
+								$(digit_enabled_value).val() && this.value.includes('class11'));
+							setClassVisibility('classvisibility_model_cnn_threshold',
+								$(digit_enabled_value).val() && this.value.includes('cont'));
+							setClassVisibility('classvisibility_postprocessing_extended_resolution',
+								$(digit_enabled_value).val() && !this.value.includes('class11'));
 							gatherChangedParameter(this.form)">
 					</select>
 				</form>
@@ -879,7 +881,7 @@
 			<td style="visibility:hidden">$TOOLTIP_digit_model</td>
 		</tr>
 
-		<tr class="classvisibility_digit_enabled classvisibility_digit_model_cont expert">
+		<tr class="classvisibility_digit_enabled classvisibility_model_cnn_threshold expert">
 			<td class="indent1">
 				<span>CNN Good Threshold</span>
 			</td>
@@ -981,8 +983,10 @@
 				<form id="analog_enabled_form">
 					<select style="font-weight:bold" class="classvisibility_init" name="analog.enabled" id="analog_enabled_value"
 								onchange="setClassVisibility('classvisibility_analog_enabled', this.value);
-								this.value == 'true' ? $(analog_debug_saveroiimages_value).trigger('onchange') : null;
-								gatherChangedParameter(this.form)">
+									this.value == 'true' ? $(analog_debug_saveroiimages_value).trigger('onchange') : null;
+									setClassVisibility('classvisibility_postprocessing_extended_resolution',
+										$(digit_enabled_value).val() && !this.value.includes('class11'));
+									gatherChangedParameter(this.form)">
 						<option value="false" selected>Disabled</option>
 						<option value="true">Enabled</option>
 					</select>
@@ -1133,7 +1137,7 @@
 			<td style="visibility:hidden">$TOOLTIP_postprocessing_sequence_analogdigitsyncvalue</td>
 		</tr>
 
-		<tr>
+		<tr class="classvisibility_postprocessing_extended_resolution hidden">
 			<td class="indent1">
 				<span>Extended Resolution</span>
 			</td>
@@ -1149,7 +1153,7 @@
 			<td style="visibility:hidden">$TOOLTIP_postprocessing_sequence_extendedresolution</td>
 		</tr>
 
-		<tr class="classvisibility_digit_model_class11 hidden">
+		<tr class="classvisibility_digit_model_class11 hidden expert">
 			<td class="indent1">
 				<span>Ignore Leading NaNs</span>
 			</td>
@@ -1165,7 +1169,7 @@
 			<td style="visibility:hidden">$TOOLTIP_postprocessing_sequence_ignoreleadingnan</td>
 		</tr>
 
-		<tr class="classvisibility_digit_model_class11 hidden">
+		<tr class="classvisibility_digit_model_class11 hidden expert">
 			<td class="indent1">
 				<span>Check Digit Increase Consistency</span>
 			</td>


### PR DESCRIPTION
Fix extended resolution post-processing option while using digits only together with decimal shift.
--> Ensure always 2-digit ROI results are processed (e.g. 0.1 -> 01) to avoid wrong decimal shift application for the range of 0.0-0.9 (Pad ROI results 0–9 with a leading zero)

fixes #326 

---
#### Further changes:
- Refactor post-processing log messages to be more clear
- Further align WebUI post-processing parameter visibility to show only active parameter (depending on model selection)
- Clarify some post-processing parameter descriptions
- Increase default for CNN probability threshold parameter (dig-cont models and new installations only)

---
### Usage Stats

Before (based on ESP32)
RAM:   [==        ]  16.6% (used 54288 bytes from 327680 bytes)
Flash: [========= ]  88.3% (used 1717790 bytes from 1945600 bytes)

After
RAM:   [==        ]  16.6% (used 54288 bytes from 327680 bytes)
Flash: [========= ]  88.3% (used 1717758 bytes from 1945600 bytes)