### PR TITLE
fix(config): Fix camera model assignment

### DIFF
--- a/code/components/config_handling/cfgDataStruct.h
+++ b/code/components/config_handling/cfgDataStruct.h
@@ -143,7 +143,7 @@ struct RoiElement {
     int y = 1;
     int dx = 10;
     int dy = 10;
-    bool ccw = false;
+    bool ccw = false; // counter-clock-wise
 };
 
 
@@ -187,7 +187,7 @@ struct GpioElement {
     std::string pinMode = "input";
     std::string captureMode = "cyclic-polling";
     int inputDebounceTime = 200;
-    int PwmFrequency = 5000;
+    int pwmFrequency = 5000;
     bool logicActiveLow = false;
     bool exposeToMqtt = false;
     bool exposeToRest = false;

--- a/code/components/config_handling/configClass.cpp
+++ b/code/components/config_handling/configClass.cpp
@@ -326,7 +326,7 @@ esp_err_t ConfigClass::parseConfig(httpd_req_t *req, bool init, bool unityTest)
 
     objEl = cJSON_GetObjectItem(cJSON_GetObjectItem(cJSON_GetObjectItem(cJsonObject, "takeimage"), "camera"), "cameramodel");
     if (cJSON_IsNumber(objEl)) {
-        cfgDataTemp.sectionTakeImage.camera.imageQuality = std::clamp(objEl->valueint, 0, 14);
+        cfgDataTemp.sectionTakeImage.camera.cameraModel = std::clamp(objEl->valueint, 0, 14);
     }
 
     objEl = cJSON_GetObjectItem(cJSON_GetObjectItem(cJSON_GetObjectItem(cJsonObject, "takeimage"), "camera"), "camerafrequency");

--- a/code/components/config_handling/configClass.cpp
+++ b/code/components/config_handling/configClass.cpp
@@ -326,7 +326,7 @@ esp_err_t ConfigClass::parseConfig(httpd_req_t *req, bool init, bool unityTest)
 
     objEl = cJSON_GetObjectItem(cJSON_GetObjectItem(cJSON_GetObjectItem(cJsonObject, "takeimage"), "camera"), "cameramodel");
     if (cJSON_IsNumber(objEl)) {
-        cfgDataTemp.sectionTakeImage.camera.cameraModel = std::clamp(objEl->valueint, 0, 14);
+        cfgDataTemp.sectionTakeImage.camera.cameraModel = (camera_model_t)std::clamp(objEl->valueint, 0, 14);
     }
 
     objEl = cJSON_GetObjectItem(cJSON_GetObjectItem(cJSON_GetObjectItem(cJsonObject, "takeimage"), "camera"), "camerafrequency");
@@ -1415,7 +1415,7 @@ esp_err_t ConfigClass::parseConfig(httpd_req_t *req, bool init, bool unityTest)
 
         arrEl = cJSON_GetObjectItem(objArrEl, "pwmfrequency");
         if (cJSON_IsNumber(arrEl)) {
-            gpioElTemp->PwmFrequency = std::clamp(arrEl->valueint, 5, 1000000); // Hertz
+            gpioElTemp->pwmFrequency = std::clamp(arrEl->valueint, 5, 1000000); // Hertz
         }
 
         arrEl = cJSON_GetObjectItem(objArrEl, "logicactivelow");
@@ -2454,7 +2454,7 @@ esp_err_t ConfigClass::serializeConfig(bool unityTest)
         if (cJSON_AddNumberToObject(gpiopinEl, "inputdebouncetime", cfgDataTemp.sectionGpio.gpioPin[i].inputDebounceTime) == NULL) {
             retVal = ESP_FAIL;
         }
-        if (cJSON_AddNumberToObject(gpiopinEl, "pwmfrequency", cfgDataTemp.sectionGpio.gpioPin[i].PwmFrequency) == NULL) {
+        if (cJSON_AddNumberToObject(gpiopinEl, "pwmfrequency", cfgDataTemp.sectionGpio.gpioPin[i].pwmFrequency) == NULL) {
             retVal = ESP_FAIL;
         }
         if (cJSON_AddBoolToObject(gpiopinEl, "logicactivelow", cfgDataTemp.sectionGpio.gpioPin[i].logicActiveLow) == NULL) {

--- a/code/components/gpio_ctrl/gpioControl.cpp
+++ b/code/components/gpio_ctrl/gpioControl.cpp
@@ -350,14 +350,14 @@ esp_err_t GpioHandler::loadParameter()
             ESP_LOG_DEBUG, TAG,
             "Pin Config: GPIO" + std::to_string((int)gpioNr) + ", Name: " + std::string(gpioName) + ", Mode: " + pin.pinMode +
                 ", Interrupt Type: " + pin.captureMode + ", Debounce Time: " + std::to_string(pin.inputDebounceTime) +
-                ", Frequency: " + std::to_string(pin.PwmFrequency) + ", Logic Active Low: " + std::to_string(pin.logicActiveLow) +
+                ", Frequency: " + std::to_string(pin.pwmFrequency) + ", Logic Active Low: " + std::to_string(pin.logicActiveLow) +
                 ", HTTP Access: " + std::to_string(pin.exposeToRest) + ", MQTT Access: " + std::to_string(mqttAccess) +
                 ", MQTT Topic: " + mqttTopic + ", LED Type: " + std::to_string(pin.smartLed.type) +
                 ", LED Quantity: " + std::to_string(pin.smartLed.quantity) + ", LED Color: R:" + std::to_string(LEDColor.r) +
                 " | G:" + std::to_string(LEDColor.g) + " | B:" + std::to_string(LEDColor.b) +
                 ", LED Intensity Correction: " + std::to_string(pin.intensityCorrectionFactor));
 
-        GpioPin *gpioPin = new GpioPin(gpioNr, gpioName, pinMode, captureMode, pin.inputDebounceTime, pin.PwmFrequency, pin.logicActiveLow,
+        GpioPin *gpioPin = new GpioPin(gpioNr, gpioName, pinMode, captureMode, pin.inputDebounceTime, pin.pwmFrequency, pin.logicActiveLow,
                                        pin.exposeToRest, mqttAccess, mqttTopic, LEDType, pin.smartLed.quantity, LEDColor,
                                        pin.intensityCorrectionFactor);
         (*gpioMap)[gpioNr] = gpioPin;


### PR DESCRIPTION
- Fix camera model assignment to wrong config variable
- Rename config variable `PwmFrequency` to `pwmFrequency` to align with actual coding style

---
### Usage Stats

Before (based on ESP32CAM)
RAM:   [==        ]  16.6% (used 54288 bytes from 327680 bytes)
Flash: [========= ]  88.4% (used 1719298 bytes from 1945600 bytes)

After
RAM:   [==        ]  16.6% (used 54288 bytes from 327680 bytes)
Flash: [========= ]  88.4% (used 1719314 bytes from 1945600 bytes)