### PR TITLE
fix(alignment):  Add validation for corrupt/malformed alignment marker image

### DIFF
--- a/code/components/image_handling/make_stb.cpp
+++ b/code/components/image_handling/make_stb.cpp
@@ -1,7 +1,8 @@
 #include "psram.h"
 
 
-#define STBI_ONLY_JPEG // JPG handling only (disable other file types to save flash)
+#define STBI_ONLY_JPEG       // JPG handling only (disable other file types to save flash)
+#define STBI_FAILURE_USERMSG // Compile user friendly error messages
 
 // Custom defined memory allocation strategy
 #define STBI_MALLOC(sz)        malloc_psram_heap_STBI("STBI", sz, MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT)

--- a/code/components/mainprocess_ctrl/ClassFlowAlignment.cpp
+++ b/code/components/mainprocess_ctrl/ClassFlowAlignment.cpp
@@ -43,33 +43,41 @@ bool ClassFlowAlignment::loadParameter()
         for (int i = 0; i < 2; i++) {
             int x = 0, y = 0, channels = 0;
             std::string sIndex = std::to_string(i + 1);
+            alignmentMarker[i].markerImageFilename = "/sdcard/config/marker" + sIndex + ".jpg";
 
-            // Check availability of marker image before usage
-            if (!fileExists("/sdcard/config/marker" + sIndex + ".jpg")) {
+            // Check availability of marker image
+            if (!fileExists(alignmentMarker[i].markerImageFilename)) {
                 LogFile.writeToFile(ESP_LOG_ERROR, TAG,
-                                    "Alignment marker image missing: '/sdcard/config/marker" + sIndex +
-                                        ".jpg' > Please update alignment marker");
+                                    "Marker missing: > Create alignment marker | File: " + alignmentMarker[i].markerImageFilename);
                 return false;
             }
 
-            alignmentMarker[i].alignmentAlgo = cfgDataPtr->alignmentAlgo;
-            alignmentMarker[i].searchX = cfgDataPtr->searchField.x;
-            alignmentMarker[i].searchY = cfgDataPtr->searchField.y;
-            alignmentMarker[i].similarityCheckSADThreshold = alignSimilarityCheckSADThreshold;
+            // Parse marker image meta data (dimension, channels)
+            if (!stbi_info(alignmentMarker[i].markerImageFilename.c_str(), &x, &y, &channels)) {
+                std::string failureReason = stbi_failure_reason() ? stbi_failure_reason() : "Unknown";
+                LogFile.writeToFile(ESP_LOG_ERROR, TAG,
+                                    "Marker invalid > Recreate alignment marker | File: " + alignmentMarker[i].markerImageFilename +
+                                        " | Reason: " + failureReason);
+                return false;
+            }
 
-            alignmentMarker[i].markerImageFilename = "/sdcard/config/marker" + sIndex + ".jpg";
-            stbi_info(alignmentMarker[i].markerImageFilename.c_str(), &x, &y, &channels);
-
+            // Create BMP image container (with required image dimension)
             alignmentMarker[i].markerImage = new CImage("marker" + sIndex, x, y, channels, true);
             if (!alignmentMarker[i].markerImage) {
-                LogFile.writeToFile(ESP_LOG_ERROR, TAG, "Failed to create alignment marker image");
+                LogFile.writeToFile(ESP_LOG_ERROR, TAG, "Failed to create image container");
                 return false;
             }
 
+            // Read marker to BMP image container
             if (alignmentMarker[i].markerImage->loadJpgFromFile(alignmentMarker[i].markerImageFilename.c_str(), true) != ESP_OK) {
                 return false;
             }
 
+            // Preset marker parameter
+            alignmentMarker[i].alignmentAlgo = cfgDataPtr->alignmentAlgo;
+            alignmentMarker[i].searchX = cfgDataPtr->searchField.x;
+            alignmentMarker[i].searchY = cfgDataPtr->searchField.y;
+            alignmentMarker[i].similarityCheckSADThreshold = alignSimilarityCheckSADThreshold;
             alignmentMarker[i].targetX = cfgDataPtr->marker[i].x;
             alignmentMarker[i].targetY = cfgDataPtr->marker[i].y;
             alignmentMarker[i].width = alignmentMarker[i].markerImage->getWidth();


### PR DESCRIPTION
fixes #377 

<!-- greptile_comment -->

<h3>Summary</h3>

The PR improves alignment-marker validation by rejecting corrupt or malformed JPEGs before creating their image containers.
- Enables user-friendly stb_image failure messages.
- Checks marker metadata parsing and logs the filename and failure reason when validation fails.
- Defers alignment-parameter initialization until the marker has loaded successfully.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no concrete changed-code defects identified.

The new validation cleanly rejects unreadable marker metadata before allocation, while reachable failure paths retain correct teardown behavior.
</details>


</details>

<sub>Reviews (1): Last reviewed commit: ["fix(alignment): Add error check to detec..."](https://github.com/slider0007/ai-on-the-edge-device/commit/f0e2e7139be7ffa1563e45ed2d2eea739941106a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57612318)</sub>

<!-- /greptile_comment -->

---
### Usage Stats

Before (based on ESP32CAM)
RAM:   [==        ]  16.6% (used 54288 bytes from 327680 bytes)
Flash: [========= ]  88.4% (used 1719230 bytes from 1945600 bytes)

After
RAM:   [==        ]  16.6% (used 54288 bytes from 327680 bytes)
Flash: [========= ]  88.3% (used 1718850 bytes from 1945600 bytes)