### PR TITLE
fix(post-processing): checkDigitConsistency - Increase precision to improve accuracy for large readings

### DIFF
--- a/code/components/mainprocess_ctrl/ClassFlowPostProcessing.cpp
+++ b/code/components/mainprocess_ctrl/ClassFlowPostProcessing.cpp
@@ -579,12 +579,12 @@ std::string ClassFlowPostProcessing::substituteN(std::string input, double _fall
 }
 
 
-float ClassFlowPostProcessing::checkDigitConsistency(double input, int _decimalshift, bool _isanalog, double _fallbackValue)
+double ClassFlowPostProcessing::checkDigitConsistency(double input, int _decimalshift, bool _isanalog, double _fallbackValue)
 {
     int aktdigit, olddigit;
     int aktdigit_before, olddigit_before;
     int pot, pot_max;
-    float zw;
+    double zw;
     bool no_nulldurchgang = false;
 
     pot = _decimalshift;
@@ -612,12 +612,12 @@ float ClassFlowPostProcessing::checkDigitConsistency(double input, int _decimals
 
         if (no_nulldurchgang) {
             if (aktdigit != olddigit) {
-                input = input + ((float)(olddigit - aktdigit)) * pow(10, pot); // New Digit is replaced by old Digit;
+                input = input + ((double)(olddigit - aktdigit)) * pow(10, pot); // New Digit is replaced by old Digit;
             }
         }
         else {
-            if (aktdigit == olddigit) {                      // despite zero crossing, digit was not incremented --> add 1
-                input = input + ((float)(1)) * pow(10, pot); // add 1 at the point
+            if (aktdigit == olddigit) {                       // despite zero crossing, digit was not incremented --> add 1
+                input = input + ((double)(1)) * pow(10, pot); // add 1 at the point
             }
         }
 

--- a/code/components/mainprocess_ctrl/ClassFlowPostProcessing.h
+++ b/code/components/mainprocess_ctrl/ClassFlowPostProcessing.h
@@ -26,7 +26,7 @@ class ClassFlowPostProcessing : public ClassFlow
     void setDecimalShift();
     std::string shiftDecimal(std::string in, int _decShift);
     std::string substituteN(std::string, double _fallbackValue);
-    float checkDigitConsistency(double _value, int _decimalshift, bool _isanalog, double _fallbackValue);
+    double checkDigitConsistency(double _value, int _decimalshift, bool _isanalog, double _fallbackValue);
 
     void writeDataLog(std::string sequenceName);
 


### PR DESCRIPTION
Use double precision to ensure sufficient processing accuracy with activated post-processing algorithm `Check Digit Increase Consistency` even for large readings (relevant for class11-models only).

Cherry-picked from here: #4145

---
### Usage Stats

Before (based on ESP32CAM)
RAM:   [==        ]  16.6% (used 54288 bytes from 327680 bytes)
Flash: [========= ]  88.4% (used 1719298 bytes from 1945600 bytes)

After
RAM:   [==        ]  16.6% (used 54288 bytes from 327680 bytes)
Flash: [========= ]  88.4% (used 1719246 bytes from 1945600 bytes)