### PR TITLE
skip(repository): Disable automatic builds for push / pull request on release-please branches

### DIFF
--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -2,7 +2,11 @@ name: Build and Release
 
 on:
   push:
+    branches-ignore:
+      - 'release-please--*'
   pull_request:
+    branches-ignore:
+      - 'release-please--*'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
<h3>Summary</h3>

The PR disables automatic Build and Release workflow runs for pushes to release-please branches and attempts to do the same for pull requests so changelog changes can be reviewed first.
- Adds a `release-please--*` exclusion to push events.
- Adds the same exclusion to pull request events, where GitHub applies it to the base branch rather than the source branch.