### PR TITLE
chore(build): Combined debug artifact for releases

### DIFF
--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -3,6 +3,7 @@ name: Build and Release
 on:
   push:
   pull_request:
+  workflow_dispatch:
 
 jobs:
 #########################################################################################
@@ -140,7 +141,7 @@ jobs:
     - name: Debug files package - Upload artifact
       uses: actions/upload-artifact@v7
       with:
-        name: "AI-on-the-edge-device__${{ matrix.plat }}__debug-files__SLFork_${{ steps.vars.outputs.branch }}_${{ steps.vars.outputs.sha_short }}"
+        name: "aioted__debug-files_developer-only__${{ matrix.plat }}__SLFork_${{ steps.vars.outputs.branch }}_${{ steps.vars.outputs.sha_short }}"
         path: ./debug
 
 
@@ -193,9 +194,6 @@ jobs:
         cd "AI-on-the-edge-device__${{ matrix.plat }}__SLFork_${{ steps.vars.outputs.branch }}_${{ steps.vars.outputs.sha_short }}"
         zip -r ../release/AI-on-the-edge-device__${{ matrix.plat }}__SLFork_v${{ needs.prepare-release.outputs.version }}.zip *
         cd ..
-        cd "AI-on-the-edge-device__${{ matrix.plat }}__debug-files__SLFork_${{ steps.vars.outputs.branch }}_${{ steps.vars.outputs.sha_short }}"
-        zip -r ../release/AI-on-the-edge-device__${{ matrix.plat }}__debug-files__SLFork_v${{ needs.prepare-release.outputs.version }}.zip *
-        cd ..
 
     - name: Upload artifacts to release tag
       env:
@@ -203,6 +201,49 @@ jobs:
       run:
         gh release upload ${{ needs.prepare-release.outputs.tag_name }} release/*
 
+
+#########################################################################################
+## Create release - PART 3: Combine all debug files into one artifact and upload
+#
+# All per-platform debug artifacts are merged into a single zip and uploaded to the release
+#########################################################################################
+  upload-release-debug-artifact:
+    runs-on: ubuntu-latest
+    needs: [prepare-release, build, upload-release-artifacts]
+    if: ${{ needs.prepare-release.outputs.release_created }}
+ 
+    # Sets permissions of the GITHUB_TOKEN to allow uploading to the release
+    permissions:
+      actions: read
+      contents: write
+ 
+    steps:
+    - name: Checkout tag
+      uses: actions/checkout@v6
+      with:
+        ref: ${{ needs.prepare-release.outputs.tag_name }}
+ 
+    - name: Pull all debug artifacts
+      uses: actions/download-artifact@v8
+      with:
+        pattern: "aioted__debug-files_developer-only__*__SLFork_${{ needs.upload-release-artifacts.outputs.branch }}_${{ needs.upload-release-artifacts.outputs.sha_short }}"
+        path: ./debug
+        merge-multiple: false
+ 
+    - name: Combine and zip all debug artifacts
+      run: |
+        mkdir -p release
+        cd debug
+        # Each platform's files land in their own subdirectory named after the artifact;
+        # zip them all together, preserving the per-platform folder structure.
+        zip -r ../release/aioted__debug-files_developer-only__SLFork_v${{ needs.prepare-release.outputs.version }}.zip .
+        cd ..
+ 
+    - name: Upload combined debug artifact to release tag
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run:
+        gh release upload ${{ needs.prepare-release.outputs.tag_name }} release/*
 
 #########################################################################################
 ## Update web installer (branch: gh-pages-webinstaller)


### PR DESCRIPTION
- Combine the single debug-file zip artifacts of each supported platform to a single zip artifact for official releases
- Indicate that this debug artifact is only required for developers (and package cannot be flashed to device)
- Add a manual trigger to start build process