### PR TITLE
fix(mqtt): home assistant discovery - add device mac address

### DIFF
--- a/code/components/mqtt_ctrl/server_mqtt.cpp
+++ b/code/components/mqtt_ctrl/server_mqtt.cpp
@@ -934,12 +934,13 @@ static bool publishHADiscoveryTopic(const strHADiscoveryData *_data, const int _
             firmwareVersion = std::string(libfive_git_branch()) + " (" + std::string(libfive_git_revision()) + ")";
         }
 
-        payload += std::string(", \"dev\": {") + "\"ids\":[\"" + nodeID + "\"]," + "\"name\":\"" + nodeID + "\"," +
-                   "\"mdl\":\"AI-on-the-Edge device (" + getBoardType() + ")\"," + "\"mf\":\"AI-on-the-Edge\"," + "\"sw\":\"" +
-                   firmwareVersion + " [SLFork]\"," + "\"cu\":\"http://" + getIpAddress() + "\"}";
+        payload += std::string(", \"dev\": {") + "\"ids\":[\"" + nodeID + "\"]," + "\"cns\": [[\"mac\", \"" + getMac() + "\"]]," +
+                   "\"name\":\"" + nodeID + "\"," + "\"mdl\":\"AI-on-the-Edge device (" + getBoardType() + ")\"," +
+                   "\"mf\":\"AI-on-the-Edge\"," + "\"sw\":\"" + firmwareVersion + " [SLFork]\"," + "\"cu\":\"http://" + getIpAddress() +
+                   "\"}";
     }
-    else { // Publish device reference only to group data together
-        payload += std::string(", \"dev\": {") + "\"ids\":[\"" + nodeID + "\"]}";
+    else { // Publish device reference and connections to group data together
+        payload += std::string(", \"dev\": {") + "\"ids\":[\"" + nodeID + "\"]," + "\"cns\":[[\"mac\",\"" + getMac() + "\"]]}";
     }
 
     payload += "}";


### PR DESCRIPTION
## Summary of Changes

This pull request enhances the Home Assistant MQTT discovery integration by explicitly providing the device's MAC address. By including this information in the discovery payload, Home Assistant can possible merge device infos/data from multiple HA integrations into a single device view.

--> Solves situation described here: #4071

## Usage

Before (based on ESP32CAM)
RAM:   [==        ]  16.6% (used 54288 bytes from 327680 bytes)
Flash: [========= ]  88.4% (used 1719034 bytes from 1945600 bytes)

After
RAM:   [==        ]  16.6% (used 54288 bytes from 327680 bytes)
Flash: [========= ]  88.4% (used 1719282 bytes from 1945600 bytes)