### PR TITLE
refactor(source code): Cleanup header includes

### DIFF
--- a/code/components/camera_ctrl/CMakeLists.txt
+++ b/code/components/camera_ctrl/CMakeLists.txt
@@ -1,4 +1,4 @@
-FILE(GLOB_RECURSE app_sources ${CMAKE_CURRENT_SOURCE_DIR}/*.*)
+FILE(GLOB_RECURSE app_sources ${CMAKE_CURRENT_SOURCE_DIR}/*.cpp ${CMAKE_CURRENT_SOURCE_DIR}/*.c)
 
 idf_component_register(SRCS ${app_sources}
                     INCLUDE_DIRS "."

--- a/code/components/camera_ctrl/ClassControlCamera.cpp
+++ b/code/components/camera_ctrl/ClassControlCamera.cpp
@@ -6,13 +6,14 @@
 #include <driver/gpio.h>
 #include <driver/ledc.h>
 
-#include "psram.h"
+#include "configClass.h"
 #include "helper.h"
 #include "statusled.h"
 #include "gpioControl.h"
 #include "MainFlowControl.h"
 #include "ClassLogFile.h"
 #include "ov2640_sharpness.h"
+#include "CImageMod.h"
 
 
 static const char *TAG = "CAMCTRL";

--- a/code/components/camera_ctrl/ClassControlCamera.h
+++ b/code/components/camera_ctrl/ClassControlCamera.h
@@ -11,8 +11,8 @@
 #include <esp_http_server.h>
 #include <esp_camera.h>
 
-#include "configClass.h"
 #include "CImage.h"
+#include "cfgDataStruct.h"
 
 
 typedef struct {

--- a/code/components/camera_ctrl/ov2640_sharpness.cpp
+++ b/code/components/camera_ctrl/ov2640_sharpness.cpp
@@ -1,6 +1,7 @@
 #include "ov2640_sharpness.h"
 
 #include <stdint.h>
+#include <cstddef>
 
 
 #define OV2640_MAXLEVEL_SHARPNESS 6

--- a/code/components/camera_ctrl/ov2640_sharpness.h
+++ b/code/components/camera_ctrl/ov2640_sharpness.h
@@ -1,7 +1,8 @@
 #ifndef OV2640_SHARPNESS_H
 #define OV2640_SHARPNESS_H
 
-#include "esp_camera.h"
+#include "sensor.h"
+
 
 bool ov2640_enable_auto_sharpness(sensor_t *_sensor);
 bool ov2640_set_sharpness(sensor_t *_sensor, int _sharpness); // -3 to +3, -4 for auto-sharpness

--- a/code/components/camera_ctrl/server_camera.cpp
+++ b/code/components/camera_ctrl/server_camera.cpp
@@ -4,11 +4,10 @@
 #include <string>
 
 #include <esp_log.h>
-#include "esp_camera.h"
 
 #include "http_auth.h"
+#include "configClass.h"
 #include "ClassControlCamera.h"
-#include "ClassLogFile.h"
 
 
 static const char *TAG = "SERVER_CAM";

--- a/code/components/config_handling/CMakeLists.txt
+++ b/code/components/config_handling/CMakeLists.txt
@@ -1,7 +1,7 @@
-FILE(GLOB_RECURSE app_sources ${CMAKE_CURRENT_SOURCE_DIR}/*.*)
+FILE(GLOB_RECURSE app_sources ${CMAKE_CURRENT_SOURCE_DIR}/*.cpp ${CMAKE_CURRENT_SOURCE_DIR}/*.c)
 
 idf_component_register(SRCS ${app_sources}
                     INCLUDE_DIRS "."
-                    REQUIRES webserver_softap logfile_handling gpio_ctrl misc_helper)
+                    REQUIRES json webserver_softap logfile_handling gpio_ctrl misc_helper)
 
 

--- a/code/components/config_handling/configClass.cpp
+++ b/code/components/config_handling/configClass.cpp
@@ -5,6 +5,7 @@
 #include <lwip/sockets.h>
 #include <arpa/inet.h>
 
+#include "esp_heap_caps.h"
 #include <esp_log.h>
 #include <esp_http_server.h>
 #include <nvs_flash.h>

--- a/code/components/config_handling/configClass.h
+++ b/code/components/config_handling/configClass.h
@@ -2,7 +2,6 @@
 #define CONFIGCLASS_H
 
 #include <string>
-#include <vector>
 
 #include <freertos/FreeRTOS.h>
 #include <esp_log.h>

--- a/code/components/config_handling/configMigration.cpp
+++ b/code/components/config_handling/configMigration.cpp
@@ -6,7 +6,6 @@
 #include "configClass.h"
 #include "helper.h"
 #include "ClassLogFile.h"
-#include "ClassControlCamera.h"
 
 
 static const char *TAG = "CFGMIG";

--- a/code/components/fileserver_ota/CMakeLists.txt
+++ b/code/components/fileserver_ota/CMakeLists.txt
@@ -1,7 +1,7 @@
-FILE(GLOB_RECURSE app_sources ${CMAKE_CURRENT_SOURCE_DIR}/*.*)
+FILE(GLOB_RECURSE app_sources ${CMAKE_CURRENT_SOURCE_DIR}/*.cpp ${CMAKE_CURRENT_SOURCE_DIR}/*.c)
 
 idf_component_register(SRCS ${app_sources}
                     INCLUDE_DIRS "." "../../include" "miniz"
-                    REQUIRES vfs spiffs esp_http_server espcoredump webserver_softap app_update mainprocess_ctrl misc_helper)
+                    REQUIRES vfs spiffs esp_http_server espcoredump webserver_softap app_update mainprocess_ctrl misc_helper json)
 
 

--- a/code/components/fileserver_ota/server_file.cpp
+++ b/code/components/fileserver_ota/server_file.cpp
@@ -9,14 +9,7 @@
 #include <sys/unistd.h>
 #include <sys/stat.h>
 #include <cJSON.h>
-
-#ifdef __cplusplus
-extern "C" {
-#endif
 #include <dirent.h>
-#ifdef __cplusplus
-}
-#endif
 
 #include <esp_partition.h>
 #include <esp_core_dump.h>
@@ -30,11 +23,8 @@ extern "C" {
 #include "webserver.h"
 #include "server_help.h"
 #include "ClassLogFile.h"
-#include "MainFlowControl.h"
-#include "gpioControl.h"
 #include "helper.h"
 #include "system.h"
-#include "psram.h"
 
 #ifdef ENABLE_MQTT
 #include "interface_mqtt.h"

--- a/code/components/fileserver_ota/server_help.cpp
+++ b/code/components/fileserver_ota/server_help.cpp
@@ -7,22 +7,11 @@
 #include <sys/param.h>
 #include <sys/unistd.h>
 #include <sys/stat.h>
-
-#ifdef __cplusplus
-extern "C" {
-#endif
 #include <dirent.h>
-#ifdef __cplusplus
-}
-#endif
 
 #include "esp_http_server.h"
 #include "esp_err.h"
 #include <esp_log.h>
-
-#include "helper.h"
-#include "psram.h"
-#include "ClassLogFile.h"
 
 
 // static const char *TAG = "SERVER_HELP"; // Unsed

--- a/code/components/fileserver_ota/server_ota.cpp
+++ b/code/components/fileserver_ota/server_ota.cpp
@@ -3,21 +3,14 @@
 
 #include <string>
 
-#include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
 
 #include <sys/stat.h>
-
-/* TODO Rethink the usage of the int watchdog. It is no longer to be used, see
-https://docs.espressif.com/projects/esp-idf/en/latest/esp32/migration-guides/release-5.x/5.0/system.html?highlight=esp_int_wdt */
-#include "esp_private/esp_int_wdt.h"
 #include <esp_task_wdt.h>
-
 #include <esp_ota_ops.h>
 #include "esp_system.h"
 #include <esp_log.h>
 #include <esp_http_client.h>
-#include "esp_flash_partitions.h"
 #include "esp_partition.h"
 #include "esp_app_format.h"
 #include "miniz.h"

--- a/code/components/gpio_ctrl/CMakeLists.txt
+++ b/code/components/gpio_ctrl/CMakeLists.txt
@@ -1,4 +1,4 @@
-FILE(GLOB_RECURSE app_sources ${CMAKE_CURRENT_SOURCE_DIR}/*.*)
+FILE(GLOB_RECURSE app_sources ${CMAKE_CURRENT_SOURCE_DIR}/*.cpp ${CMAKE_CURRENT_SOURCE_DIR}/*.c)
 
 idf_component_register(SRCS ${app_sources}
                     INCLUDE_DIRS "." "../../include"

--- a/code/components/gpio_ctrl/gpioControl.cpp
+++ b/code/components/gpio_ctrl/gpioControl.cpp
@@ -2,17 +2,15 @@
 
 #include <string>
 #include <functional>
+#include <math.h>
 
-#include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
-#include "esp_system.h"
 
 #include <esp_log.h>
 #include <cJSON.h>
-
 #include <sys/stat.h>
-#include <vector>
 
+#include "configClass.h"
 #include "http_auth.h"
 #include "ClassLogFile.h"
 #include "helper.h"

--- a/code/components/gpio_ctrl/gpioControl.h
+++ b/code/components/gpio_ctrl/gpioControl.h
@@ -11,7 +11,7 @@
 #include <driver/gpio.h>
 #include <driver/ledc.h>
 
-#include "configClass.h"
+#include "cfgDataStruct.h"
 #include "gpioPin.h"
 
 

--- a/code/components/gpio_ctrl/gpioPin.cpp
+++ b/code/components/gpio_ctrl/gpioPin.cpp
@@ -4,7 +4,6 @@
 #include "freertos/queue.h"
 #include <cJSON.h>
 
-#include "gpioControl.h"
 #include "ClassLogFile.h"
 #include "helper.h"
 #include "MainFlowControl.h"

--- a/code/components/gpio_ctrl/gpioPin.h
+++ b/code/components/gpio_ctrl/gpioPin.h
@@ -6,7 +6,7 @@
 #include <string>
 
 #include "hal/gpio_types.h"
-#include "driver/ledc.h"
+#include "hal/ledc_types.h"
 #include "SmartLeds.h"
 
 

--- a/code/components/gpio_ctrl/statusled.cpp
+++ b/code/components/gpio_ctrl/statusled.cpp
@@ -7,9 +7,11 @@
 #include <esp_rom_gpio.h>
 #include <driver/ledc.h>
 
-#include "gpioControl.h"
 #include "ClassLogFile.h"
-#include "helper.h"
+
+#ifdef GPIO_STATUS_LED_ONBOARD_USE_SMARTLED
+#include "gpioControl.h"
+#endif // GPIO_STATUS_LED_ONBOARD_USE_SMARTLED
 
 
 static const char *TAG = "STATUSLED";

--- a/code/components/image_handling/CImage.cpp
+++ b/code/components/image_handling/CImage.cpp
@@ -3,7 +3,6 @@
 #include "CImage.h"
 
 #include "esp_heap_caps.h"
-#include "esp_system.h"
 
 #include "webserver.h"
 #include "helper.h"

--- a/code/components/image_handling/CImageJpg.cpp
+++ b/code/components/image_handling/CImageJpg.cpp
@@ -1,6 +1,7 @@
 #include "CImageJpg.h"
 
 #include "esp_system.h"
+#include "esp_heap_caps.h"
 
 #include "helper.h"
 #include "psram.h"

--- a/code/components/image_handling/CImageLockGuard.cpp
+++ b/code/components/image_handling/CImageLockGuard.cpp
@@ -1,6 +1,5 @@
 #include "CImageLockGuard.h"
 
-#include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
 
 #include "ClassLogFile.h"

--- a/code/components/image_handling/CImageMod.cpp
+++ b/code/components/image_handling/CImageMod.cpp
@@ -2,9 +2,6 @@
 
 #include <math.h>
 
-#include "esp_log.h"
-
-#include "psram.h"
 #include "ClassLogFile.h"
 
 

--- a/code/components/image_handling/CImageTplMatch.cpp
+++ b/code/components/image_handling/CImageTplMatch.cpp
@@ -4,10 +4,8 @@
 
 #include <algorithm>
 #include <cmath>
-#include <vector>
 
 #include "CImageMod.h"
-#include "psram.h"
 #include "ClassLogFile.h"
 #include "helper.h"
 

--- a/code/components/image_handling/CMakeLists.txt
+++ b/code/components/image_handling/CMakeLists.txt
@@ -1,4 +1,4 @@
-FILE(GLOB_RECURSE app_sources ${CMAKE_CURRENT_SOURCE_DIR}/*.*)
+FILE(GLOB_RECURSE app_sources ${CMAKE_CURRENT_SOURCE_DIR}/*.cpp ${CMAKE_CURRENT_SOURCE_DIR}/*.c)
 
 idf_component_register(SRCS ${app_sources}
                     INCLUDE_DIRS "."

--- a/code/components/image_handling/make_stb.cpp
+++ b/code/components/image_handling/make_stb.cpp
@@ -1,5 +1,6 @@
 #include "psram.h"
 
+#include "esp_heap_caps.h"
 
 #define STBI_ONLY_JPEG       // JPG handling only (disable other file types to save flash)
 #define STBI_FAILURE_USERMSG // Compile user friendly error messages

--- a/code/components/influxdb_ctrl/CMakeLists.txt
+++ b/code/components/influxdb_ctrl/CMakeLists.txt
@@ -1,4 +1,4 @@
-FILE(GLOB_RECURSE app_sources ${CMAKE_CURRENT_SOURCE_DIR}/*.*)
+FILE(GLOB_RECURSE app_sources ${CMAKE_CURRENT_SOURCE_DIR}/*.cpp ${CMAKE_CURRENT_SOURCE_DIR}/*.c)
 
 idf_component_register(SRCS ${app_sources}
                     INCLUDE_DIRS "."

--- a/code/components/influxdb_ctrl/interface_influxdbv1.cpp
+++ b/code/components/influxdb_ctrl/interface_influxdbv1.cpp
@@ -8,7 +8,6 @@
 #include <esp_log.h>
 
 #include "ClassLogFile.h"
-#include "psram.h"
 #include "helper.h"
 #include "time_sntp.h"
 

--- a/code/components/influxdb_ctrl/interface_influxdbv1.h
+++ b/code/components/influxdb_ctrl/interface_influxdbv1.h
@@ -6,7 +6,7 @@
 
 #include <string>
 
-#include "configClass.h"
+#include "cfgDataStruct.h"
 
 bool influxDBv1Init(const CfgData::SectionInfluxDBv1 *_cfgDataPtr);
 esp_err_t influxDBv1Publish(const std::string &_measurement, const std::string &_fieldkey1, const std::string &_fieldvalue1,

--- a/code/components/influxdb_ctrl/interface_influxdbv2.cpp
+++ b/code/components/influxdb_ctrl/interface_influxdbv2.cpp
@@ -8,7 +8,6 @@
 #include <esp_log.h>
 
 #include "ClassLogFile.h"
-#include "psram.h"
 #include "helper.h"
 #include "time_sntp.h"
 

--- a/code/components/influxdb_ctrl/interface_influxdbv2.h
+++ b/code/components/influxdb_ctrl/interface_influxdbv2.h
@@ -6,7 +6,7 @@
 
 #include <string>
 
-#include "configClass.h"
+#include "cfgDataStruct.h"
 
 bool influxDBv2Init(const CfgData::SectionInfluxDBv2 *_cfgDataPtr);
 esp_err_t influxDBv2Publish(const std::string &_measurement, const std::string &_fieldkey1, const std::string &_fieldvalue1,

--- a/code/components/logfile_handling/CMakeLists.txt
+++ b/code/components/logfile_handling/CMakeLists.txt
@@ -1,4 +1,4 @@
-FILE(GLOB_RECURSE app_sources ${CMAKE_CURRENT_SOURCE_DIR}/*.*)
+FILE(GLOB_RECURSE app_sources ${CMAKE_CURRENT_SOURCE_DIR}/*.cpp ${CMAKE_CURRENT_SOURCE_DIR}/*.c)
 
 idf_component_register(SRCS ${app_sources}
                     INCLUDE_DIRS "."

--- a/code/components/logfile_handling/ClassLogFile.cpp
+++ b/code/components/logfile_handling/ClassLogFile.cpp
@@ -5,14 +5,7 @@
 #include <sys/stat.h>
 #include <algorithm>
 #include <unistd.h>
-
-#ifdef __cplusplus
-extern "C" {
-#endif
 #include <dirent.h>
-#ifdef __cplusplus
-}
-#endif
 
 #include "helper.h"
 #include "system.h"

--- a/code/components/mainprocess_ctrl/CMakeLists.txt
+++ b/code/components/mainprocess_ctrl/CMakeLists.txt
@@ -1,4 +1,4 @@
-FILE(GLOB_RECURSE app_sources ${CMAKE_CURRENT_SOURCE_DIR}/*.*)
+FILE(GLOB_RECURSE app_sources ${CMAKE_CURRENT_SOURCE_DIR}/*.cpp ${CMAKE_CURRENT_SOURCE_DIR}/*.c)
 
 idf_component_register(SRCS ${app_sources}
                     INCLUDE_DIRS "."

--- a/code/components/mainprocess_ctrl/ClassFlowAlignment.cpp
+++ b/code/components/mainprocess_ctrl/ClassFlowAlignment.cpp
@@ -1,19 +1,16 @@
 #include "ClassFlowAlignment.h"
 #include "../../include/defines.h"
 
-#include "nvs_flash.h"
-#include "nvs.h"
-
+#include <nvs.h>
 #include <esp_log.h>
 
 #include "CImage.h"
 #include "CImageMod.h"
 #include "CImageTplMatch.h"
-#include "ClassFlowTakeImage.h"
+#include "ClassControlCamera.h"
 #include "ClassLogFile.h"
 #include "MainFlowControl.h"
-#include "time_sntp.h"
-#include "psram.h"
+#include "helper.h"
 
 
 static const char *TAG = "ALIGN";

--- a/code/components/mainprocess_ctrl/ClassFlowAlignment.h
+++ b/code/components/mainprocess_ctrl/ClassFlowAlignment.h
@@ -4,9 +4,8 @@
 #include <string>
 
 #include "ClassFlowDefineTypes.h"
-#include "configClass.h"
+#include "cfgDataStruct.h"
 #include "ClassFlow.h"
-#include "helper.h"
 
 
 class ClassFlowAlignment : public ClassFlow

--- a/code/components/mainprocess_ctrl/ClassFlowCNNGeneral.cpp
+++ b/code/components/mainprocess_ctrl/ClassFlowCNNGeneral.cpp
@@ -10,6 +10,7 @@
 #include "ClassLogFile.h"
 #include "ClassControlCamera.h"
 #include "CImageMod.h"
+#include "helper.h"
 
 
 static const char *TAG = "CNN";

--- a/code/components/mainprocess_ctrl/ClassFlowCNNGeneral.h
+++ b/code/components/mainprocess_ctrl/ClassFlowCNNGeneral.h
@@ -3,10 +3,9 @@
 
 #include "ClassFlowDefineTypes.h"
 #include "ClassLogImage.h"
-#include "ClassFlowAlignment.h"
 #include "CTfLiteClass.h"
 #include "ClassLogImage.h"
-#include "configClass.h"
+#include "cfgDataStruct.h"
 
 
 class ClassFlowCNNGeneral : public ClassLogImage

--- a/code/components/mainprocess_ctrl/ClassFlowControl.cpp
+++ b/code/components/mainprocess_ctrl/ClassFlowControl.cpp
@@ -1,28 +1,16 @@
 #include "ClassFlowControl.h"
 #include "../../include/defines.h"
 
-#include "freertos/task.h"
 #include <sys/stat.h>
-
-#ifdef __cplusplus
-extern "C" {
-#endif
 #include <dirent.h>
-#ifdef __cplusplus
-}
-#endif
 
-#include "configClass.h"
-#include "connect_wlan.h"
+#include "ClassControlCamera.h"
 #include "ClassLogFile.h"
 #include "time_sntp.h"
 #include "helper.h"
 #include "system.h"
 #include "statusled.h"
-#include "server_ota.h"
-#include "server_help.h"
 #include "MainFlowControl.h"
-#include "gpioControl.h"
 #include "server_file.h"
 
 #ifdef ENABLE_MQTT

--- a/code/components/mainprocess_ctrl/ClassFlowInfluxDBv1.cpp
+++ b/code/components/mainprocess_ctrl/ClassFlowInfluxDBv1.cpp
@@ -5,12 +5,9 @@
 
 #include <esp_log.h>
 
-#include "time_sntp.h"
+#include "configClass.h"
 #include "interface_influxdbv1.h"
-#include "ClassFlowPostProcessing.h"
 #include "ClassLogFile.h"
-#include "helper.h"
-#include "connect_wlan.h"
 
 
 static const char *TAG = "INFLUXDBV1";

--- a/code/components/mainprocess_ctrl/ClassFlowInfluxDBv1.h
+++ b/code/components/mainprocess_ctrl/ClassFlowInfluxDBv1.h
@@ -6,9 +6,8 @@
 
 #include <string>
 
-#include "configClass.h"
+#include "cfgDataStruct.h"
 #include "ClassFlow.h"
-#include "ClassFlowPostProcessing.h"
 
 
 class ClassFlowInfluxDBv1 : public ClassFlow

--- a/code/components/mainprocess_ctrl/ClassFlowInfluxDBv2.cpp
+++ b/code/components/mainprocess_ctrl/ClassFlowInfluxDBv2.cpp
@@ -5,12 +5,9 @@
 
 #include <esp_log.h>
 
-#include "time_sntp.h"
+#include "configClass.h"
 #include "interface_influxdbv2.h"
-#include "ClassFlowPostProcessing.h"
 #include "ClassLogFile.h"
-#include "helper.h"
-#include "connect_wlan.h"
 
 
 static const char *TAG = "INFLUXDBV2";

--- a/code/components/mainprocess_ctrl/ClassFlowInfluxDBv2.h
+++ b/code/components/mainprocess_ctrl/ClassFlowInfluxDBv2.h
@@ -6,9 +6,8 @@
 
 #include <string>
 
-#include "configClass.h"
+#include "cfgDataStruct.h"
 #include "ClassFlow.h"
-#include "ClassFlowPostProcessing.h"
 
 
 class ClassFlowInfluxDBv2 : public ClassFlow

--- a/code/components/mainprocess_ctrl/ClassFlowMQTT.h
+++ b/code/components/mainprocess_ctrl/ClassFlowMQTT.h
@@ -6,9 +6,8 @@
 
 #include <string>
 
-#include "configClass.h"
+#include "cfgDataStruct.h"
 #include "ClassFlow.h"
-#include "ClassFlowPostProcessing.h"
 #include "interface_mqtt.h"
 #include "server_mqtt.h"
 

--- a/code/components/mainprocess_ctrl/ClassFlowPostProcessing.cpp
+++ b/code/components/mainprocess_ctrl/ClassFlowPostProcessing.cpp
@@ -3,11 +3,10 @@
 
 #include <time.h>
 
-#include "nvs_flash.h"
-#include "nvs.h"
-
+#include <nvs.h>
 #include <esp_log.h>
 
+#include "configClass.h"
 #include "time_sntp.h"
 #include "helper.h"
 #include "ClassLogFile.h"

--- a/code/components/mainprocess_ctrl/ClassFlowPostProcessing.h
+++ b/code/components/mainprocess_ctrl/ClassFlowPostProcessing.h
@@ -3,9 +3,8 @@
 
 #include <string>
 
-#include "configClass.h"
+#include "cfgDataStruct.h"
 #include "ClassFlow.h"
-#include "ClassFlowDefineTypes.h"
 #include "ClassFlowTakeImage.h"
 #include "ClassFlowCNNGeneral.h"
 

--- a/code/components/mainprocess_ctrl/ClassFlowTakeImage.cpp
+++ b/code/components/mainprocess_ctrl/ClassFlowTakeImage.cpp
@@ -7,7 +7,7 @@
 #include <esp_log.h>
 
 #include "configClass.h"
-#include "helper.h"
+#include "ClassControlCamera.h"
 #include "ClassLogFile.h"
 #include "CImage.h"
 #include "CImageJpg.h"

--- a/code/components/mainprocess_ctrl/ClassFlowTakeImage.h
+++ b/code/components/mainprocess_ctrl/ClassFlowTakeImage.h
@@ -3,10 +3,8 @@
 
 #include <string>
 
-#include "configClass.h"
+#include "cfgDataStruct.h"
 #include "ClassLogImage.h"
-#include "ClassControlCamera.h"
-#include "ClassFlowDefineTypes.h"
 
 
 class ClassFlowTakeImage : public ClassLogImage

--- a/code/components/mainprocess_ctrl/ClassFlowWebhook.cpp
+++ b/code/components/mainprocess_ctrl/ClassFlowWebhook.cpp
@@ -5,12 +5,9 @@
 
 #include <esp_log.h>
 
-#include "time_sntp.h"
+#include "configClass.h"
 #include "interface_webhook.h"
-#include "ClassFlowPostProcessing.h"
 #include "ClassLogFile.h"
-#include "helper.h"
-#include "connect_wlan.h"
 
 
 static const char *TAG = "WEBHOOK";

--- a/code/components/mainprocess_ctrl/ClassFlowWebhook.h
+++ b/code/components/mainprocess_ctrl/ClassFlowWebhook.h
@@ -6,11 +6,10 @@
 
 #include <string>
 
-#include "configClass.h"
+#include "cfgDataStruct.h"
 #include "ClassFlow.h"
-#include "ClassFlowPostProcessing.h"
 
-
+#include "configClass.h"
 class ClassFlowWebhook : public ClassFlow
 {
   protected:

--- a/code/components/mainprocess_ctrl/ClassLogImage.cpp
+++ b/code/components/mainprocess_ctrl/ClassLogImage.cpp
@@ -2,14 +2,7 @@
 #include "../../include/defines.h"
 
 #include <sys/stat.h>
-
-#ifdef __cplusplus
-extern "C" {
-#endif
 #include <dirent.h>
-#ifdef __cplusplus
-}
-#endif
 
 #include <esp_log.h>
 

--- a/code/components/mainprocess_ctrl/MainFlowControl.cpp
+++ b/code/components/mainprocess_ctrl/MainFlowControl.cpp
@@ -6,7 +6,6 @@
 
 #include <esp_log.h>
 #include <esp_timer.h>
-#include "esp_camera.h"
 #include <cJSON.h>
 
 #include "configClass.h"
@@ -22,6 +21,7 @@
 #include "network_main.h"
 #include "connect_wlan.h"
 #include "psram.h"
+#include "CImageMod.h"
 
 #ifdef ENABLE_MQTT
 #include "interface_mqtt.h"

--- a/code/components/mainprocess_ctrl/MainFlowControl.cpp
+++ b/code/components/mainprocess_ctrl/MainFlowControl.cpp
@@ -6,6 +6,7 @@
 
 #include <esp_log.h>
 #include <esp_timer.h>
+#include "esp_heap_caps.h"
 #include <cJSON.h>
 
 #include "configClass.h"

--- a/code/components/mainprocess_ctrl/MainFlowControl.h
+++ b/code/components/mainprocess_ctrl/MainFlowControl.h
@@ -6,8 +6,6 @@
 #include <esp_log.h>
 #include <esp_http_server.h>
 
-#include "CImage.h"
-#include "CImageMod.h"
 #include "ClassFlowControl.h"
 
 

--- a/code/components/misc_helper/CMakeLists.txt
+++ b/code/components/misc_helper/CMakeLists.txt
@@ -1,4 +1,4 @@
-FILE(GLOB_RECURSE app_sources ${CMAKE_CURRENT_SOURCE_DIR}/*.*)
+FILE(GLOB_RECURSE app_sources ${CMAKE_CURRENT_SOURCE_DIR}/*.cpp ${CMAKE_CURRENT_SOURCE_DIR}/*.c)
 
 idf_component_register(SRCS ${app_sources}
                     INCLUDE_DIRS "."

--- a/code/components/misc_helper/helper.cpp
+++ b/code/components/misc_helper/helper.cpp
@@ -9,14 +9,7 @@
 
 #include <sys/types.h>
 #include <sys/stat.h>
-
-#ifdef __cplusplus
-extern "C" {
-#endif
 #include <dirent.h>
-#ifdef __cplusplus
-}
-#endif
 
 #include <esp_log.h>
 #include <esp_timer.h>

--- a/code/components/misc_helper/psram.cpp
+++ b/code/components/misc_helper/psram.cpp
@@ -1,6 +1,8 @@
 #include "psram.h"
 
+#include "esp_heap_caps.h"
 #include <cJSON.h>
+
 #include "ClassLogFile.h"
 
 

--- a/code/components/misc_helper/psram.cpp
+++ b/code/components/misc_helper/psram.cpp
@@ -1,4 +1,6 @@
 #include "psram.h"
+
+#include <cJSON.h>
 #include "ClassLogFile.h"
 
 

--- a/code/components/misc_helper/psram.h
+++ b/code/components/misc_helper/psram.h
@@ -1,6 +1,7 @@
 #ifndef COMPONENTS_HELPER_PSRAM_H_
 #define COMPONENTS_HELPER_PSRAM_H_
 
+#include <cstdint>
 #include <string>
 #include <unistd.h>
 

--- a/code/components/misc_helper/psram.h
+++ b/code/components/misc_helper/psram.h
@@ -2,9 +2,7 @@
 #define COMPONENTS_HELPER_PSRAM_H_
 
 #include <string>
-
-#include "esp_heap_caps.h"
-
+#include <unistd.h>
 
 /* SPIRAM profile in IDLE (date: 19.08.2023)*/
 /* Showing data for heap: 0x3f802fa8

--- a/code/components/misc_helper/sdcard_check.cpp
+++ b/code/components/misc_helper/sdcard_check.cpp
@@ -6,7 +6,6 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <unistd.h>
-#include <inttypes.h>
 #include <sys/stat.h>
 
 #include "esp_rom_crc.h"

--- a/code/components/misc_helper/system.cpp
+++ b/code/components/misc_helper/system.cpp
@@ -5,6 +5,7 @@
 #include "esp_chip_info.h"
 #include "hal/efuse_hal.h"
 #include "esp_vfs_fat.h"
+#include "esp_heap_caps.h"
 
 #ifdef SOC_TEMP_SENSOR_SUPPORTED
 #include "driver/temperature_sensor.h"

--- a/code/components/misc_helper/system.h
+++ b/code/components/misc_helper/system.h
@@ -3,7 +3,7 @@
 
 #include <string>
 
-#include "sdmmc_cmd.h"
+#include <sd_protocol_types.h>
 
 typedef enum {
     SPIRAMCategory_4MB = 0,

--- a/code/components/mqtt_ctrl/CMakeLists.txt
+++ b/code/components/mqtt_ctrl/CMakeLists.txt
@@ -1,4 +1,4 @@
-FILE(GLOB_RECURSE app_sources ${CMAKE_CURRENT_SOURCE_DIR}/*.*)
+FILE(GLOB_RECURSE app_sources ${CMAKE_CURRENT_SOURCE_DIR}/*.cpp ${CMAKE_CURRENT_SOURCE_DIR}/*.c)
 
 idf_component_register(SRCS ${app_sources}
                     INCLUDE_DIRS "."

--- a/code/components/mqtt_ctrl/interface_mqtt.cpp
+++ b/code/components/mqtt_ctrl/interface_mqtt.cpp
@@ -11,14 +11,13 @@
 #include <esp_timer.h>
 #endif // DEBUG_DETAIL_ON
 
-#include "configClass.h"
+#include "cfgDataStruct.h"
 #include "MainFlowControl.h"
 #include "ClassLogFile.h"
 #include "network_main.h"
-#include "connect_wlan.h"
-#include "server_mqtt.h"
 #include "time_sntp.h"
 #include "server_ota.h"
+#include "helper.h"
 
 
 static const char *TAG = "MQTT_IF";

--- a/code/components/mqtt_ctrl/interface_mqtt.h
+++ b/code/components/mqtt_ctrl/interface_mqtt.h
@@ -5,7 +5,6 @@
 #define INTERFACE_MQTT_H
 
 #include <string>
-#include <map>
 #include <functional>
 
 #include "cfgDataStruct.h"

--- a/code/components/mqtt_ctrl/server_mqtt.cpp
+++ b/code/components/mqtt_ctrl/server_mqtt.cpp
@@ -8,8 +8,9 @@
 #include <esp_private/esp_clk.h>
 #include <cJSON.h>
 
+#include "configClass.h"
 #include "http_auth.h"
-#include "MainFlowControl.h"
+#include "ClassControlCamera.h"
 #include "ClassLogFile.h"
 #include "network_main.h"
 #include "connect_wlan.h"

--- a/code/components/mqtt_ctrl/server_mqtt.h
+++ b/code/components/mqtt_ctrl/server_mqtt.h
@@ -6,7 +6,7 @@
 
 #include "ClassFlowDefineTypes.h"
 #include "ClassFlowMQTT.h"
-#include "configClass.h"
+#include "cfgDataStruct.h"
 
 
 struct HAMeterConfig {

--- a/code/components/network_ctrl/CMakeLists.txt
+++ b/code/components/network_ctrl/CMakeLists.txt
@@ -1,4 +1,4 @@
-FILE(GLOB_RECURSE app_sources ${CMAKE_CURRENT_SOURCE_DIR}/*.*)
+FILE(GLOB_RECURSE app_sources ${CMAKE_CURRENT_SOURCE_DIR}/*.cpp ${CMAKE_CURRENT_SOURCE_DIR}/*.c)
 
 idf_component_register(SRCS ${app_sources}
                     INCLUDE_DIRS "."

--- a/code/components/network_ctrl/connect_ethernet.cpp
+++ b/code/components/network_ctrl/connect_ethernet.cpp
@@ -2,25 +2,22 @@
 
 #ifdef BOARD_FEATURE_ETHERNET
 
-#include "esp_event.h"
-#include "esp_eth.h"
+#include <esp_event.h>
+#include <esp_eth.h>
 #include <esp_mac.h>
-#include "esp_log.h"
-#include "esp_netif.h"
+#include <esp_netif.h>
 #include <esp_netif_sntp.h>
-#include "driver/spi_master.h"
-#include "driver/gpio.h"
+#include <driver/spi_master.h>
+#include <driver/gpio.h>
 
 #ifdef ENABLE_MQTT
 #include "interface_mqtt.h"
 #endif // ENABLE_MQTT
 
 #include "configClass.h"
-#include "connect_wlan.h"
 #include "time_sntp.h"
 #include "ClassLogFile.h"
 #include "helper.h"
-#include "statusled.h"
 #include "mdns_service.h"
 
 static const char *TAG = "ETHERNET";

--- a/code/components/network_ctrl/improvWifiProvisioning.cpp
+++ b/code/components/network_ctrl/improvWifiProvisioning.cpp
@@ -23,7 +23,6 @@
 #include "configClass.h"
 #include "ClassLogFile.h"
 #include "system.h"
-#include "server_ota.h"
 #include "softAP.h"
 #include "helper.h"
 

--- a/code/components/network_ctrl/server_wlan.cpp
+++ b/code/components/network_ctrl/server_wlan.cpp
@@ -4,7 +4,6 @@
 #include <string>
 
 #include "http_auth.h"
-#include "ClassLogFile.h"
 #include "connect_wlan.h"
 
 

--- a/code/components/openmetrics_ctrl/CMakeLists.txt
+++ b/code/components/openmetrics_ctrl/CMakeLists.txt
@@ -1,4 +1,4 @@
-FILE(GLOB_RECURSE app_sources ${CMAKE_CURRENT_SOURCE_DIR}/*.*)
+FILE(GLOB_RECURSE app_sources ${CMAKE_CURRENT_SOURCE_DIR}/*.cpp ${CMAKE_CURRENT_SOURCE_DIR}/*.c)
 
 idf_component_register(SRCS ${app_sources}
                     INCLUDE_DIRS "."

--- a/code/components/openmetrics_ctrl/openmetrics.cpp
+++ b/code/components/openmetrics_ctrl/openmetrics.cpp
@@ -10,9 +10,11 @@
 #include "http_auth.h"
 #include "system.h"
 #include "ClassFlowDefineTypes.h"
+#include "ClassControlCamera.h"
 #include "MainFlowControl.h"
 #include "network_main.h"
 #include "connect_wlan.h"
+#include "helper.h"
 
 extern std::string getFwVersion(void);
 

--- a/code/components/tflite_ctrl/CMakeLists.txt
+++ b/code/components/tflite_ctrl/CMakeLists.txt
@@ -1,4 +1,4 @@
-FILE(GLOB_RECURSE app_sources ${CMAKE_CURRENT_SOURCE_DIR}/*.*)
+FILE(GLOB_RECURSE app_sources ${CMAKE_CURRENT_SOURCE_DIR}/*.cpp ${CMAKE_CURRENT_SOURCE_DIR}/*.c)
 
 idf_component_register(SRCS ${app_sources}
                     INCLUDE_DIRS "."

--- a/code/components/tflite_ctrl/CTfLiteClass.cpp
+++ b/code/components/tflite_ctrl/CTfLiteClass.cpp
@@ -1,6 +1,7 @@
 #include "CTfLiteClass.h"
 #include "../../include/defines.h"
 
+#include "esp_heap_caps.h"
 #include <flatbuffers/verifier.h>
 
 #include "ClassLogFile.h"

--- a/code/components/time_sntp/CMakeLists.txt
+++ b/code/components/time_sntp/CMakeLists.txt
@@ -1,4 +1,4 @@
-FILE(GLOB_RECURSE app_sources ${CMAKE_CURRENT_SOURCE_DIR}/*.*)
+FILE(GLOB_RECURSE app_sources ${CMAKE_CURRENT_SOURCE_DIR}/*.cpp ${CMAKE_CURRENT_SOURCE_DIR}/*.c)
 
 idf_component_register(SRCS ${app_sources}
                     INCLUDE_DIRS "."

--- a/code/components/time_sntp/time_sntp.cpp
+++ b/code/components/time_sntp/time_sntp.cpp
@@ -9,7 +9,6 @@
 
 #include "configClass.h"
 #include "ClassLogFile.h"
-#include "helper.h"
 #include "interface_mqtt.h"
 
 

--- a/code/components/webhook_ctrl/CMakeLists.txt
+++ b/code/components/webhook_ctrl/CMakeLists.txt
@@ -1,4 +1,4 @@
-FILE(GLOB_RECURSE app_sources ${CMAKE_CURRENT_SOURCE_DIR}/*.*)
+FILE(GLOB_RECURSE app_sources ${CMAKE_CURRENT_SOURCE_DIR}/*.cpp ${CMAKE_CURRENT_SOURCE_DIR}/*.c)
 
 idf_component_register(SRCS ${app_sources}
                     INCLUDE_DIRS "."

--- a/code/components/webhook_ctrl/interface_webhook.cpp
+++ b/code/components/webhook_ctrl/interface_webhook.cpp
@@ -8,7 +8,6 @@
 #include <esp_log.h>
 
 #include "ClassLogFile.h"
-#include "psram.h"
 #include "helper.h"
 #include "time_sntp.h"
 

--- a/code/components/webhook_ctrl/interface_webhook.h
+++ b/code/components/webhook_ctrl/interface_webhook.h
@@ -4,9 +4,7 @@
 #ifndef INTERFACE_WEBHOOK_H
 #define INTERFACE_WEBHOOK_H
 
-#include <string>
-
-#include "configClass.h"
+#include "cfgDataStruct.h"
 #include "CImageJpg.h"
 
 bool webhookInit(const CfgData::SectionWebhook *_cfgDataPtr);

--- a/code/components/webserver_softap/CMakeLists.txt
+++ b/code/components/webserver_softap/CMakeLists.txt
@@ -1,4 +1,4 @@
-FILE(GLOB_RECURSE app_sources ${CMAKE_CURRENT_SOURCE_DIR}/*.*)
+FILE(GLOB_RECURSE app_sources ${CMAKE_CURRENT_SOURCE_DIR}/*.cpp ${CMAKE_CURRENT_SOURCE_DIR}/*.c)
 
 idf_component_register(SRCS ${app_sources}
                     INCLUDE_DIRS "." "../../include"

--- a/code/components/webserver_softap/webserver.cpp
+++ b/code/components/webserver_softap/webserver.cpp
@@ -6,6 +6,7 @@
 
 #include <esp_log.h>
 #include <esp_wifi.h>
+#include "esp_heap_caps.h"
 #include <esp_private/esp_clk.h>
 #include <cJSON.h>
 

--- a/code/components/webserver_softap/webserver.cpp
+++ b/code/components/webserver_softap/webserver.cpp
@@ -16,9 +16,9 @@
 #include "../main/version.h" // Only include once
 #include "http_auth.h"
 #include "MainFlowControl.h"
+#include "ClassControlCamera.h"
 #include "ClassLogFile.h"
 #include "server_file.h"
-#include "server_help.h"
 #include "time_sntp.h"
 #include "network_main.h"
 #include "connect_wlan.h"

--- a/code/main/CMakeLists.txt
+++ b/code/main/CMakeLists.txt
@@ -66,11 +66,9 @@ endif()
 #######################################################################
 #######################################################################
 
-
-FILE(GLOB_RECURSE app_sources ${CMAKE_SOURCE_DIR}/main/*.*)
-
-# idf_component_register(SRCS ${app_sources})
+FILE(GLOB_RECURSE app_sources ${CMAKE_CURRENT_SOURCE_DIR}/*.cpp ${CMAKE_CURRENT_SOURCE_DIR}/*.c)
 
 idf_component_register(SRCS ${app_sources}
                     INCLUDE_DIRS "."
-                    REQUIRES esp_driver_sdmmc nvs_flash esp_psram)
+                    REQUIRES esp_driver_sdmmc nvs_flash esp_psram esp_netif esp_hw_support config_handling
+                        camera_ctrl logfile_handling mainprocess_ctrl network_ctrl webserver_softap misc_helper)

--- a/code/main/main.cpp
+++ b/code/main/main.cpp
@@ -1,7 +1,6 @@
-#include "../../include/defines.h"
+#include "../include/defines.h"
 
 #include <string>
-#include <regex>
 
 #include <nvs_flash.h>
 #include <esp_psram.h>
@@ -16,6 +15,7 @@
 
 #include "configClass.h"
 #include "configMigration.h"
+#include "ClassControlCamera.h"
 #include "ClassLogFile.h"
 #include "helper.h"
 #include "system.h"

--- a/code/test/components/config_handling/CMakeLists.txt
+++ b/code/test/components/config_handling/CMakeLists.txt
@@ -1,4 +1,4 @@
-FILE(GLOB_RECURSE app_sources ${CMAKE_CURRENT_SOURCE_DIR}/*.*)
+FILE(GLOB_RECURSE app_sources ${CMAKE_CURRENT_SOURCE_DIR}/*.cpp ${CMAKE_CURRENT_SOURCE_DIR}/*.c)
 
 idf_component_register(SRCS ${app_sources}
                     INCLUDE_DIRS "."

--- a/code/test/components/image_handling/CMakeLists.txt
+++ b/code/test/components/image_handling/CMakeLists.txt
@@ -1,4 +1,4 @@
-FILE(GLOB_RECURSE app_sources ${CMAKE_CURRENT_SOURCE_DIR}/*.*)
+FILE(GLOB_RECURSE app_sources ${CMAKE_CURRENT_SOURCE_DIR}/*.cpp ${CMAKE_CURRENT_SOURCE_DIR}/*.c)
 
 idf_component_register(SRCS ${app_sources}
                     INCLUDE_DIRS "."

--- a/code/test/components/mainprocess_ctrl/CMakeLists.txt
+++ b/code/test/components/mainprocess_ctrl/CMakeLists.txt
@@ -1,4 +1,4 @@
-FILE(GLOB_RECURSE app_sources ${CMAKE_CURRENT_SOURCE_DIR}/*.*)
+FILE(GLOB_RECURSE app_sources ${CMAKE_CURRENT_SOURCE_DIR}/*.cpp ${CMAKE_CURRENT_SOURCE_DIR}/*.c)
 
 idf_component_register(SRCS ${app_sources}
                     INCLUDE_DIRS "."


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Summary</h3>

The PR makes component headers more self-contained and moves implementation-specific dependencies into source files, while narrowing CMake source globs to compilable C/C++ files.
- Adds direct fixed-width integer declarations to `psram.h`.
- Adds direct heap-capability includes to every source file using `MALLOC_CAP_*`.
- Updates component dependencies and removes unnecessary transitive includes.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.
</details>


</details>

<sub>Reviews (3): Last reviewed commit: ["Update"](https://github.com/slider0007/ai-on-the-edge-device/commit/1a643573fb59f388ae634ad3343fb5ab0df7405b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57904889)</sub>

<!-- /greptile_comment -->