### PR TITLE
fix(config handling): Fix thread-safety issue using cJSON with PSRAM

### DIFF
--- a/code/components/config_handling/configClass.cpp
+++ b/code/components/config_handling/configClass.cpp
@@ -325,7 +325,6 @@ esp_err_t ConfigClass::setConfigRequest(httpd_req_t *req)
         // Delete JSON AST while TLS arena is still active
         cJSON_Delete(cJsonObject);
         cJsonObject = nullptr;
-
     } // CfgMutexGuard releases here
 
     return retVal;

--- a/code/components/config_handling/configClass.cpp
+++ b/code/components/config_handling/configClass.cpp
@@ -2835,14 +2835,13 @@ esp_err_t ConfigClass::writeConfigFile()
 bool ConfigClass::persistConfig()
 {
     if (!cJsonObjectBuffer || !jsonBuffer || !cfgMutex) {
-        return ESP_FAIL;
+        return false;
     }
 
     CfgMutexGuard lock(cfgMutex, pdMS_TO_TICKS(5000));
     if (!lock.isAcquired()) {
         LogFile.writeToFile(ESP_LOG_ERROR, TAG, "Failed to acquire cfgMutex - timeout expired");
-        httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "E90: System busy");
-        return ESP_FAIL;
+        return false;
     }
 
     // Activates TLS PSRAM arena for this thread during serialization

--- a/code/components/config_handling/configClass.cpp
+++ b/code/components/config_handling/configClass.cpp
@@ -2832,6 +2832,33 @@ esp_err_t ConfigClass::writeConfigFile()
 }
 
 
+bool ConfigClass::persistConfig()
+{
+    if (!cJsonObjectBuffer || !jsonBuffer || !cfgMutex) {
+        return ESP_FAIL;
+    }
+
+    CfgMutexGuard lock(cfgMutex, pdMS_TO_TICKS(5000));
+    if (!lock.isAcquired()) {
+        LogFile.writeToFile(ESP_LOG_ERROR, TAG, "Failed to acquire cfgMutex - timeout expired");
+        httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "E90: System busy");
+        return ESP_FAIL;
+    }
+
+    // Activates TLS PSRAM arena for this thread during serialization
+    cJsonPsramArena jsonArena(cJsonObjectBuffer, CONFIG_HANDLING_PREALLOCATED_BUFFER_SIZE);
+
+    // Clear existing buffer target
+    jsonBuffer[0] = '\0';
+
+    if (serializeConfig() != ESP_OK) {
+        return false;
+    }
+
+    return (writeConfigFile() == ESP_OK);
+}
+
+
 bool ConfigClass::loadDataFromNVS(std::string key, std::string &value)
 {
     if (key.empty() || key.length() > 15) {

--- a/code/components/config_handling/configClass.cpp
+++ b/code/components/config_handling/configClass.cpp
@@ -2606,7 +2606,7 @@ esp_err_t ConfigClass::serializeConfig(bool unityTest)
 
     jsonBuffer[0] = '\0'; // Reset content
     // Print to preallocted buffer
-    if (!cJSON_PrintPreallocated(cJsonObject, jsonBuffer, CONFIG_HANDLING_CJSON_OBJECT_BUFFER_SIZE, unityTest ? 0 : 1)) {
+    if (!cJSON_PrintPreallocated(cJsonObject, jsonBuffer, CONFIG_HANDLING_CJSON_STRING_BUFFER_SIZE, unityTest ? 0 : 1)) {
         retVal = ESP_FAIL;
     }
 
@@ -2636,6 +2636,16 @@ bool ConfigClass::persistConfig()
     // Activates TLS PSRAM arena
     cJsonPsramArena jsonArena(cJsonObjectBuffer, CONFIG_HANDLING_CJSON_OBJECT_BUFFER_SIZE);
 
+    if (serializeConfig() != ESP_OK) {
+        return false;
+    }
+
+    return (writeConfigFile() == ESP_OK);
+}
+
+
+bool ConfigClass::persistConfigAfterMigration()
+{
     if (serializeConfig() != ESP_OK) {
         return false;
     }

--- a/code/components/config_handling/configClass.cpp
+++ b/code/components/config_handling/configClass.cpp
@@ -88,7 +88,7 @@ ConfigClass::ConfigClass()
     cfgMutex = xSemaphoreCreateMutex();
 
     if (cfgMutex == nullptr) {
-        LogFile.writeToFile(ESP_LOG_ERROR, TAG, "Failed to create mutex");
+        LogFile.writeToFile(ESP_LOG_ERROR, TAG, "ConfigClass: Failed to create mutex");
     }
 
     // Use preallocted buffer to avoid fragmentation and reduce internal RAM usage using SPIRAM
@@ -96,7 +96,7 @@ ConfigClass::ConfigClass()
     jsonBuffer = (char *)heap_caps_calloc(1, CONFIG_HANDLING_PREALLOCATED_BUFFER_SIZE, MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
 
     if (!cJsonObjectBuffer || !jsonBuffer) {
-        LogFile.writeToFile(ESP_LOG_ERROR, TAG, "Failed to allocate PSRAM buffers");
+        LogFile.writeToFile(ESP_LOG_ERROR, TAG, "ConfigClass: Failed to allocate PSRAM buffers");
 
         if (cJsonObjectBuffer) {
             heap_caps_free(cJsonObjectBuffer);
@@ -144,13 +144,13 @@ bool ConfigClass::parseJsonFromFile(const char *jsonStr, bool isUnityTest)
     }
 
     if (jsonStr == nullptr) {
-        LogFile.writeToFile(ESP_LOG_ERROR, TAG, "parseJson: JSON input is null");
+        LogFile.writeToFile(ESP_LOG_ERROR, TAG, "parseJsonFromFile: JSON input is null");
         return false;
     }
 
     CfgMutexGuard lock(cfgMutex, pdMS_TO_TICKS(10000));
     if (!lock.isAcquired()) {
-        LogFile.writeToFile(ESP_LOG_ERROR, TAG, "parseJson: Failed to acquire cfgMutex: Timeout");
+        LogFile.writeToFile(ESP_LOG_ERROR, TAG, "parseJsonFromFile: Failed to acquire cfgMutex: Timeout");
         return false;
     }
 
@@ -162,10 +162,10 @@ bool ConfigClass::parseJsonFromFile(const char *jsonStr, bool isUnityTest)
     if (cJsonObject == nullptr) {
         const char *errPtr = cJSON_GetErrorPtr();
         if (errPtr != nullptr) {
-            LogFile.writeToFile(ESP_LOG_ERROR, TAG, "parseJson: Parse error near: %.20s", errPtr);
+            LogFile.writeToFile(ESP_LOG_ERROR, TAG, "parseJsonFromFile: Parse error near: %.20s", errPtr);
         }
         else {
-            LogFile.writeToFile(ESP_LOG_ERROR, TAG, "parseJson: Parse failed (null or invalid payload)");
+            LogFile.writeToFile(ESP_LOG_ERROR, TAG, "parseJsonFromFile: Parse failed (null or invalid payload)");
         }
         return false;
     }
@@ -258,14 +258,14 @@ esp_err_t ConfigClass::setConfigRequest(httpd_req_t *req)
     httpd_resp_set_type(req, "application/json");
 
     if (remaining >= CONFIG_HANDLING_PREALLOCATED_BUFFER_SIZE - 1) {
-        LogFile.writeToFile(ESP_LOG_ERROR, TAG, "setConfig: Payload exceeds maximum buffer size");
-        httpd_resp_send_err(req, HTTPD_413_CONTENT_TOO_LARGE, "E93: Payload too large");
+        // LogFile.writeToFile(ESP_LOG_ERROR, TAG, "setConfig: Payload exceeds maximum buffer size");
+        httpd_resp_send_err(req, HTTPD_413_CONTENT_TOO_LARGE, "Payload exceeds maximum buffer size");
         return ESP_FAIL;
     }
 
     if (req->user_ctx == nullptr) {
-        LogFile.writeToFile(ESP_LOG_ERROR, TAG, "setConfig: Server context is null");
-        httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "E90: Internal Server Error");
+        // LogFile.writeToFile(ESP_LOG_ERROR, TAG, "setConfig: Server context is null");
+        httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "Internal Server Error: Server context is null");
         return ESP_FAIL;
     }
 
@@ -280,8 +280,8 @@ esp_err_t ConfigClass::setConfigRequest(httpd_req_t *req)
                 vTaskDelay(pdMS_TO_TICKS(10));
                 continue;
             }
-            LogFile.writeToFile(ESP_LOG_ERROR, TAG, "setConfig: Config reception failed");
-            httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "E92: Config reception failed");
+            // LogFile.writeToFile(ESP_LOG_ERROR, TAG, "setConfig: Config reception failed");
+            httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "Config reception failed");
             return ESP_FAIL;
         }
 
@@ -291,8 +291,8 @@ esp_err_t ConfigClass::setConfigRequest(httpd_req_t *req)
         {
             CfgMutexGuard lock(cfgMutex, pdMS_TO_TICKS(10000));
             if (!lock.isAcquired()) {
-                LogFile.writeToFile(ESP_LOG_ERROR, TAG, "setConfig: Failed to acquire cfgMutex - timeout expired");
-                httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "E90: System busy");
+                // LogFile.writeToFile(ESP_LOG_ERROR, TAG, "setConfig: Failed to acquire cfgMutex - Timeout");
+                httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "Internal Server Error: Failed to acquire cfgMutex - Timeout");
                 return ESP_FAIL;
             }
 
@@ -308,8 +308,8 @@ esp_err_t ConfigClass::setConfigRequest(httpd_req_t *req)
     {
         CfgMutexGuard lock(cfgMutex, pdMS_TO_TICKS(10000));
         if (!lock.isAcquired()) {
-            LogFile.writeToFile(ESP_LOG_ERROR, TAG, "setConfig: Failed to acquire cfgMutex - timeout expired");
-            httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "E90: System busy");
+            // LogFile.writeToFile(ESP_LOG_ERROR, TAG, "setConfig: Failed to acquire cfgMutex - Timeout");
+            httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "Internal Server Error: Failed to acquire cfgMutex - Timeout");
             return ESP_FAIL;
         }
 
@@ -2783,29 +2783,32 @@ esp_err_t ConfigClass::getConfigRequest(httpd_req_t *req)
         return ESP_FAIL;
     }
 
-    CfgMutexGuard lock(cfgMutex, pdMS_TO_TICKS(10000));
-    if (!lock.isAcquired()) {
-        LogFile.writeToFile(ESP_LOG_ERROR, TAG, "Failed to acquire cfgMutex - timeout expired");
-        httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "E90: System busy");
-        return ESP_FAIL;
+    esp_err_t retVal = ESP_FAIL;
+    {
+        CfgMutexGuard lock(cfgMutex, pdMS_TO_TICKS(10000));
+        if (!lock.isAcquired()) {
+            // LogFile.writeToFile(ESP_LOG_ERROR, TAG, "Failed to acquire cfgMutex - Timeout");
+            httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "Internal Server Error: Failed to acquire cfgMutex - Timeout");
+            return ESP_FAIL;
+        }
+
+        // Activates TLS PSRAM arena for this thread during serialization
+        cJsonPsramArena jsonArena(cJsonObjectBuffer, CONFIG_HANDLING_PREALLOCATED_BUFFER_SIZE);
+
+        // Clear existing buffer target
+        jsonBuffer[0] = '\0';
+
+        // Serialize config data into cJSON / jsonBuffer
+        retVal = serializeConfig();
     }
-
-    // Activates TLS PSRAM arena for this thread during serialization
-    cJsonPsramArena jsonArena(cJsonObjectBuffer, CONFIG_HANDLING_PREALLOCATED_BUFFER_SIZE);
-
-    // Clear existing buffer target
-    jsonBuffer[0] = '\0';
-
-    // Serialize config data into cJSON / jsonBuffer
-    esp_err_t ret = serializeConfig();
 
     if (ret == ESP_OK) {
         httpd_resp_set_type(req, "application/json");
         httpd_resp_send(req, jsonBuffer, HTTPD_RESP_USE_STRLEN);
     }
     else {
-        LogFile.writeToFile(ESP_LOG_ERROR, TAG, "Failed to serialize configuration");
-        httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "E93: Failed to serialize JSON data");
+        // LogFile.writeToFile(ESP_LOG_ERROR, TAG, "Failed to serialize configuration");
+        httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "Failed to serialize configuration");
     }
 
     // Delete root cJSON tree if allocated
@@ -2854,7 +2857,7 @@ bool ConfigClass::persistConfig()
 
     CfgMutexGuard lock(cfgMutex, pdMS_TO_TICKS(10000));
     if (!lock.isAcquired()) {
-        LogFile.writeToFile(ESP_LOG_ERROR, TAG, "Failed to acquire cfgMutex - timeout expired");
+        LogFile.writeToFile(ESP_LOG_ERROR, TAG, "persistConfig: Failed to acquire cfgMutex - Timeout");
         return false;
     }
 

--- a/code/components/config_handling/configClass.cpp
+++ b/code/components/config_handling/configClass.cpp
@@ -2802,7 +2802,7 @@ esp_err_t ConfigClass::getConfigRequest(httpd_req_t *req)
         retVal = serializeConfig();
     }
 
-    if (ret == ESP_OK) {
+    if (retVal == ESP_OK) {
         httpd_resp_set_type(req, "application/json");
         httpd_resp_send(req, jsonBuffer, HTTPD_RESP_USE_STRLEN);
     }
@@ -2817,7 +2817,7 @@ esp_err_t ConfigClass::getConfigRequest(httpd_req_t *req)
         cJsonObject = nullptr;
     }
 
-    return ret;
+    return retVal;
 }
 
 

--- a/code/components/config_handling/configClass.cpp
+++ b/code/components/config_handling/configClass.cpp
@@ -148,7 +148,7 @@ bool ConfigClass::parseJsonFromFile(const char *jsonStr, bool isUnityTest)
         return false;
     }
 
-    CfgMutexGuard lock(cfgMutex, pdMS_TO_TICKS(5000));
+    CfgMutexGuard lock(cfgMutex, pdMS_TO_TICKS(10000));
     if (!lock.isAcquired()) {
         LogFile.writeToFile(ESP_LOG_ERROR, TAG, "parseJson: Failed to acquire cfgMutex: Timeout");
         return false;
@@ -269,36 +269,50 @@ esp_err_t ConfigClass::setConfigRequest(httpd_req_t *req)
         return ESP_FAIL;
     }
 
+    char *httpBuffer = static_cast<char *>(((struct HttpServerData *)req->user_ctx)->scratch);
+
+    int retries = 0;
+    while (remaining > 0) {
+        received = httpd_req_recv(req, httpBuffer, std::min<size_t>(remaining, WEBSERVER_SCRATCH_BUFSIZE));
+
+        if (received <= 0) {
+            if (received == HTTPD_SOCK_ERR_TIMEOUT && ++retries < 5) {
+                vTaskDelay(pdMS_TO_TICKS(10));
+                continue;
+            }
+            LogFile.writeToFile(ESP_LOG_ERROR, TAG, "setConfig: Config reception failed");
+            httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "E92: Config reception failed");
+            return ESP_FAIL;
+        }
+
+        retries = 0;
+
+        // Scoped block to handle JSON processing under the mutex guard safely
+        {
+            CfgMutexGuard lock(cfgMutex, pdMS_TO_TICKS(10000));
+            if (!lock.isAcquired()) {
+                LogFile.writeToFile(ESP_LOG_ERROR, TAG, "setConfig: Failed to acquire cfgMutex - timeout expired");
+                httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "E90: System busy");
+                return ESP_FAIL;
+            }
+
+            memcpy(jsonBuffer + offset, httpBuffer, received);
+            offset += received;
+        } // CfgMutexGuard releases here
+
+        remaining -= received;
+    }
+
     // Scoped block to handle JSON processing under the mutex guard safely
     esp_err_t retVal = ESP_FAIL;
     {
-        CfgMutexGuard lock(cfgMutex, pdMS_TO_TICKS(5000));
+        CfgMutexGuard lock(cfgMutex, pdMS_TO_TICKS(10000));
         if (!lock.isAcquired()) {
             LogFile.writeToFile(ESP_LOG_ERROR, TAG, "setConfig: Failed to acquire cfgMutex - timeout expired");
             httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "E90: System busy");
             return ESP_FAIL;
         }
 
-        char *httpBuffer = static_cast<char *>(((struct HttpServerData *)req->user_ctx)->scratch);
-
-        int retries = 0;
-        while (remaining > 0) {
-            received = httpd_req_recv(req, httpBuffer, std::min<size_t>(remaining, WEBSERVER_SCRATCH_BUFSIZE));
-
-            if (received <= 0) {
-                if (received == HTTPD_SOCK_ERR_TIMEOUT && ++retries < 5) {
-                    vTaskDelay(pdMS_TO_TICKS(10));
-                    continue;
-                }
-                LogFile.writeToFile(ESP_LOG_ERROR, TAG, "setConfig: Config reception failed");
-                httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "E92: Config reception failed");
-                return ESP_FAIL;
-            }
-
-            memcpy(jsonBuffer + offset, httpBuffer, received);
-            offset += received;
-            remaining -= received;
-        }
         jsonBuffer[offset] = '\0';
 
         // Activates TLS PSRAM arena for this thread only
@@ -2769,7 +2783,7 @@ esp_err_t ConfigClass::getConfigRequest(httpd_req_t *req)
         return ESP_FAIL;
     }
 
-    CfgMutexGuard lock(cfgMutex, pdMS_TO_TICKS(5000));
+    CfgMutexGuard lock(cfgMutex, pdMS_TO_TICKS(10000));
     if (!lock.isAcquired()) {
         LogFile.writeToFile(ESP_LOG_ERROR, TAG, "Failed to acquire cfgMutex - timeout expired");
         httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "E90: System busy");
@@ -2838,7 +2852,7 @@ bool ConfigClass::persistConfig()
         return false;
     }
 
-    CfgMutexGuard lock(cfgMutex, pdMS_TO_TICKS(5000));
+    CfgMutexGuard lock(cfgMutex, pdMS_TO_TICKS(10000));
     if (!lock.isAcquired()) {
         LogFile.writeToFile(ESP_LOG_ERROR, TAG, "Failed to acquire cfgMutex - timeout expired");
         return false;

--- a/code/components/config_handling/configClass.cpp
+++ b/code/components/config_handling/configClass.cpp
@@ -152,7 +152,7 @@ void ConfigClass::readConfigFile(bool unityTest, std::string unityTestData)
 //**************************************************************************************************
 // Helper: Parse JSON string from file using Thread-Local PSRAM arena and extract into class state
 //**************************************************************************************************
-bool ConfigClass::parseJsonFromFile(const char *jsonStr, bool isUnityTest)
+bool ConfigClass::parseJsonFromFile(const char *jsonStr, bool unityTest)
 {
     if (!cfgMutex || !cJsonObjectBuffer) {
         return false;
@@ -163,29 +163,55 @@ bool ConfigClass::parseJsonFromFile(const char *jsonStr, bool isUnityTest)
         return false;
     }
 
-    CfgMutexGuard lock(cfgMutex, pdMS_TO_TICKS(10000));
+    CfgMutexGuard lock(cfgMutex, pdMS_TO_TICKS(5000));
     if (!lock.isAcquired()) {
         LogFile.writeToFile(ESP_LOG_ERROR, TAG, "parseJsonFromFile: Failed to acquire cfgMutex: Timeout");
         return false;
     }
 
-    // Activates TLS PSRAM arena
-    cJsonPsramArena jsonArena(cJsonObjectBuffer, CONFIG_HANDLING_CJSON_OBJECT_BUFFER_SIZE);
+    // Parse JSON and update internal configuration
+    {
+        cJsonPsramArena jsonArena(cJsonObjectBuffer, CONFIG_HANDLING_CJSON_OBJECT_BUFFER_SIZE);
 
-    // Parse JSON payload (allocates AST inside cJsonObjectBuffer)
-    cJsonObject = cJSON_Parse(jsonStr);
-    if (cJsonObject == NULL) {
-        const char *errPtr = cJSON_GetErrorPtr();
-        if (errPtr != NULL) {
-            LogFile.writeToFile(ESP_LOG_ERROR, TAG, "parseJsonFromFile: Parse error near: %.20s", errPtr);
+        cJsonObject = cJSON_Parse(jsonStr);
+        if (cJsonObject != nullptr) {
+            if (parseConfig(true, unityTest) != ESP_OK) {
+                LogFile.writeToFile(ESP_LOG_ERROR, TAG, "parseJsonFromFile: Failed to update configuration");
+                return false;
+            }
         }
         else {
-            LogFile.writeToFile(ESP_LOG_ERROR, TAG, "parseJsonFromFile: Parse failed (null or invalid payload)");
+            const char *errPtr = cJSON_GetErrorPtr();
+            if (errPtr != nullptr) {
+                char errorMsg[96] = {};
+                snprintf(errorMsg, sizeof(errorMsg), "parseJsonFromFile: Parse JSON error near: %.20s", errPtr);
+                LogFile.writeToFile(ESP_LOG_ERROR, TAG, std::string(errorMsg));
+            }
+            else {
+                LogFile.writeToFile(ESP_LOG_ERROR, TAG, "parseJsonFromFile: Parse JSON failed");
+            }
+            return false;
         }
+    } // Free parse arena
+
+    // Serialize updated configuration
+    {
+        cJsonPsramArena jsonArena(cJsonObjectBuffer, CONFIG_HANDLING_CJSON_OBJECT_BUFFER_SIZE);
+
+        if (serializeConfig(unityTest) != ESP_OK) {
+            LogFile.writeToFile(ESP_LOG_ERROR, TAG, "parseJsonFromFile: Failed to serialize configuration");
+            return false;
+        }
+    } // Free serialization arena
+
+
+    // Persist updated configuration
+    if (!unityTest && writeConfigFile() != ESP_OK) {
+        LogFile.writeToFile(ESP_LOG_ERROR, TAG, "parseJsonFromFile: Failed to write configuration file");
         return false;
     }
 
-    return (parseConfig(true, isUnityTest) == ESP_OK);
+    return true;
 }
 
 
@@ -1663,24 +1689,14 @@ esp_err_t ConfigClass::parseConfig(bool init, bool unityTest)
         cfgDataTemp.sectionWebUi.AutoRefresh.dataGraphPage.refreshTime = std::max(objEl->valueint, 1);
     }
 
-    // Check for configuration migration
-    if (!unityTest) {
-        migrateConfiguration(cJsonObject);
-    }
-
-    // Init active config struct with latest configuration data
     if (init) {
+        // Check for configuration migration
+        if (!unityTest) {
+            migrateConfiguration(cJsonObject);
+        }
+
+        // Init active config struct with latest configuration data
         cfgData = cfgDataTemp;
-    }
-
-    // Serialize config to provide feedback and/or store to JSON file
-    if (serializeConfig(unityTest) != ESP_OK) {
-        return ESP_FAIL;
-    }
-
-    // Write config file
-    if (!unityTest) {
-        return writeConfigFile();
     }
 
     return ESP_OK;
@@ -2621,7 +2637,7 @@ bool ConfigClass::persistConfig()
         return false;
     }
 
-    CfgMutexGuard lock(cfgMutex, pdMS_TO_TICKS(10000));
+    CfgMutexGuard lock(cfgMutex, pdMS_TO_TICKS(5000));
     if (!lock.isAcquired()) {
         LogFile.writeToFile(ESP_LOG_ERROR, TAG, "persistConfig: Failed to acquire cfgMutex - Timeout");
         return false;
@@ -2663,185 +2679,6 @@ esp_err_t ConfigClass::writeConfigFile()
     copyFile(CONFIG_PERSISTENCE_FILE, CONFIG_PERSISTENCE_FILE_FALLBACK);
 
     return ESP_OK;
-}
-
-
-//**************************************************************************************************
-// Retrieve actual configuration via REST API (JSON notation)
-//**************************************************************************************************
-esp_err_t ConfigClass::getConfigRequest(httpd_req_t *req)
-{
-    if (!cJsonObjectBuffer || !jsonBuffer || !cfgMutex || !req) {
-        return ESP_FAIL;
-    }
-
-    if (req->user_ctx == nullptr) {
-        httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "Internal Server Error: Server context is null");
-        return ESP_FAIL;
-    }
-
-    char *httpBuffer = static_cast<char *>(((struct HttpServerData *)req->user_ctx)->scratch);
-
-    if (httpBuffer == nullptr) {
-        httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "Internal Server Error: Scratch buffer is null");
-        return ESP_FAIL;
-    }
-
-    esp_err_t retVal = ESP_FAIL;
-
-    // Lock mutex guard (RAII)
-    {
-        CfgMutexGuard lock(cfgMutex, pdMS_TO_TICKS(10000));
-        if (!lock.isAcquired()) {
-            httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "Internal Server Error: Failed to acquire cfgMutex - Timeout");
-            return ESP_FAIL;
-        }
-
-        // Activates TLS PSRAM arena
-        cJsonPsramArena jsonArena(cJsonObjectBuffer, CONFIG_HANDLING_CJSON_OBJECT_BUFFER_SIZE);
-
-        // Serialize config data into jsonBuffer
-        retVal = serializeConfig();
-        if (retVal == ESP_OK) {
-            const size_t length = strlen(jsonBuffer);
-
-            if (length < WEBSERVER_SCRATCH_BUFSIZE) {
-                memcpy(httpBuffer, jsonBuffer, length + 1);
-            }
-            else {
-                retVal = ESP_ERR_NO_MEM;
-            }
-        }
-    } // Release mutex guard (RAII)
-
-    if (retVal == ESP_OK) {
-        httpd_resp_set_type(req, "application/json");
-        return httpd_resp_send(req, httpBuffer, HTTPD_RESP_USE_STRLEN);
-    }
-
-    httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "Failed to serialize configuration");
-    return retVal;
-}
-
-
-//**************************************************************************************************
-// Update configuration via REST API (JSON notation)
-//**************************************************************************************************
-esp_err_t ConfigClass::setConfigRequest(httpd_req_t *req)
-{
-    if (!cJsonObjectBuffer || !jsonBuffer || !cfgMutex || !req) {
-        return ESP_FAIL;
-    }
-
-    if (req->user_ctx == nullptr) {
-        httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "Internal Server Error: Server context is null");
-        return ESP_FAIL;
-    }
-
-    char *httpBuffer = static_cast<char *>(((struct HttpServerData *)req->user_ctx)->scratch);
-
-    if (httpBuffer == nullptr) {
-        httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "Internal Server Error: Scratch buffer is null");
-        return ESP_FAIL;
-    }
-
-    // Scratch buffer must accommodate the complete payload plus the terminating '\0'
-    if (req->content_len >= WEBSERVER_SCRATCH_BUFSIZE) {
-        httpd_resp_set_type(req, "application/json");
-        httpd_resp_send_err(req, HTTPD_413_CONTENT_TOO_LARGE, "Payload exceeds maximum buffer size");
-        return ESP_FAIL;
-    }
-
-    httpd_resp_set_type(req, "application/json");
-
-    size_t remaining = req->content_len;
-    size_t offset = 0;
-    uint8_t retries = 0;
-
-    // Receive the complete request into the webserver scratch buffer
-    while (remaining > 0) {
-        const int received = httpd_req_recv(req, httpBuffer + offset, remaining);
-
-        if (received <= 0) {
-            if (received == HTTPD_SOCK_ERR_TIMEOUT && ++retries < 5) {
-                vTaskDelay(pdMS_TO_TICKS(10));
-                continue;
-            }
-
-            httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "Config reception failed");
-            return ESP_FAIL;
-        }
-
-        retries = 0;
-        offset += received;
-        remaining -= received;
-    }
-
-    httpBuffer[offset] = '\0';
-
-    esp_err_t retVal = ESP_OK;
-    bool parseFailed = false;
-    char errorMsg[64] = "Failed to update configuration";
-
-    // Lock mutex guard (RAII)
-    {
-        CfgMutexGuard lock(cfgMutex, pdMS_TO_TICKS(10000));
-        if (!lock.isAcquired()) {
-            httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "Internal Server Error: Failed to acquire cfgMutex - Timeout");
-            return ESP_FAIL;
-        }
-
-        // Copy the complete request atomically
-        memcpy(jsonBuffer, httpBuffer, offset + 1);
-
-        // Activates TLS PSRAM arena
-        cJsonPsramArena jsonArena(cJsonObjectBuffer, CONFIG_HANDLING_CJSON_OBJECT_BUFFER_SIZE);
-
-        // Parse JSON payload (allocates AST inside cJsonObjectBuffer)
-        cJsonObject = cJSON_Parse(jsonBuffer);
-
-        if (cJsonObject == NULL) {
-            const char *errPtr = cJSON_GetErrorPtr();
-            if (errPtr != NULL) {
-                snprintf(errorMsg, sizeof(errorMsg), "Parse JSON error near: %.20s", errPtr);
-            }
-            else {
-                snprintf(errorMsg, sizeof(errorMsg), "Parse JSON failed");
-            }
-            parseFailed = true;
-        }
-
-        if (retVal == ESP_OK && !parseFailed) {
-            retVal = parseConfig();
-
-            if (retVal == ESP_OK) {
-                const size_t length = strlen(jsonBuffer);
-
-                if (length < WEBSERVER_SCRATCH_BUFSIZE) {
-                    memcpy(httpBuffer, jsonBuffer, length + 1);
-                }
-                else {
-                    snprintf(errorMsg, sizeof(errorMsg), "JSON size exceeds buffer");
-                    retVal = ESP_ERR_NO_MEM;
-                }
-            }
-        }
-    } // Release mutex guard (RAII)
-
-    // HTTP response
-    if (retVal == ESP_OK) {
-        httpd_resp_set_type(req, "application/json");
-        return httpd_resp_send(req, httpBuffer, HTTPD_RESP_USE_STRLEN);
-    }
-
-    // Error return
-    if (parseFailed) {
-        httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST, errorMsg);
-    }
-    else {
-        httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, errorMsg);
-    }
-    return retVal;
 }
 
 
@@ -3015,6 +2852,197 @@ void ConfigClass::validateStructure(std::string &structureName)
     if (!structureName.empty() && structureName.back() == '/') {
         structureName.pop_back();
     }
+}
+
+
+//**************************************************************************************************
+// Retrieve actual configuration via REST API (JSON notation)
+//**************************************************************************************************
+esp_err_t ConfigClass::getConfigRequest(httpd_req_t *req)
+{
+    if (!cJsonObjectBuffer || !jsonBuffer || !cfgMutex || !req) {
+        return ESP_FAIL;
+    }
+
+    if (req->user_ctx == nullptr) {
+        httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "Internal Server Error: Server context is null");
+        return ESP_FAIL;
+    }
+
+    char *httpBuffer = static_cast<char *>(((struct HttpServerData *)req->user_ctx)->scratch);
+
+    if (httpBuffer == nullptr) {
+        httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "Internal Server Error: Scratch buffer is null");
+        return ESP_FAIL;
+    }
+
+    esp_err_t retVal = ESP_FAIL;
+
+    // Lock mutex guard (RAII)
+    {
+        CfgMutexGuard lock(cfgMutex, pdMS_TO_TICKS(5000));
+        if (!lock.isAcquired()) {
+            httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "Internal Server Error: Failed to acquire cfgMutex - Timeout");
+            return ESP_FAIL;
+        }
+
+        // Activates TLS PSRAM arena
+        cJsonPsramArena jsonArena(cJsonObjectBuffer, CONFIG_HANDLING_CJSON_OBJECT_BUFFER_SIZE);
+
+        // Serialize config data into jsonBuffer
+        retVal = serializeConfig();
+        if (retVal == ESP_OK) {
+            const size_t length = strlen(jsonBuffer);
+
+            if (length < WEBSERVER_SCRATCH_BUFSIZE) {
+                memcpy(httpBuffer, jsonBuffer, length + 1);
+            }
+            else {
+                retVal = ESP_ERR_NO_MEM;
+            }
+        }
+    } // Release mutex guard (RAII)
+
+    if (retVal == ESP_OK) {
+        httpd_resp_set_type(req, "application/json");
+        return httpd_resp_send(req, httpBuffer, HTTPD_RESP_USE_STRLEN);
+    }
+
+    httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "Failed to serialize configuration");
+    return retVal;
+}
+
+
+//**************************************************************************************************
+// Update configuration via REST API (JSON notation)
+//**************************************************************************************************
+//**************************************************************************************************
+// Update configuration via REST API (JSON notation)
+//**************************************************************************************************
+esp_err_t ConfigClass::setConfigRequest(httpd_req_t *req)
+{
+    if (!cJsonObjectBuffer || !jsonBuffer || !cfgMutex || !req) {
+        return ESP_FAIL;
+    }
+
+    if (req->user_ctx == nullptr) {
+        httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "Internal Server Error: Server context is null");
+        return ESP_FAIL;
+    }
+
+    char *httpBuffer = static_cast<char *>(((struct HttpServerData *)req->user_ctx)->scratch);
+
+    if (httpBuffer == nullptr) {
+        httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "Internal Server Error: Scratch buffer is null");
+        return ESP_FAIL;
+    }
+
+    // Scratch buffer must accommodate the complete payload plus '\0'
+    if (req->content_len >= WEBSERVER_SCRATCH_BUFSIZE) {
+        httpd_resp_set_type(req, "application/json");
+        httpd_resp_send_err(req, HTTPD_413_CONTENT_TOO_LARGE, "Payload exceeds maximum buffer size");
+        return ESP_FAIL;
+    }
+
+    httpd_resp_set_type(req, "application/json");
+
+    // Receive the complete request into the webserver scratch buffer
+    size_t remaining = req->content_len;
+    size_t offset = 0;
+    uint8_t retries = 0;
+
+    while (remaining > 0) {
+        const int received = httpd_req_recv(req, httpBuffer + offset, remaining);
+
+        if (received <= 0) {
+            if (received == HTTPD_SOCK_ERR_TIMEOUT && ++retries < 5) {
+                vTaskDelay(pdMS_TO_TICKS(10));
+                continue;
+            }
+
+            httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "Config reception failed");
+            return ESP_FAIL;
+        }
+
+        retries = 0;
+        offset += static_cast<size_t>(received);
+        remaining -= static_cast<size_t>(received);
+    }
+
+    httpBuffer[offset] = '\0';
+
+    esp_err_t retVal = ESP_OK;
+    httpd_err_code_t httpError = HTTPD_500_INTERNAL_SERVER_ERROR;
+    char errorMsg[64] = "Failed to update configuration";
+
+    // Keep cfgMutex locked for the complete configuration update
+    {
+        CfgMutexGuard lock(cfgMutex, pdMS_TO_TICKS(5000));
+
+        if (!lock.isAcquired()) {
+            httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "Internal Server Error: Failed to acquire cfgMutex - Timeout");
+            return ESP_FAIL;
+        }
+
+        // Copy the complete request atomically
+        memcpy(jsonBuffer, httpBuffer, offset + 1);
+
+        // Parse JSON and update internal configuration
+        {
+            cJsonPsramArena jsonArena(cJsonObjectBuffer, CONFIG_HANDLING_CJSON_OBJECT_BUFFER_SIZE);
+
+            cJsonObject = cJSON_Parse(jsonBuffer);
+
+            if (cJsonObject == nullptr) {
+                const char *errPtr = cJSON_GetErrorPtr();
+
+                if (errPtr != nullptr) {
+                    snprintf(errorMsg, sizeof(errorMsg), "Parse JSON error near: %.20s", errPtr);
+                }
+                else {
+                    snprintf(errorMsg, sizeof(errorMsg), "Parse JSON failed");
+                }
+
+                httpError = HTTPD_400_BAD_REQUEST;
+                retVal = ESP_ERR_INVALID_ARG;
+            }
+            else {
+                retVal = parseConfig();
+            }
+        } // Free parse arena
+
+        // Serialize updated configuration
+        if (retVal == ESP_OK) {
+            cJsonPsramArena jsonArena(cJsonObjectBuffer, CONFIG_HANDLING_CJSON_OBJECT_BUFFER_SIZE);
+
+            retVal = serializeConfig();
+
+            if (retVal == ESP_OK) {
+                const size_t length = strlen(jsonBuffer);
+
+                if (length < WEBSERVER_SCRATCH_BUFSIZE) {
+                    memcpy(httpBuffer, jsonBuffer, length + 1);
+                }
+                else {
+                    snprintf(errorMsg, sizeof(errorMsg), "JSON size exceeds buffer");
+                    retVal = ESP_ERR_NO_MEM;
+                }
+            }
+        } // Free serialization arena
+
+        // Persist updated configuration
+        if (retVal == ESP_OK) {
+            retVal = writeConfigFile();
+        }
+    } // Release cfgMutex
+
+    // HTTP response
+    if (retVal == ESP_OK) {
+        return httpd_resp_send(req, httpBuffer, HTTPD_RESP_USE_STRLEN);
+    }
+
+    httpd_resp_send_err(req, httpError, errorMsg);
+    return retVal;
 }
 
 

--- a/code/components/config_handling/configClass.cpp
+++ b/code/components/config_handling/configClass.cpp
@@ -185,14 +185,14 @@ bool ConfigClass::parseJsonFromFile(const char *jsonStr, bool isUnityTest)
         return false;
     }
 
-    return (parseConfig(nullptr, true, isUnityTest) == ESP_OK);
+    return (parseConfig(true, isUnityTest) == ESP_OK);
 }
 
 
 //**************************************************************************************************
 // Parse JSON string and save to internal struct
 //**************************************************************************************************
-esp_err_t ConfigClass::parseConfig(httpd_req_t *req, bool init, bool unityTest)
+esp_err_t ConfigClass::parseConfig(bool init, bool unityTest)
 {
     // Config Version
     // ***************************
@@ -1678,13 +1678,7 @@ esp_err_t ConfigClass::parseConfig(httpd_req_t *req, bool init, bool unityTest)
         return ESP_FAIL;
     }
 
-    // Response actual config to HTTP POST request
-    if (req) {
-        httpd_resp_set_status(req, HTTPD_200);
-        httpd_resp_send(req, jsonBuffer, strlen(jsonBuffer));
-    }
-
-    // Only for testing purpose
+    // Write config file
     if (!unityTest) {
         return writeConfigFile();
     }
@@ -2677,11 +2671,11 @@ esp_err_t ConfigClass::writeConfigFile()
 //**************************************************************************************************
 esp_err_t ConfigClass::getConfigRequest(httpd_req_t *req)
 {
-    if (!cJsonObjectBuffer || !jsonBuffer || !cfgMutex) {
+    if (!cJsonObjectBuffer || !jsonBuffer || !cfgMutex || !req) {
         return ESP_FAIL;
     }
 
-    if (req == nullptr || req->user_ctx == nullptr) {
+    if (req->user_ctx == nullptr) {
         httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "Internal Server Error: Server context is null");
         return ESP_FAIL;
     }
@@ -2708,15 +2702,14 @@ esp_err_t ConfigClass::getConfigRequest(httpd_req_t *req)
 
         // Serialize config data into jsonBuffer
         retVal = serializeConfig();
-
         if (retVal == ESP_OK) {
             const size_t length = strlen(jsonBuffer);
 
-            if (length >= WEBSERVER_SCRATCH_BUFSIZE) {
-                retVal = ESP_ERR_NO_MEM;
+            if (length < WEBSERVER_SCRATCH_BUFSIZE) {
+                memcpy(httpBuffer, jsonBuffer, length + 1);
             }
             else {
-                memcpy(httpBuffer, jsonBuffer, length + 1);
+                retVal = ESP_ERR_NO_MEM;
             }
         }
     } // Release mutex guard (RAII)
@@ -2736,11 +2729,11 @@ esp_err_t ConfigClass::getConfigRequest(httpd_req_t *req)
 //**************************************************************************************************
 esp_err_t ConfigClass::setConfigRequest(httpd_req_t *req)
 {
-    if (!cJsonObjectBuffer || !jsonBuffer || !cfgMutex) {
+    if (!cJsonObjectBuffer || !jsonBuffer || !cfgMutex || !req) {
         return ESP_FAIL;
     }
 
-    if (req == nullptr || req->user_ctx == nullptr) {
+    if (req->user_ctx == nullptr) {
         httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "Internal Server Error: Server context is null");
         return ESP_FAIL;
     }
@@ -2786,7 +2779,9 @@ esp_err_t ConfigClass::setConfigRequest(httpd_req_t *req)
 
     httpBuffer[offset] = '\0';
 
-    esp_err_t retVal = ESP_FAIL;
+    esp_err_t retVal = ESP_OK;
+    bool parseFailed = false;
+    char errorMsg[64] = "Failed to update configuration";
 
     // Lock mutex guard (RAII)
     {
@@ -2807,23 +2802,45 @@ esp_err_t ConfigClass::setConfigRequest(httpd_req_t *req)
 
         if (cJsonObject == NULL) {
             const char *errPtr = cJSON_GetErrorPtr();
-
             if (errPtr != NULL) {
-                char errMsg[64];
-                snprintf(errMsg, sizeof(errMsg), "Parse JSON error near: %.20s", errPtr);
-
-                httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, errMsg);
+                snprintf(errorMsg, sizeof(errorMsg), "Parse JSON error near: %.20s", errPtr);
             }
             else {
-                httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "Parse JSON failed");
+                snprintf(errorMsg, sizeof(errorMsg), "Parse JSON failed");
             }
-
-            return ESP_FAIL;
+            parseFailed = true;
         }
 
-        retVal = parseConfig(req);
+        if (retVal == ESP_OK && !parseFailed) {
+            retVal = parseConfig();
+
+            if (retVal == ESP_OK) {
+                const size_t length = strlen(jsonBuffer);
+
+                if (length < WEBSERVER_SCRATCH_BUFSIZE) {
+                    memcpy(httpBuffer, jsonBuffer, length + 1);
+                }
+                else {
+                    snprintf(errorMsg, sizeof(errorMsg), "JSON size exceeds buffer");
+                    retVal = ESP_ERR_NO_MEM;
+                }
+            }
+        }
     } // Release mutex guard (RAII)
 
+    // HTTP response
+    if (retVal == ESP_OK) {
+        httpd_resp_set_type(req, "application/json");
+        return httpd_resp_send(req, httpBuffer, HTTPD_RESP_USE_STRLEN);
+    }
+
+    // Error return
+    if (parseFailed) {
+        httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST, errorMsg);
+    }
+    else {
+        httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, errorMsg);
+    }
     return retVal;
 }
 

--- a/code/components/config_handling/configClass.cpp
+++ b/code/components/config_handling/configClass.cpp
@@ -35,15 +35,15 @@ static bool isValidIpAddress(const char *ipAddress)
 
 ConfigClass::ConfigClass()
 {
-    static_assert(WEBSERVER_SCRATCH_BUFSIZE >= CONFIG_HANDLING_CJSON_STRING_BUFFER_SIZE,
-                  "Webserver scratch buffer must be at least as large as the config JSON string buffer");
-
     // Create a FreeRTOS mutex semaphore to protect JSON buffer & global hooks
     cfgMutex = xSemaphoreCreateMutex();
 
     if (cfgMutex == nullptr) {
         LogFile.writeToFile(ESP_LOG_ERROR, TAG, "ConfigClass: Failed to create mutex");
     }
+
+    static_assert(WEBSERVER_SCRATCH_BUFSIZE >= CONFIG_HANDLING_CJSON_STRING_BUFFER_SIZE,
+                  "Webserver scratch buffer must be at least as large as the config JSON string buffer");
 
     // Use preallocted buffer to avoid fragmentation and reduce internal RAM usage using SPIRAM
     cJsonObjectBuffer = (uint8_t *)heap_caps_calloc(1, CONFIG_HANDLING_CJSON_OBJECT_BUFFER_SIZE, MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
@@ -2909,9 +2909,6 @@ esp_err_t ConfigClass::getConfigRequest(httpd_req_t *req)
 }
 
 
-//**************************************************************************************************
-// Update configuration via REST API (JSON notation)
-//**************************************************************************************************
 //**************************************************************************************************
 // Update configuration via REST API (JSON notation)
 //**************************************************************************************************

--- a/code/components/config_handling/configClass.cpp
+++ b/code/components/config_handling/configClass.cpp
@@ -204,7 +204,6 @@ bool ConfigClass::parseJsonFromFile(const char *jsonStr, bool unityTest)
         }
     } // Free serialization arena
 
-
     // Persist updated configuration
     if (!unityTest && writeConfigFile() != ESP_OK) {
         LogFile.writeToFile(ESP_LOG_ERROR, TAG, "parseJsonFromFile: Failed to write configuration file");
@@ -1699,6 +1698,10 @@ esp_err_t ConfigClass::parseConfig(bool init, bool unityTest)
         cfgData = cfgDataTemp;
     }
 
+    // Cleanup root cJSON structure
+    cJSON_Delete(cJsonObject);
+    cJsonObject = NULL;
+
     return ESP_OK;
 }
 
@@ -1708,11 +1711,6 @@ esp_err_t ConfigClass::parseConfig(bool init, bool unityTest)
 //**************************************************************************************************
 esp_err_t ConfigClass::serializeConfig(bool unityTest)
 {
-    if (cJsonObject != NULL) {
-        cJSON_Delete(cJsonObject);
-        cJsonObject = NULL;
-    }
-
     cJsonObject = cJSON_CreateObject();
     if (cJsonObject == NULL) {
         LogFile.writeToFile(ESP_LOG_ERROR, TAG, "serializeConfig: Error while creating JSON object");

--- a/code/components/config_handling/configClass.cpp
+++ b/code/components/config_handling/configClass.cpp
@@ -33,57 +33,11 @@ static bool isValidIpAddress(const char *ipAddress)
 }
 
 
-template <typename ConfigDataType> inline void clearConfigDataStructure(ConfigDataType &data)
-{
-    // Clear and release outer sequence vectors
-    data.sectionNumberSequences.sequence.clear();
-    decltype(data.sectionNumberSequences.sequence)().swap(data.sectionNumberSequences.sequence);
-
-    // Clear inner and outer vectors for Digit
-    for (auto &seq : data.sectionDigit.sequence) {
-        seq.roi.clear();
-        decltype(seq.roi)().swap(seq.roi);
-    }
-    data.sectionDigit.sequence.clear();
-    decltype(data.sectionDigit.sequence)().swap(data.sectionDigit.sequence);
-
-    // Clear inner and outer vectors for Analog
-    for (auto &seq : data.sectionAnalog.sequence) {
-        seq.roi.clear();
-        decltype(seq.roi)().swap(seq.roi);
-    }
-    data.sectionAnalog.sequence.clear();
-    decltype(data.sectionAnalog.sequence)().swap(data.sectionAnalog.sequence);
-
-    // Clear remaining sections
-    data.sectionPostProcessing.sequence.clear();
-    decltype(data.sectionPostProcessing.sequence)().swap(data.sectionPostProcessing.sequence);
-
-    data.sectionInfluxDBv1.sequence.clear();
-    decltype(data.sectionInfluxDBv1.sequence)().swap(data.sectionInfluxDBv1.sequence);
-
-    data.sectionInfluxDBv2.sequence.clear();
-    decltype(data.sectionInfluxDBv2.sequence)().swap(data.sectionInfluxDBv2.sequence);
-
-    data.sectionGpio.gpioPin.clear();
-    decltype(data.sectionGpio.gpioPin)().swap(data.sectionGpio.gpioPin);
-}
-
-
-void ConfigClass::clearCfgDataTemp()
-{
-    clearConfigDataStructure(cfgDataTemp);
-}
-
-
-void ConfigClass::clearCfgData()
-{
-    clearConfigDataStructure(cfgData);
-}
-
-
 ConfigClass::ConfigClass()
 {
+    static_assert(WEBSERVER_SCRATCH_BUFSIZE >= CONFIG_HANDLING_CJSON_STRING_BUFFER_SIZE,
+                  "Webserver scratch buffer must be at least as large as the config JSON string buffer");
+
     // Create a FreeRTOS mutex semaphore to protect JSON buffer & global hooks
     cfgMutex = xSemaphoreCreateMutex();
 
@@ -92,8 +46,8 @@ ConfigClass::ConfigClass()
     }
 
     // Use preallocted buffer to avoid fragmentation and reduce internal RAM usage using SPIRAM
-    cJsonObjectBuffer = (uint8_t *)heap_caps_calloc(1, CONFIG_HANDLING_PREALLOCATED_BUFFER_SIZE, MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
-    jsonBuffer = (char *)heap_caps_calloc(1, CONFIG_HANDLING_PREALLOCATED_BUFFER_SIZE, MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
+    cJsonObjectBuffer = (uint8_t *)heap_caps_calloc(1, CONFIG_HANDLING_CJSON_OBJECT_BUFFER_SIZE, MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
+    jsonBuffer = (char *)heap_caps_calloc(1, CONFIG_HANDLING_CJSON_STRING_BUFFER_SIZE, MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
 
     if (!cJsonObjectBuffer || !jsonBuffer) {
         LogFile.writeToFile(ESP_LOG_ERROR, TAG, "ConfigClass: Failed to allocate PSRAM buffers");
@@ -107,9 +61,6 @@ ConfigClass::ConfigClass()
             jsonBuffer = nullptr;
         }
     }
-
-    static_assert(WEBSERVER_SCRATCH_BUFSIZE >= CONFIG_HANDLING_PREALLOCATED_BUFFER_SIZE,
-                  "Webserver scratch buffer must be at least as large as the config JSON buffer");
 
     initCjsonHooks();
 }
@@ -134,53 +85,6 @@ ConfigClass::~ConfigClass()
         vSemaphoreDelete(cfgMutex);
         cfgMutex = nullptr;
     }
-}
-
-
-//**************************************************************************************************
-// Helper: Parse JSON string from file using Thread-Local PSRAM arena and extract into class state
-//**************************************************************************************************
-bool ConfigClass::parseJsonFromFile(const char *jsonStr, bool isUnityTest)
-{
-    if (!cfgMutex || !cJsonObjectBuffer) {
-        return false;
-    }
-
-    if (jsonStr == nullptr) {
-        LogFile.writeToFile(ESP_LOG_ERROR, TAG, "parseJsonFromFile: JSON input is null");
-        return false;
-    }
-
-    CfgMutexGuard lock(cfgMutex, pdMS_TO_TICKS(10000));
-    if (!lock.isAcquired()) {
-        LogFile.writeToFile(ESP_LOG_ERROR, TAG, "parseJsonFromFile: Failed to acquire cfgMutex: Timeout");
-        return false;
-    }
-
-    // Activates TLS PSRAM arena for this thread only (Auto-clears on scope exit)
-    cJsonPsramArena jsonArena(cJsonObjectBuffer, CONFIG_HANDLING_PREALLOCATED_BUFFER_SIZE);
-
-    // Parse JSON payload (allocates AST inside cJsonObjectBuffer)
-    cJsonObject = cJSON_Parse(jsonStr);
-    if (cJsonObject == nullptr) {
-        const char *errPtr = cJSON_GetErrorPtr();
-        if (errPtr != nullptr) {
-            LogFile.writeToFile(ESP_LOG_ERROR, TAG, "parseJsonFromFile: Parse error near: %.20s", errPtr);
-        }
-        else {
-            LogFile.writeToFile(ESP_LOG_ERROR, TAG, "parseJsonFromFile: Parse failed (null or invalid payload)");
-        }
-        return false;
-    }
-
-    // Extract configuration fields into class structures
-    bool retVal = (parseConfig(nullptr, true, isUnityTest) == ESP_OK);
-
-    // Delete JSON AST while TLS arena is still active
-    cJSON_Delete(cJsonObject);
-    cJsonObject = nullptr;
-
-    return retVal;
 }
 
 
@@ -246,103 +150,42 @@ void ConfigClass::readConfigFile(bool unityTest, std::string unityTestData)
 
 
 //**************************************************************************************************
-// Update configuration via REST API (JSON notation)
+// Helper: Parse JSON string from file using Thread-Local PSRAM arena and extract into class state
 //**************************************************************************************************
-esp_err_t ConfigClass::setConfigRequest(httpd_req_t *req)
+bool ConfigClass::parseJsonFromFile(const char *jsonStr, bool isUnityTest)
 {
-    if (!cJsonObjectBuffer || !jsonBuffer || !cfgMutex) {
-        return ESP_FAIL;
+    if (!cfgMutex || !cJsonObjectBuffer) {
+        return false;
     }
 
-    if (req == nullptr || req->user_ctx == nullptr) {
-        httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "Internal Server Error: Server context is null");
-        return ESP_FAIL;
+    if (jsonStr == NULL) {
+        LogFile.writeToFile(ESP_LOG_ERROR, TAG, "parseJsonFromFile: JSON input is null");
+        return false;
     }
 
-    char *httpBuffer = static_cast<char *>(((struct HttpServerData *)req->user_ctx)->scratch);
-
-    if (httpBuffer == nullptr) {
-        httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "Internal Server Error: Scratch buffer is null");
-        return ESP_FAIL;
+    CfgMutexGuard lock(cfgMutex, pdMS_TO_TICKS(10000));
+    if (!lock.isAcquired()) {
+        LogFile.writeToFile(ESP_LOG_ERROR, TAG, "parseJsonFromFile: Failed to acquire cfgMutex: Timeout");
+        return false;
     }
 
-    // Scratch buffer must accommodate the complete payload plus the terminating '\0'
-    if (req->content_len >= WEBSERVER_SCRATCH_BUFSIZE) {
-        httpd_resp_set_type(req, "application/json");
-        httpd_resp_send_err(req, HTTPD_413_CONTENT_TOO_LARGE, "Payload exceeds maximum buffer size");
-        return ESP_FAIL;
-    }
+    // Activates TLS PSRAM arena
+    cJsonPsramArena jsonArena(cJsonObjectBuffer, CONFIG_HANDLING_CJSON_OBJECT_BUFFER_SIZE);
 
-    httpd_resp_set_type(req, "application/json");
-
-    size_t remaining = req->content_len;
-    size_t offset = 0;
-    uint8_t retries = 0;
-
-    // Receive the complete request into the webserver scratch buffer
-    while (remaining > 0) {
-        const int received = httpd_req_recv(req, httpBuffer + offset, remaining);
-
-        if (received <= 0) {
-            if (received == HTTPD_SOCK_ERR_TIMEOUT && ++retries < 5) {
-                vTaskDelay(pdMS_TO_TICKS(10));
-                continue;
-            }
-
-            httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "Config reception failed");
-            return ESP_FAIL;
+    // Parse JSON payload (allocates AST inside cJsonObjectBuffer)
+    cJsonObject = cJSON_Parse(jsonStr);
+    if (cJsonObject == NULL) {
+        const char *errPtr = cJSON_GetErrorPtr();
+        if (errPtr != NULL) {
+            LogFile.writeToFile(ESP_LOG_ERROR, TAG, "parseJsonFromFile: Parse error near: %.20s", errPtr);
         }
-
-        retries = 0;
-        offset += received;
-        remaining -= received;
+        else {
+            LogFile.writeToFile(ESP_LOG_ERROR, TAG, "parseJsonFromFile: Parse failed (null or invalid payload)");
+        }
+        return false;
     }
 
-    httpBuffer[offset] = '\0';
-
-    esp_err_t retVal = ESP_FAIL;
-
-    {
-        CfgMutexGuard lock(cfgMutex, pdMS_TO_TICKS(10000));
-        if (!lock.isAcquired()) {
-            httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "Internal Server Error: Failed to acquire cfgMutex - Timeout");
-            return ESP_FAIL;
-        }
-
-        // Copy the complete request atomically with respect to other configuration users
-        memcpy(jsonBuffer, httpBuffer, offset + 1);
-
-        // Activates TLS PSRAM arena for this thread only.
-        cJsonPsramArena jsonArena(cJsonObjectBuffer, CONFIG_HANDLING_PREALLOCATED_BUFFER_SIZE);
-
-        // Parse JSON payload (allocates AST inside cJsonObjectBuffer).
-        cJsonObject = cJSON_Parse(jsonBuffer);
-
-        if (cJsonObject == nullptr) {
-            const char *errPtr = cJSON_GetErrorPtr();
-
-            if (errPtr != nullptr) {
-                char errMsg[64];
-                snprintf(errMsg, sizeof(errMsg), "Parse JSON error near: %.20s", errPtr);
-
-                httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, errMsg);
-            }
-            else {
-                httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "Parse JSON failed");
-            }
-
-            return ESP_FAIL;
-        }
-
-        // Extract configuration fields into class structures.
-        retVal = parseConfig(req);
-
-        // Delete JSON AST while TLS arena is still active.
-        cJSON_Delete(cJsonObject);
-        cJsonObject = nullptr;
-    }
-
-    return retVal;
+    return (parseConfig(nullptr, true, isUnityTest) == ESP_OK);
 }
 
 
@@ -1855,9 +1698,9 @@ esp_err_t ConfigClass::parseConfig(httpd_req_t *req, bool init, bool unityTest)
 //**************************************************************************************************
 esp_err_t ConfigClass::serializeConfig(bool unityTest)
 {
-    if (cJsonObject != nullptr) {
+    if (cJsonObject != NULL) {
         cJSON_Delete(cJsonObject);
-        cJsonObject = nullptr;
+        cJsonObject = NULL;
     }
 
     cJsonObject = cJSON_CreateObject();
@@ -2763,7 +2606,7 @@ esp_err_t ConfigClass::serializeConfig(bool unityTest)
 
     jsonBuffer[0] = '\0'; // Reset content
     // Print to preallocted buffer
-    if (!cJSON_PrintPreallocated(cJsonObject, jsonBuffer, CONFIG_HANDLING_PREALLOCATED_BUFFER_SIZE, unityTest ? 0 : 1)) {
+    if (!cJSON_PrintPreallocated(cJsonObject, jsonBuffer, CONFIG_HANDLING_CJSON_OBJECT_BUFFER_SIZE, unityTest ? 0 : 1)) {
         retVal = ESP_FAIL;
     }
 
@@ -2776,73 +2619,33 @@ esp_err_t ConfigClass::serializeConfig(bool unityTest)
 
 
 //**************************************************************************************************
-// Retrieve actual configuration via REST API (JSON notation)
+// Persist configuration
 //**************************************************************************************************
-esp_err_t ConfigClass::getConfigRequest(httpd_req_t *req)
+bool ConfigClass::persistConfig()
 {
     if (!cJsonObjectBuffer || !jsonBuffer || !cfgMutex) {
-        return ESP_FAIL;
+        return false;
     }
 
-    if (req == nullptr || req->user_ctx == nullptr) {
-        httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "Internal Server Error: Server context is null");
-        return ESP_FAIL;
+    CfgMutexGuard lock(cfgMutex, pdMS_TO_TICKS(10000));
+    if (!lock.isAcquired()) {
+        LogFile.writeToFile(ESP_LOG_ERROR, TAG, "persistConfig: Failed to acquire cfgMutex - Timeout");
+        return false;
     }
 
-    char *httpBuffer = static_cast<char *>(((struct HttpServerData *)req->user_ctx)->scratch);
+    // Activates TLS PSRAM arena
+    cJsonPsramArena jsonArena(cJsonObjectBuffer, CONFIG_HANDLING_CJSON_OBJECT_BUFFER_SIZE);
 
-    if (httpBuffer == nullptr) {
-        httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "Internal Server Error: Scratch buffer is null");
-        return ESP_FAIL;
+    if (serializeConfig() != ESP_OK) {
+        return false;
     }
 
-    esp_err_t retVal = ESP_FAIL;
-    {
-        CfgMutexGuard lock(cfgMutex, pdMS_TO_TICKS(10000));
-        if (!lock.isAcquired()) {
-            httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "Internal Server Error: Failed to acquire cfgMutex - Timeout");
-            return ESP_FAIL;
-        }
-
-        // Activates TLS PSRAM arena for this thread during serialization
-        cJsonPsramArena jsonArena(cJsonObjectBuffer, CONFIG_HANDLING_PREALLOCATED_BUFFER_SIZE);
-
-        // Clear existing buffer target
-        jsonBuffer[0] = '\0';
-
-        // Serialize config data into jsonBuffer
-        retVal = serializeConfig();
-
-        if (retVal == ESP_OK) {
-            const size_t length = strlen(jsonBuffer);
-
-            if (length >= WEBSERVER_SCRATCH_BUFSIZE) {
-                retVal = ESP_ERR_NO_MEM;
-            }
-            else {
-                memcpy(httpBuffer, jsonBuffer, length + 1);
-            }
-        }
-    }
-
-    // Delete root cJSON tree if allocated
-    if (cJsonObject != nullptr) {
-        cJSON_Delete(cJsonObject);
-        cJsonObject = nullptr;
-    }
-
-    if (retVal == ESP_OK) {
-        httpd_resp_set_type(req, "application/json");
-        return httpd_resp_send(req, httpBuffer, HTTPD_RESP_USE_STRLEN);
-    }
-
-    httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "Failed to serialize configuration");
-    return retVal;
+    return (writeConfigFile() == ESP_OK);
 }
 
 
 //**************************************************************************************************
-// Persist actual configuration to file (JSON string)
+// Write configuration to file (JSON string)
 //**************************************************************************************************
 esp_err_t ConfigClass::writeConfigFile()
 {
@@ -2869,29 +2672,208 @@ esp_err_t ConfigClass::writeConfigFile()
 }
 
 
-bool ConfigClass::persistConfig()
+//**************************************************************************************************
+// Retrieve actual configuration via REST API (JSON notation)
+//**************************************************************************************************
+esp_err_t ConfigClass::getConfigRequest(httpd_req_t *req)
 {
     if (!cJsonObjectBuffer || !jsonBuffer || !cfgMutex) {
-        return false;
+        return ESP_FAIL;
     }
 
-    CfgMutexGuard lock(cfgMutex, pdMS_TO_TICKS(10000));
-    if (!lock.isAcquired()) {
-        LogFile.writeToFile(ESP_LOG_ERROR, TAG, "persistConfig: Failed to acquire cfgMutex - Timeout");
-        return false;
+    if (req == nullptr || req->user_ctx == nullptr) {
+        httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "Internal Server Error: Server context is null");
+        return ESP_FAIL;
     }
 
-    // Activates TLS PSRAM arena for this thread during serialization
-    cJsonPsramArena jsonArena(cJsonObjectBuffer, CONFIG_HANDLING_PREALLOCATED_BUFFER_SIZE);
+    char *httpBuffer = static_cast<char *>(((struct HttpServerData *)req->user_ctx)->scratch);
 
-    // Clear existing buffer target
-    jsonBuffer[0] = '\0';
-
-    if (serializeConfig() != ESP_OK) {
-        return false;
+    if (httpBuffer == nullptr) {
+        httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "Internal Server Error: Scratch buffer is null");
+        return ESP_FAIL;
     }
 
-    return (writeConfigFile() == ESP_OK);
+    esp_err_t retVal = ESP_FAIL;
+
+    // Lock mutex guard (RAII)
+    {
+        CfgMutexGuard lock(cfgMutex, pdMS_TO_TICKS(10000));
+        if (!lock.isAcquired()) {
+            httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "Internal Server Error: Failed to acquire cfgMutex - Timeout");
+            return ESP_FAIL;
+        }
+
+        // Activates TLS PSRAM arena
+        cJsonPsramArena jsonArena(cJsonObjectBuffer, CONFIG_HANDLING_CJSON_OBJECT_BUFFER_SIZE);
+
+        // Serialize config data into jsonBuffer
+        retVal = serializeConfig();
+
+        if (retVal == ESP_OK) {
+            const size_t length = strlen(jsonBuffer);
+
+            if (length >= WEBSERVER_SCRATCH_BUFSIZE) {
+                retVal = ESP_ERR_NO_MEM;
+            }
+            else {
+                memcpy(httpBuffer, jsonBuffer, length + 1);
+            }
+        }
+    } // Release mutex guard (RAII)
+
+    if (retVal == ESP_OK) {
+        httpd_resp_set_type(req, "application/json");
+        return httpd_resp_send(req, httpBuffer, HTTPD_RESP_USE_STRLEN);
+    }
+
+    httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "Failed to serialize configuration");
+    return retVal;
+}
+
+
+//**************************************************************************************************
+// Update configuration via REST API (JSON notation)
+//**************************************************************************************************
+esp_err_t ConfigClass::setConfigRequest(httpd_req_t *req)
+{
+    if (!cJsonObjectBuffer || !jsonBuffer || !cfgMutex) {
+        return ESP_FAIL;
+    }
+
+    if (req == nullptr || req->user_ctx == nullptr) {
+        httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "Internal Server Error: Server context is null");
+        return ESP_FAIL;
+    }
+
+    char *httpBuffer = static_cast<char *>(((struct HttpServerData *)req->user_ctx)->scratch);
+
+    if (httpBuffer == nullptr) {
+        httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "Internal Server Error: Scratch buffer is null");
+        return ESP_FAIL;
+    }
+
+    // Scratch buffer must accommodate the complete payload plus the terminating '\0'
+    if (req->content_len >= WEBSERVER_SCRATCH_BUFSIZE) {
+        httpd_resp_set_type(req, "application/json");
+        httpd_resp_send_err(req, HTTPD_413_CONTENT_TOO_LARGE, "Payload exceeds maximum buffer size");
+        return ESP_FAIL;
+    }
+
+    httpd_resp_set_type(req, "application/json");
+
+    size_t remaining = req->content_len;
+    size_t offset = 0;
+    uint8_t retries = 0;
+
+    // Receive the complete request into the webserver scratch buffer
+    while (remaining > 0) {
+        const int received = httpd_req_recv(req, httpBuffer + offset, remaining);
+
+        if (received <= 0) {
+            if (received == HTTPD_SOCK_ERR_TIMEOUT && ++retries < 5) {
+                vTaskDelay(pdMS_TO_TICKS(10));
+                continue;
+            }
+
+            httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "Config reception failed");
+            return ESP_FAIL;
+        }
+
+        retries = 0;
+        offset += received;
+        remaining -= received;
+    }
+
+    httpBuffer[offset] = '\0';
+
+    esp_err_t retVal = ESP_FAIL;
+
+    // Lock mutex guard (RAII)
+    {
+        CfgMutexGuard lock(cfgMutex, pdMS_TO_TICKS(10000));
+        if (!lock.isAcquired()) {
+            httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "Internal Server Error: Failed to acquire cfgMutex - Timeout");
+            return ESP_FAIL;
+        }
+
+        // Copy the complete request atomically
+        memcpy(jsonBuffer, httpBuffer, offset + 1);
+
+        // Activates TLS PSRAM arena
+        cJsonPsramArena jsonArena(cJsonObjectBuffer, CONFIG_HANDLING_CJSON_OBJECT_BUFFER_SIZE);
+
+        // Parse JSON payload (allocates AST inside cJsonObjectBuffer)
+        cJsonObject = cJSON_Parse(jsonBuffer);
+
+        if (cJsonObject == NULL) {
+            const char *errPtr = cJSON_GetErrorPtr();
+
+            if (errPtr != NULL) {
+                char errMsg[64];
+                snprintf(errMsg, sizeof(errMsg), "Parse JSON error near: %.20s", errPtr);
+
+                httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, errMsg);
+            }
+            else {
+                httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "Parse JSON failed");
+            }
+
+            return ESP_FAIL;
+        }
+
+        retVal = parseConfig(req);
+    } // Release mutex guard (RAII)
+
+    return retVal;
+}
+
+
+template <typename ConfigDataType> inline void clearConfigDataStructure(ConfigDataType &data)
+{
+    // Clear and release outer sequence vectors
+    data.sectionNumberSequences.sequence.clear();
+    decltype(data.sectionNumberSequences.sequence)().swap(data.sectionNumberSequences.sequence);
+
+    // Clear inner and outer vectors for Digit
+    for (auto &seq : data.sectionDigit.sequence) {
+        seq.roi.clear();
+        decltype(seq.roi)().swap(seq.roi);
+    }
+    data.sectionDigit.sequence.clear();
+    decltype(data.sectionDigit.sequence)().swap(data.sectionDigit.sequence);
+
+    // Clear inner and outer vectors for Analog
+    for (auto &seq : data.sectionAnalog.sequence) {
+        seq.roi.clear();
+        decltype(seq.roi)().swap(seq.roi);
+    }
+    data.sectionAnalog.sequence.clear();
+    decltype(data.sectionAnalog.sequence)().swap(data.sectionAnalog.sequence);
+
+    // Clear remaining sections
+    data.sectionPostProcessing.sequence.clear();
+    decltype(data.sectionPostProcessing.sequence)().swap(data.sectionPostProcessing.sequence);
+
+    data.sectionInfluxDBv1.sequence.clear();
+    decltype(data.sectionInfluxDBv1.sequence)().swap(data.sectionInfluxDBv1.sequence);
+
+    data.sectionInfluxDBv2.sequence.clear();
+    decltype(data.sectionInfluxDBv2.sequence)().swap(data.sectionInfluxDBv2.sequence);
+
+    data.sectionGpio.gpioPin.clear();
+    decltype(data.sectionGpio.gpioPin)().swap(data.sectionGpio.gpioPin);
+}
+
+
+void ConfigClass::clearCfgDataTemp()
+{
+    clearConfigDataStructure(cfgDataTemp);
+}
+
+
+void ConfigClass::clearCfgData()
+{
+    clearConfigDataStructure(cfgData);
 }
 
 

--- a/code/components/config_handling/configClass.cpp
+++ b/code/components/config_handling/configClass.cpp
@@ -171,7 +171,7 @@ bool ConfigClass::parseJsonFromFile(const char *jsonStr, bool unityTest)
 
     // Parse JSON and update internal configuration
     {
-        cJsonPsramArena jsonArena(cJsonObjectBuffer, CONFIG_HANDLING_CJSON_OBJECT_BUFFER_SIZE);
+        cJsonObjectArena jsonArena(cJsonObjectBuffer, CONFIG_HANDLING_CJSON_OBJECT_BUFFER_SIZE);
 
         cJsonObject = cJSON_Parse(jsonStr);
         if (cJsonObject != nullptr) {
@@ -196,7 +196,7 @@ bool ConfigClass::parseJsonFromFile(const char *jsonStr, bool unityTest)
 
     // Serialize updated configuration
     {
-        cJsonPsramArena jsonArena(cJsonObjectBuffer, CONFIG_HANDLING_CJSON_OBJECT_BUFFER_SIZE);
+        cJsonObjectArena jsonArena(cJsonObjectBuffer, CONFIG_HANDLING_CJSON_OBJECT_BUFFER_SIZE);
 
         if (serializeConfig(unityTest) != ESP_OK) {
             LogFile.writeToFile(ESP_LOG_ERROR, TAG, "parseJsonFromFile: Failed to serialize configuration");
@@ -2643,8 +2643,7 @@ bool ConfigClass::persistConfig()
         return false;
     }
 
-    // Activates TLS PSRAM arena
-    cJsonPsramArena jsonArena(cJsonObjectBuffer, CONFIG_HANDLING_CJSON_OBJECT_BUFFER_SIZE);
+    cJsonObjectArena jsonArena(cJsonObjectBuffer, CONFIG_HANDLING_CJSON_OBJECT_BUFFER_SIZE);
 
     if (serializeConfig() != ESP_OK) {
         return false;
@@ -2886,8 +2885,7 @@ esp_err_t ConfigClass::getConfigRequest(httpd_req_t *req)
             return ESP_FAIL;
         }
 
-        // Activates TLS PSRAM arena
-        cJsonPsramArena jsonArena(cJsonObjectBuffer, CONFIG_HANDLING_CJSON_OBJECT_BUFFER_SIZE);
+        cJsonObjectArena jsonArena(cJsonObjectBuffer, CONFIG_HANDLING_CJSON_OBJECT_BUFFER_SIZE);
 
         // Serialize config data into jsonBuffer
         retVal = serializeConfig();
@@ -2989,7 +2987,7 @@ esp_err_t ConfigClass::setConfigRequest(httpd_req_t *req)
 
         // Parse JSON and update internal configuration
         {
-            cJsonPsramArena jsonArena(cJsonObjectBuffer, CONFIG_HANDLING_CJSON_OBJECT_BUFFER_SIZE);
+            cJsonObjectArena jsonArena(cJsonObjectBuffer, CONFIG_HANDLING_CJSON_OBJECT_BUFFER_SIZE);
 
             cJsonObject = cJSON_Parse(jsonBuffer);
 
@@ -3013,7 +3011,7 @@ esp_err_t ConfigClass::setConfigRequest(httpd_req_t *req)
 
         // Serialize updated configuration
         if (retVal == ESP_OK) {
-            cJsonPsramArena jsonArena(cJsonObjectBuffer, CONFIG_HANDLING_CJSON_OBJECT_BUFFER_SIZE);
+            cJsonObjectArena jsonArena(cJsonObjectBuffer, CONFIG_HANDLING_CJSON_OBJECT_BUFFER_SIZE);
 
             retVal = serializeConfig();
 

--- a/code/components/config_handling/configClass.cpp
+++ b/code/components/config_handling/configClass.cpp
@@ -108,6 +108,9 @@ ConfigClass::ConfigClass()
         }
     }
 
+    static_assert(WEBSERVER_SCRATCH_BUFSIZE >= CONFIG_HANDLING_PREALLOCATED_BUFFER_SIZE,
+                  "Webserver scratch buffer must be at least as large as the config JSON buffer");
+
     initCjsonHooks();
 }
 
@@ -251,95 +254,93 @@ esp_err_t ConfigClass::setConfigRequest(httpd_req_t *req)
         return ESP_FAIL;
     }
 
-    size_t remaining = req->content_len;
-    int received = 0;
-    size_t offset = 0;
-
-    httpd_resp_set_type(req, "application/json");
-
-    if (remaining >= CONFIG_HANDLING_PREALLOCATED_BUFFER_SIZE - 1) {
-        // LogFile.writeToFile(ESP_LOG_ERROR, TAG, "setConfig: Payload exceeds maximum buffer size");
-        httpd_resp_send_err(req, HTTPD_413_CONTENT_TOO_LARGE, "Payload exceeds maximum buffer size");
-        return ESP_FAIL;
-    }
-
-    if (req->user_ctx == nullptr) {
-        // LogFile.writeToFile(ESP_LOG_ERROR, TAG, "setConfig: Server context is null");
+    if (req == nullptr || req->user_ctx == nullptr) {
         httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "Internal Server Error: Server context is null");
         return ESP_FAIL;
     }
 
     char *httpBuffer = static_cast<char *>(((struct HttpServerData *)req->user_ctx)->scratch);
 
-    int retries = 0;
+    if (httpBuffer == nullptr) {
+        httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "Internal Server Error: Scratch buffer is null");
+        return ESP_FAIL;
+    }
+
+    // Scratch buffer must accommodate the complete payload plus the terminating '\0'
+    if (req->content_len >= WEBSERVER_SCRATCH_BUFSIZE) {
+        httpd_resp_set_type(req, "application/json");
+        httpd_resp_send_err(req, HTTPD_413_CONTENT_TOO_LARGE, "Payload exceeds maximum buffer size");
+        return ESP_FAIL;
+    }
+
+    httpd_resp_set_type(req, "application/json");
+
+    size_t remaining = req->content_len;
+    size_t offset = 0;
+    uint8_t retries = 0;
+
+    // Receive the complete request into the webserver scratch buffer
     while (remaining > 0) {
-        received = httpd_req_recv(req, httpBuffer, std::min<size_t>(remaining, WEBSERVER_SCRATCH_BUFSIZE));
+        const int received = httpd_req_recv(req, httpBuffer + offset, remaining);
 
         if (received <= 0) {
             if (received == HTTPD_SOCK_ERR_TIMEOUT && ++retries < 5) {
                 vTaskDelay(pdMS_TO_TICKS(10));
                 continue;
             }
-            // LogFile.writeToFile(ESP_LOG_ERROR, TAG, "setConfig: Config reception failed");
+
             httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "Config reception failed");
             return ESP_FAIL;
         }
 
         retries = 0;
-
-        // Scoped block to handle JSON processing under the mutex guard safely
-        {
-            CfgMutexGuard lock(cfgMutex, pdMS_TO_TICKS(10000));
-            if (!lock.isAcquired()) {
-                // LogFile.writeToFile(ESP_LOG_ERROR, TAG, "setConfig: Failed to acquire cfgMutex - Timeout");
-                httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "Internal Server Error: Failed to acquire cfgMutex - Timeout");
-                return ESP_FAIL;
-            }
-
-            memcpy(jsonBuffer + offset, httpBuffer, received);
-            offset += received;
-        } // CfgMutexGuard releases here
-
+        offset += received;
         remaining -= received;
     }
 
-    // Scoped block to handle JSON processing under the mutex guard safely
+    httpBuffer[offset] = '\0';
+
     esp_err_t retVal = ESP_FAIL;
+
     {
         CfgMutexGuard lock(cfgMutex, pdMS_TO_TICKS(10000));
         if (!lock.isAcquired()) {
-            // LogFile.writeToFile(ESP_LOG_ERROR, TAG, "setConfig: Failed to acquire cfgMutex - Timeout");
             httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "Internal Server Error: Failed to acquire cfgMutex - Timeout");
             return ESP_FAIL;
         }
 
-        jsonBuffer[offset] = '\0';
+        // Copy the complete request atomically with respect to other configuration users
+        memcpy(jsonBuffer, httpBuffer, offset + 1);
 
-        // Activates TLS PSRAM arena for this thread only
+        // Activates TLS PSRAM arena for this thread only.
         cJsonPsramArena jsonArena(cJsonObjectBuffer, CONFIG_HANDLING_PREALLOCATED_BUFFER_SIZE);
 
-        // Parse JSON payload (allocates AST inside cJsonObjectBuffer)
+        // Parse JSON payload (allocates AST inside cJsonObjectBuffer).
         cJsonObject = cJSON_Parse(jsonBuffer);
+
         if (cJsonObject == nullptr) {
             const char *errPtr = cJSON_GetErrorPtr();
+
             if (errPtr != nullptr) {
                 char errMsg[64];
                 snprintf(errMsg, sizeof(errMsg), "Parse JSON error near: %.20s", errPtr);
+
                 httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, errMsg);
             }
             else {
                 httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "Parse JSON failed");
             }
+
             return ESP_FAIL;
         }
 
-        // Extract configuration fields into class structures
+        // Extract configuration fields into class structures.
         retVal = parseConfig(req);
 
-        // Delete JSON AST while TLS arena is still active
+        // Delete JSON AST while TLS arena is still active.
         cJSON_Delete(cJsonObject);
         cJsonObject = nullptr;
-    } // CfgMutexGuard releases here
+    }
 
     return retVal;
 }
@@ -2783,11 +2784,22 @@ esp_err_t ConfigClass::getConfigRequest(httpd_req_t *req)
         return ESP_FAIL;
     }
 
+    if (req == nullptr || req->user_ctx == nullptr) {
+        httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "Internal Server Error: Server context is null");
+        return ESP_FAIL;
+    }
+
+    char *httpBuffer = static_cast<char *>(((struct HttpServerData *)req->user_ctx)->scratch);
+
+    if (httpBuffer == nullptr) {
+        httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "Internal Server Error: Scratch buffer is null");
+        return ESP_FAIL;
+    }
+
     esp_err_t retVal = ESP_FAIL;
     {
         CfgMutexGuard lock(cfgMutex, pdMS_TO_TICKS(10000));
         if (!lock.isAcquired()) {
-            // LogFile.writeToFile(ESP_LOG_ERROR, TAG, "Failed to acquire cfgMutex - Timeout");
             httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "Internal Server Error: Failed to acquire cfgMutex - Timeout");
             return ESP_FAIL;
         }
@@ -2798,17 +2810,19 @@ esp_err_t ConfigClass::getConfigRequest(httpd_req_t *req)
         // Clear existing buffer target
         jsonBuffer[0] = '\0';
 
-        // Serialize config data into cJSON / jsonBuffer
+        // Serialize config data into jsonBuffer
         retVal = serializeConfig();
-    }
 
-    if (retVal == ESP_OK) {
-        httpd_resp_set_type(req, "application/json");
-        httpd_resp_send(req, jsonBuffer, HTTPD_RESP_USE_STRLEN);
-    }
-    else {
-        // LogFile.writeToFile(ESP_LOG_ERROR, TAG, "Failed to serialize configuration");
-        httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "Failed to serialize configuration");
+        if (retVal == ESP_OK) {
+            const size_t length = strlen(jsonBuffer);
+
+            if (length >= WEBSERVER_SCRATCH_BUFSIZE) {
+                retVal = ESP_ERR_NO_MEM;
+            }
+            else {
+                memcpy(httpBuffer, jsonBuffer, length + 1);
+            }
+        }
     }
 
     // Delete root cJSON tree if allocated
@@ -2817,6 +2831,12 @@ esp_err_t ConfigClass::getConfigRequest(httpd_req_t *req)
         cJsonObject = nullptr;
     }
 
+    if (retVal == ESP_OK) {
+        httpd_resp_set_type(req, "application/json");
+        return httpd_resp_send(req, httpBuffer, HTTPD_RESP_USE_STRLEN);
+    }
+
+    httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "Failed to serialize configuration");
     return retVal;
 }
 

--- a/code/components/config_handling/configClass.cpp
+++ b/code/components/config_handling/configClass.cpp
@@ -2644,16 +2644,6 @@ bool ConfigClass::persistConfig()
 }
 
 
-bool ConfigClass::persistConfigAfterMigration()
-{
-    if (serializeConfig() != ESP_OK) {
-        return false;
-    }
-
-    return (writeConfigFile() == ESP_OK);
-}
-
-
 //**************************************************************************************************
 // Write configuration to file (JSON string)
 //**************************************************************************************************

--- a/code/components/config_handling/configClass.cpp
+++ b/code/components/config_handling/configClass.cpp
@@ -26,72 +26,89 @@ static const char *TAG = "CONFIG";
 ConfigClass ConfigClass::cfgClass;
 
 
-bool isValidIpAddress(const char *ipAddress)
+static bool isValidIpAddress(const char *ipAddress)
 {
     struct sockaddr_in sa;
     return inet_pton(AF_INET, ipAddress, &(sa.sin_addr)) == 1;
 }
 
 
+template <typename ConfigDataType> inline void clearConfigDataStructure(ConfigDataType &data)
+{
+    // Clear and release outer sequence vectors
+    data.sectionNumberSequences.sequence.clear();
+    decltype(data.sectionNumberSequences.sequence)().swap(data.sectionNumberSequences.sequence);
+
+    // Clear inner and outer vectors for Digit
+    for (auto &seq : data.sectionDigit.sequence) {
+        seq.roi.clear();
+        decltype(seq.roi)().swap(seq.roi);
+    }
+    data.sectionDigit.sequence.clear();
+    decltype(data.sectionDigit.sequence)().swap(data.sectionDigit.sequence);
+
+    // Clear inner and outer vectors for Analog
+    for (auto &seq : data.sectionAnalog.sequence) {
+        seq.roi.clear();
+        decltype(seq.roi)().swap(seq.roi);
+    }
+    data.sectionAnalog.sequence.clear();
+    decltype(data.sectionAnalog.sequence)().swap(data.sectionAnalog.sequence);
+
+    // Clear remaining sections
+    data.sectionPostProcessing.sequence.clear();
+    decltype(data.sectionPostProcessing.sequence)().swap(data.sectionPostProcessing.sequence);
+
+    data.sectionInfluxDBv1.sequence.clear();
+    decltype(data.sectionInfluxDBv1.sequence)().swap(data.sectionInfluxDBv1.sequence);
+
+    data.sectionInfluxDBv2.sequence.clear();
+    decltype(data.sectionInfluxDBv2.sequence)().swap(data.sectionInfluxDBv2.sequence);
+
+    data.sectionGpio.gpioPin.clear();
+    decltype(data.sectionGpio.gpioPin)().swap(data.sectionGpio.gpioPin);
+}
+
+
 void ConfigClass::clearCfgDataTemp()
 {
-    cfgDataTemp.sectionNumberSequences.sequence.clear();
-    cfgDataTemp.sectionNumberSequences.sequence.shrink_to_fit();
-    for (auto &seq : cfgDataTemp.sectionDigit.sequence) {
-        seq.roi.clear();
-        seq.roi.shrink_to_fit();
-    }
-    cfgDataTemp.sectionDigit.sequence.clear();
-    cfgDataTemp.sectionDigit.sequence.shrink_to_fit();
-    for (auto &seq : cfgDataTemp.sectionAnalog.sequence) {
-        seq.roi.clear();
-        seq.roi.shrink_to_fit();
-    }
-    cfgDataTemp.sectionAnalog.sequence.clear();
-    cfgDataTemp.sectionAnalog.sequence.shrink_to_fit();
-    cfgDataTemp.sectionPostProcessing.sequence.clear();
-    cfgDataTemp.sectionPostProcessing.sequence.shrink_to_fit();
-    cfgDataTemp.sectionInfluxDBv1.sequence.clear();
-    cfgDataTemp.sectionInfluxDBv1.sequence.shrink_to_fit();
-    cfgDataTemp.sectionInfluxDBv2.sequence.clear();
-    cfgDataTemp.sectionInfluxDBv2.sequence.shrink_to_fit();
-    cfgDataTemp.sectionGpio.gpioPin.clear();
-    cfgDataTemp.sectionGpio.gpioPin.shrink_to_fit();
+    clearConfigDataStructure(cfgDataTemp);
 }
 
 
 void ConfigClass::clearCfgData()
 {
-    cfgData.sectionNumberSequences.sequence.clear();
-    cfgData.sectionNumberSequences.sequence.shrink_to_fit();
-    for (auto &seq : cfgData.sectionDigit.sequence) {
-        seq.roi.clear();
-        seq.roi.shrink_to_fit();
-    }
-    cfgData.sectionDigit.sequence.clear();
-    cfgData.sectionDigit.sequence.shrink_to_fit();
-    for (auto &seq : cfgData.sectionAnalog.sequence) {
-        seq.roi.clear();
-        seq.roi.shrink_to_fit();
-    }
-    cfgData.sectionAnalog.sequence.clear();
-    cfgData.sectionAnalog.sequence.shrink_to_fit();
-    cfgData.sectionPostProcessing.sequence.clear();
-    cfgData.sectionPostProcessing.sequence.shrink_to_fit();
-    cfgData.sectionInfluxDBv1.sequence.clear();
-    cfgData.sectionInfluxDBv1.sequence.shrink_to_fit();
-    cfgData.sectionInfluxDBv2.sequence.clear();
-    cfgData.sectionInfluxDBv2.sequence.shrink_to_fit();
-    cfgData.sectionGpio.gpioPin.clear();
-    cfgData.sectionGpio.gpioPin.shrink_to_fit();
+    clearConfigDataStructure(cfgData);
 }
 
 
 ConfigClass::ConfigClass()
 {
+    // Create a FreeRTOS mutex semaphore to protect JSON buffer & global hooks
+    cfgMutex = xSemaphoreCreateMutex();
+
+    if (cfgMutex == nullptr) {
+        LogFile.writeToFile(ESP_LOG_ERROR, TAG, "Failed to create mutex");
+    }
+
     // Use preallocted buffer to avoid fragmentation and reduce internal RAM usage using SPIRAM
     cJsonObjectBuffer = (uint8_t *)heap_caps_calloc(1, CONFIG_HANDLING_PREALLOCATED_BUFFER_SIZE, MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
     jsonBuffer = (char *)heap_caps_calloc(1, CONFIG_HANDLING_PREALLOCATED_BUFFER_SIZE, MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
+
+    if (!cJsonObjectBuffer || !jsonBuffer) {
+        LogFile.writeToFile(ESP_LOG_ERROR, TAG, "Failed to allocate PSRAM buffers");
+
+        if (cJsonObjectBuffer) {
+            heap_caps_free(cJsonObjectBuffer);
+            cJsonObjectBuffer = nullptr;
+        }
+        if (jsonBuffer) {
+            heap_caps_free(jsonBuffer);
+            jsonBuffer = nullptr;
+        }
+    }
+
+    initCjsonHooks();
 }
 
 
@@ -100,11 +117,67 @@ ConfigClass::~ConfigClass()
     clearCfgDataTemp();
     clearCfgData();
 
-    heap_caps_free(cJsonObjectBuffer);
-    cJsonObjectBuffer = nullptr;
+    if (cJsonObjectBuffer) {
+        heap_caps_free(cJsonObjectBuffer);
+        cJsonObjectBuffer = nullptr;
+    }
 
-    heap_caps_free(jsonBuffer);
-    jsonBuffer = nullptr;
+    if (jsonBuffer) {
+        heap_caps_free(jsonBuffer);
+        jsonBuffer = nullptr;
+    }
+
+    if (cfgMutex != nullptr) {
+        vSemaphoreDelete(cfgMutex);
+        cfgMutex = nullptr;
+    }
+}
+
+
+//**************************************************************************************************
+// Helper: Parse JSON string from file using Thread-Local PSRAM arena and extract into class state
+//**************************************************************************************************
+bool ConfigClass::parseJsonFromFile(const char *jsonStr, bool isUnityTest)
+{
+    if (!cfgMutex || !cJsonObjectBuffer) {
+        return false;
+    }
+
+    if (jsonStr == nullptr) {
+        LogFile.writeToFile(ESP_LOG_ERROR, TAG, "parseJson: JSON input is null");
+        return false;
+    }
+
+    CfgMutexGuard lock(cfgMutex, pdMS_TO_TICKS(5000));
+    if (!lock.isAcquired()) {
+        LogFile.writeToFile(ESP_LOG_ERROR, TAG, "parseJson: Failed to acquire cfgMutex: Timeout");
+        return false;
+    }
+
+    // Activates TLS PSRAM arena for this thread only (Auto-clears on scope exit)
+    cJsonPsramArena jsonArena(cJsonObjectBuffer, CONFIG_HANDLING_PREALLOCATED_BUFFER_SIZE);
+
+    // Parse JSON payload (allocates AST inside cJsonObjectBuffer)
+    cJsonObject = cJSON_Parse(jsonStr);
+    if (cJsonObject == nullptr) {
+        const char *errPtr = cJSON_GetErrorPtr();
+        if (errPtr != nullptr) {
+            LogFile.writeToFile(ESP_LOG_ERROR, TAG, "parseJson: Parse error near: %.20s", errPtr);
+        }
+        else {
+            LogFile.writeToFile(ESP_LOG_ERROR, TAG, "parseJson: Parse failed (null or invalid payload)");
+        }
+        return false;
+    }
+
+    // Extract configuration fields into class structures
+    bool retVal = (parseConfig(nullptr, true, isUnityTest) == ESP_OK);
+
+    // Delete JSON AST while TLS arena is still active
+    cJSON_Delete(cJsonObject);
+    cJsonObject = nullptr;
+
+    return retVal;
 }
 
 
@@ -142,62 +215,30 @@ void ConfigClass::readConfigFile(bool unityTest, std::string unityTestData)
         fallbackCfgChecked = true;
     }
 
-    portENTER_CRITICAL(&mutex);
-    // Modify hook to use SPIRAM for cJSON object
-    cJSON_Hooks hooks;
-    hooks.malloc_fn = malloc_psram_heap_cjson;
-    hooks.free_fn = free_psram_heap_cjson;
-    cJSON_InitHooks(&hooks);
-    cJSONObjectPSRAM.preallocatedMemory = cJsonObjectBuffer;
-    cJSONObjectPSRAM.preallocatedMemorySize = CONFIG_HANDLING_PREALLOCATED_BUFFER_SIZE;
-    cJSONObjectPSRAM.usedMemory = 0;
+    // Attempt primary parse
+    bool parseSuccess = parseJsonFromFile(content.c_str(), unityTest);
 
-    // Parse content to cJSON object structure
-    cJsonObject = cJSON_Parse(content.c_str());
-
-    // Reset cJSON hooks to default
-    cJSON_InitHooks(NULL);
-    portEXIT_CRITICAL(&mutex);
-
-    // Check for invalid content -> bad/malformed syntax
-    if (cJsonObject == NULL) {
-        // Save invalid config file for debug purpose
+    if (!parseSuccess) {
         copyFile(CONFIG_PERSISTENCE_FILE, CONFIG_PERSISTENCE_FILE_INVALID);
 
         if (!fallbackCfgChecked) { // Try read fallback file if not yet read
             LogFile.writeToFile(ESP_LOG_WARN, TAG, "Invalid persistent config data | Check for fallback config file");
+
             content.clear();
 
             if (readFileToString(CONFIG_PERSISTENCE_FILE_FALLBACK, content)) {
                 LogFile.writeToFile(ESP_LOG_INFO, TAG, "Fallback config file found");
-
-                portENTER_CRITICAL(&mutex);
-                // Modify hook to use SPIRAM for cJSON object
-                cJSON_Hooks hooks;
-                hooks.malloc_fn = malloc_psram_heap_cjson;
-                hooks.free_fn = free_psram_heap_cjson;
-                cJSON_InitHooks(&hooks);
-                cJSONObjectPSRAM.preallocatedMemory = cJsonObjectBuffer;
-                cJSONObjectPSRAM.preallocatedMemorySize = CONFIG_HANDLING_PREALLOCATED_BUFFER_SIZE;
-                cJSONObjectPSRAM.usedMemory = 0;
-
-                // Parse content to cJSON object structure
-                cJsonObject = cJSON_Parse(content.c_str());
-
-                // Reset cJSON hooks to default
-                cJSON_InitHooks(NULL);
-                portEXIT_CRITICAL(&mutex);
+                parseSuccess = parseJsonFromFile(content.c_str(), unityTest);
             }
         }
 
-        if (cJsonObject == NULL) {
+        if (!parseSuccess) {
             LogFile.writeToFile(ESP_LOG_ERROR, TAG, "Invalid persistent config data | Use default config");
-            // Continue to try to restore WLAN config from NVS, otherwise Access Point is getting started to reconfigure.
+
+            clearCfgDataTemp();
+            parseJsonFromFile("{}", unityTest);
         }
     }
-
-    // Parse config out of cJSON object structure
-    parseConfig(NULL, true, unityTest);
 }
 
 
@@ -206,56 +247,88 @@ void ConfigClass::readConfigFile(bool unityTest, std::string unityTestData)
 //**************************************************************************************************
 esp_err_t ConfigClass::setConfigRequest(httpd_req_t *req)
 {
-    int remaining = req->content_len; // Content length of the request gives the size of the file being uploaded
-    int received = 0;
-    jsonBuffer[0] = '\0'; // Reset buffer content before usage
-
-    httpd_resp_set_type(req, "application/json");
-
-    char *httpBuffer = (char *)((struct HttpServerData *)req->user_ctx)->scratch;
-    while (remaining > 0) {
-        // Receive the file part by part into a buffer
-        if ((received = httpd_req_recv(req, httpBuffer, std::min(remaining, WEBSERVER_SCRATCH_BUFSIZE))) <= 0) {
-            if (received == HTTPD_SOCK_ERR_TIMEOUT) {
-                continue; // Retry if timeout occurred
-            }
-
-            LogFile.writeToFile(ESP_LOG_ERROR, TAG, "setConfig: Config reception failed");
-            httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "E92: Config reception failed");
-            return ESP_FAIL;
-        }
-
-        // Concat content
-        std::strncat(jsonBuffer, httpBuffer, received);
-
-        // Keep track of remaining size of the file left to be uploaded
-        remaining -= received;
-    }
-
-    portENTER_CRITICAL(&mutex);
-    // Modify hook to use SPIRAM for cJSON object
-    cJSON_Hooks hooks;
-    hooks.malloc_fn = malloc_psram_heap_cjson;
-    hooks.free_fn = free_psram_heap_cjson;
-    cJSON_InitHooks(&hooks);
-    cJSONObjectPSRAM.preallocatedMemory = cJsonObjectBuffer;
-    cJSONObjectPSRAM.preallocatedMemorySize = CONFIG_HANDLING_PREALLOCATED_BUFFER_SIZE;
-    cJSONObjectPSRAM.usedMemory = 0;
-
-    // Parse content to cJSON object structure
-    cJsonObject = cJSON_Parse(jsonBuffer);
-
-    // Reset cJSON hooks to default
-    cJSON_InitHooks(NULL);
-    portEXIT_CRITICAL(&mutex);
-
-    if (cJsonObject == NULL) {
-        httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "E91: Failed to parse JSON data, e.g. malformed notation");
+    if (!cJsonObjectBuffer || !jsonBuffer || !cfgMutex) {
         return ESP_FAIL;
     }
 
-    // Parse config out of cJSON object structure
-    return parseConfig(req);
+    size_t remaining = req->content_len;
+    int received = 0;
+    size_t offset = 0;
+
+    httpd_resp_set_type(req, "application/json");
+
+    if (remaining >= CONFIG_HANDLING_PREALLOCATED_BUFFER_SIZE - 1) {
+        LogFile.writeToFile(ESP_LOG_ERROR, TAG, "setConfig: Payload exceeds maximum buffer size");
+        httpd_resp_send_err(req, HTTPD_413_CONTENT_TOO_LARGE, "E93: Payload too large");
+        return ESP_FAIL;
+    }
+
+    if (req->user_ctx == nullptr) {
+        LogFile.writeToFile(ESP_LOG_ERROR, TAG, "setConfig: Server context is null");
+        httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "E90: Internal Server Error");
+        return ESP_FAIL;
+    }
+
+    // Scoped block to handle JSON processing under the mutex guard safely
+    esp_err_t retVal = ESP_FAIL;
+    {
+        CfgMutexGuard lock(cfgMutex, pdMS_TO_TICKS(5000));
+        if (!lock.isAcquired()) {
+            LogFile.writeToFile(ESP_LOG_ERROR, TAG, "setConfig: Failed to acquire cfgMutex - timeout expired");
+            httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "E90: System busy");
+            return ESP_FAIL;
+        }
+
+        char *httpBuffer = static_cast<char *>(((struct HttpServerData *)req->user_ctx)->scratch);
+
+        int retries = 0;
+        while (remaining > 0) {
+            received = httpd_req_recv(req, httpBuffer, std::min<size_t>(remaining, WEBSERVER_SCRATCH_BUFSIZE));
+
+            if (received <= 0) {
+                if (received == HTTPD_SOCK_ERR_TIMEOUT && ++retries < 5) {
+                    vTaskDelay(pdMS_TO_TICKS(10));
+                    continue;
+                }
+                LogFile.writeToFile(ESP_LOG_ERROR, TAG, "setConfig: Config reception failed");
+                httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "E92: Config reception failed");
+                return ESP_FAIL;
+            }
+
+            memcpy(jsonBuffer + offset, httpBuffer, received);
+            offset += received;
+            remaining -= received;
+        }
+        jsonBuffer[offset] = '\0';
+
+        // Activates TLS PSRAM arena for this thread only
+        cJsonPsramArena jsonArena(cJsonObjectBuffer, CONFIG_HANDLING_PREALLOCATED_BUFFER_SIZE);
+
+        // Parse JSON payload (allocates AST inside cJsonObjectBuffer)
+        cJsonObject = cJSON_Parse(jsonBuffer);
+        if (cJsonObject == nullptr) {
+            const char *errPtr = cJSON_GetErrorPtr();
+            if (errPtr != nullptr) {
+                char errMsg[64];
+                snprintf(errMsg, sizeof(errMsg), "Parse JSON error near: %.20s", errPtr);
+                httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, errMsg);
+            }
+            else {
+                httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "Parse JSON failed");
+            }
+            return ESP_FAIL;
+        }
+
+        // Extract configuration fields into class structures
+        retVal = parseConfig(req);
+
+        // Delete JSON AST while TLS arena is still active
+        cJSON_Delete(cJsonObject);
+        cJsonObject = nullptr;
+
+    } // CfgMutexGuard releases here
+
+    return retVal;
 }
 
 
@@ -443,7 +516,7 @@ esp_err_t ConfigClass::parseConfig(httpd_req_t *req, bool init, bool unityTest)
     }
 
     objEl = cJSON_GetObjectItem(cJSON_GetObjectItem(cJsonObject, "imagealignment"), "marker");
-    for (int i = 0; i < cJSON_GetArraySize(objEl); i++) {
+    for (int i = 0; i < std::min(cJSON_GetArraySize(objEl), 2); i++) {
         cJSON *objArrEl = cJSON_GetArrayItem(objEl, i);
         cJSON *arrEl;
 
@@ -1768,15 +1841,10 @@ esp_err_t ConfigClass::parseConfig(httpd_req_t *req, bool init, bool unityTest)
 //**************************************************************************************************
 esp_err_t ConfigClass::serializeConfig(bool unityTest)
 {
-    portENTER_CRITICAL(&mutex);
-    // Modify hook to use SPIRAM for cJSON object
-    cJSON_Hooks hooks;
-    hooks.malloc_fn = malloc_psram_heap_cjson;
-    hooks.free_fn = free_psram_heap_cjson;
-    cJSON_InitHooks(&hooks);
-    cJSONObjectPSRAM.preallocatedMemory = cJsonObjectBuffer;
-    cJSONObjectPSRAM.preallocatedMemorySize = CONFIG_HANDLING_PREALLOCATED_BUFFER_SIZE;
-    cJSONObjectPSRAM.usedMemory = 0;
+    if (cJsonObject != nullptr) {
+        cJSON_Delete(cJsonObject);
+        cJsonObject = nullptr;
+    }
 
     cJsonObject = cJSON_CreateObject();
     if (cJsonObject == NULL) {
@@ -2679,14 +2747,15 @@ esp_err_t ConfigClass::serializeConfig(bool unityTest)
         retVal = ESP_FAIL;
     }
 
-    cJSON_InitHooks(NULL); // Reset cJSON hooks to default
-    portEXIT_CRITICAL(&mutex);
-
     jsonBuffer[0] = '\0'; // Reset content
     // Print to preallocted buffer
     if (!cJSON_PrintPreallocated(cJsonObject, jsonBuffer, CONFIG_HANDLING_PREALLOCATED_BUFFER_SIZE, unityTest ? 0 : 1)) {
         retVal = ESP_FAIL;
     }
+
+    // Cleanup root cJSON structure
+    cJSON_Delete(cJsonObject);
+    cJsonObject = NULL;
 
     return retVal;
 }
@@ -2697,16 +2766,42 @@ esp_err_t ConfigClass::serializeConfig(bool unityTest)
 //**************************************************************************************************
 esp_err_t ConfigClass::getConfigRequest(httpd_req_t *req)
 {
-    httpd_resp_set_type(req, "application/json");
-
-    if (serializeConfig() == ESP_OK) {
-        httpd_resp_send(req, jsonBuffer, strlen(jsonBuffer));
-        return ESP_OK;
-    }
-    else {
-        httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "E93: Failed to serialize JSON data");
+    if (!cJsonObjectBuffer || !jsonBuffer || !cfgMutex) {
         return ESP_FAIL;
     }
+
+    CfgMutexGuard lock(cfgMutex, pdMS_TO_TICKS(5000));
+    if (!lock.isAcquired()) {
+        LogFile.writeToFile(ESP_LOG_ERROR, TAG, "Failed to acquire cfgMutex - timeout expired");
+        httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "E90: System busy");
+        return ESP_FAIL;
+    }
+
+    // Activates TLS PSRAM arena for this thread during serialization
+    cJsonPsramArena jsonArena(cJsonObjectBuffer, CONFIG_HANDLING_PREALLOCATED_BUFFER_SIZE);
+
+    // Clear existing buffer target
+    jsonBuffer[0] = '\0';
+
+    // Serialize config data into cJSON / jsonBuffer
+    esp_err_t ret = serializeConfig();
+
+    if (ret == ESP_OK) {
+        httpd_resp_set_type(req, "application/json");
+        httpd_resp_send(req, jsonBuffer, HTTPD_RESP_USE_STRLEN);
+    }
+    else {
+        LogFile.writeToFile(ESP_LOG_ERROR, TAG, "Failed to serialize configuration");
+        httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "E93: Failed to serialize JSON data");
+    }
+
+    // Delete root cJSON tree if allocated
+    if (cJsonObject != nullptr) {
+        cJSON_Delete(cJsonObject);
+        cJsonObject = nullptr;
+    }
+
+    return ret;
 }
 
 
@@ -2856,7 +2951,7 @@ void ConfigClass::validateStructure(std::string &structureName)
     }
 
     // Remove slash at the end of the string
-    if (structureName.back() == '/') {
+    if (!structureName.empty() && structureName.back() == '/') {
         structureName.pop_back();
     }
 }

--- a/code/components/config_handling/configClass.h
+++ b/code/components/config_handling/configClass.h
@@ -36,6 +36,7 @@ class ConfigClass
     bool parseJsonFromFile(const char *jsonStr, bool isUnityTest);
     esp_err_t parseConfig(httpd_req_t *req = NULL, bool init = false, bool unityTest = false);
     esp_err_t serializeConfig(bool unityTest = false);
+    bool serializeConfigToPersist(void);
     esp_err_t writeConfigFile(void);
 
     bool loadDataFromNVS(std::string key, std::string &value);
@@ -53,11 +54,7 @@ class ConfigClass
 
     void readConfigFile(bool unityTest = false, std::string unityTestData = "{}");
     void reinitConfig(void) { cfgData = cfgDataTemp; };
-    void persistConfig(void)
-    {
-        serializeConfig();
-        writeConfigFile();
-    };
+    void persistConfig(void);
 
     static ConfigClass *getInstance(void) { return &cfgClass; }
     const CfgData *get(void) const { return &cfgData; };

--- a/code/components/config_handling/configClass.h
+++ b/code/components/config_handling/configClass.h
@@ -33,8 +33,8 @@ class ConfigClass
     char *jsonBuffer = NULL;
     char *httpBuffer = NULL;
 
-    bool parseJsonFromFile(const char *jsonStr, bool isUnityTest);
-    esp_err_t parseConfig(httpd_req_t *req = NULL, bool init = false, bool unityTest = false);
+    bool parseJsonFromFile(const char *jsonStr, bool isUnityTest = false);
+    esp_err_t parseConfig(bool init = false, bool unityTest = false);
     esp_err_t serializeConfig(bool unityTest = false);
     bool serializeConfigToPersist(void);
     esp_err_t writeConfigFile(void);

--- a/code/components/config_handling/configClass.h
+++ b/code/components/config_handling/configClass.h
@@ -54,7 +54,7 @@ class ConfigClass
 
     void readConfigFile(bool unityTest = false, std::string unityTestData = "{}");
     void reinitConfig(void) { cfgData = cfgDataTemp; };
-    void persistConfig(void);
+    bool persistConfig(void);
 
     static ConfigClass *getInstance(void) { return &cfgClass; }
     const CfgData *get(void) const { return &cfgData; };

--- a/code/components/config_handling/configClass.h
+++ b/code/components/config_handling/configClass.h
@@ -55,6 +55,7 @@ class ConfigClass
     void readConfigFile(bool unityTest = false, std::string unityTestData = "{}");
     void reinitConfig(void) { cfgData = cfgDataTemp; };
     bool persistConfig(void);
+    bool persistConfigAfterMigration(void);
 
     static ConfigClass *getInstance(void) { return &cfgClass; }
     const CfgData *get(void) const { return &cfgData; };

--- a/code/components/config_handling/configClass.h
+++ b/code/components/config_handling/configClass.h
@@ -13,10 +13,32 @@
 
 
 /* Function calls
- * 1. Restore Config : readConfigFile()       > parseConfig > serializeConfig > writeConfigFile
- * 2. REST API Set   : setConfigRequest()     > parseConfig > serializeConfig > REST API Response
- * 3. REST API Get   : getConfigRequest()                   > serializeConfig > REST API Response
- * 4. Cfg Migration  : readConfigFile()       > parseConfig >  migrateConfiguration() > serializeConfig > writeConfigFile
+ *
+ * 1. Load Config From File (once after boot)
+ *    readConfigFile()
+ *      > parseJsonFromFile()
+ *        > parseConfig()
+ *          > migrateConfiguration()
+ *        > serializeConfig()
+ *        > writeConfigFile()
+ *
+ * 2. REST API Set
+ *    setConfigRequest()
+ *      > parseConfig()
+ *      > serializeConfig()
+ *      > writeConfigFile()
+ *      > REST API Response
+ *
+ * 3. REST API Get
+ *    getConfigRequest()
+ *      > serializeConfig()
+ *      > REST API Response
+ *
+ * 4. Unity Tests
+ *    parseJsonFromFile(..., true)
+ *      > parseConfig(..., true)
+ *      > serializeConfig(true)
+ *      > no writeConfigFile()
  */
 
 class ConfigClass
@@ -33,7 +55,7 @@ class ConfigClass
     char *jsonBuffer = NULL;
     char *httpBuffer = NULL;
 
-    bool parseJsonFromFile(const char *jsonStr, bool isUnityTest = false);
+    bool parseJsonFromFile(const char *jsonStr, bool unityTest = false);
     esp_err_t parseConfig(bool init = false, bool unityTest = false);
     esp_err_t serializeConfig(bool unityTest = false);
     bool serializeConfigToPersist(void);

--- a/code/components/config_handling/configClass.h
+++ b/code/components/config_handling/configClass.h
@@ -27,12 +27,13 @@ class ConfigClass
                                  // reinitConfig())
     CfgData cfgData;             // Keep parameter configuration (in use by process)
 
-    portMUX_TYPE mutex = portMUX_INITIALIZER_UNLOCKED;
+    SemaphoreHandle_t cfgMutex = nullptr;
     cJSON *cJsonObject = NULL;
     uint8_t *cJsonObjectBuffer = NULL;
     char *jsonBuffer = NULL;
     char *httpBuffer = NULL;
 
+    bool parseJsonFromFile(const char *jsonStr, bool isUnityTest);
     esp_err_t parseConfig(httpd_req_t *req = NULL, bool init = false, bool unityTest = false);
     esp_err_t serializeConfig(bool unityTest = false);
     esp_err_t writeConfigFile(void);
@@ -77,6 +78,31 @@ class ConfigClass
     CfgData *get(void) { return &cfgData; };
     char *getJsonBuffer(void) { return jsonBuffer; };
 };
+
+
+class CfgMutexGuard
+{
+    SemaphoreHandle_t mMutex;
+    bool mAcquired;
+
+  public:
+    explicit CfgMutexGuard(SemaphoreHandle_t mutex, TickType_t timeout = portMAX_DELAY) : mMutex(mutex), mAcquired(false)
+    {
+        if (mMutex && xSemaphoreTake(mMutex, timeout) == pdTRUE) {
+            mAcquired = true;
+        }
+    }
+
+    bool isAcquired() const { return mAcquired; }
+
+    ~CfgMutexGuard()
+    {
+        if (mAcquired) {
+            xSemaphoreGive(mMutex);
+        }
+    }
+};
+
 
 void registerConfigFileUri(httpd_handle_t server);
 

--- a/code/components/config_handling/configClass.h
+++ b/code/components/config_handling/configClass.h
@@ -55,7 +55,6 @@ class ConfigClass
     void readConfigFile(bool unityTest = false, std::string unityTestData = "{}");
     void reinitConfig(void) { cfgData = cfgDataTemp; };
     bool persistConfig(void);
-    bool persistConfigAfterMigration(void);
 
     static ConfigClass *getInstance(void) { return &cfgClass; }
     const CfgData *get(void) const { return &cfgData; };

--- a/code/components/config_handling/configMigration.cpp
+++ b/code/components/config_handling/configMigration.cpp
@@ -1243,7 +1243,7 @@ void migrateConfigIni(void)
     // At least one replacement happened
     if (migrated || migratedToJson) {
         if (migratedToJson) {
-            ConfigClass::getInstance()->persistConfigAfterMigration();
+            ConfigClass::getInstance()->persistConfig();
             ConfigClass::getInstance()->initCfgTmp();
         }
 

--- a/code/components/config_handling/configMigration.cpp
+++ b/code/components/config_handling/configMigration.cpp
@@ -1243,7 +1243,7 @@ void migrateConfigIni(void)
     // At least one replacement happened
     if (migrated || migratedToJson) {
         if (migratedToJson) {
-            ConfigClass::getInstance()->persistConfig();
+            ConfigClass::getInstance()->persistConfigAfterMigration();
             ConfigClass::getInstance()->initCfgTmp();
         }
 

--- a/code/components/misc_helper/psram.cpp
+++ b/code/components/misc_helper/psram.cpp
@@ -106,7 +106,7 @@ void free_psram_heap(std::string name, void *ptr)
 // *****************
 
 // cJSON memory management: Thread-Local Storage pointer
-static __thread taskArena_t *tActiveArena = nullptr;
+__thread taskArena_t *tActiveArena = nullptr;
 
 static void *mallocCjson(size_t size)
 {

--- a/code/components/misc_helper/psram.cpp
+++ b/code/components/misc_helper/psram.cpp
@@ -9,9 +9,11 @@
 static const char *TAG = "PSRAM";
 
 struct strSTBI STBIObjectPSRAM = {};
-static __thread taskArena_t *cJsonActiveArena = nullptr; // cJSON memory management: Thread-Local Storage pointer
+static __thread taskArena_t *cJsonActiveArena = nullptr; // Thread-local storage pointer for cJSON (config handling)
 
 
+// Custom hooks (incl. logging feature)
+// ********************************************************
 void *malloc_psram_heap(std::string name, size_t size, uint32_t caps)
 {
     void *ptr;
@@ -48,6 +50,8 @@ void *remalloc_psram_heap(std::string name, void *p, size_t size, uint32_t caps)
 }
 
 
+// STBI custom hooks
+// ********************************************************
 void *malloc_psram_heap_STBI(std::string name, size_t size, uint32_t caps)
 {
     void *ptr;
@@ -105,7 +109,7 @@ void free_psram_heap(std::string name, void *ptr)
 
 
 // cJSON custom hooks
-// *****************
+// ********************************************************
 static void *mallocCjson(size_t size)
 {
     if (cJsonActiveArena != nullptr && cJsonActiveArena->active) {
@@ -150,7 +154,7 @@ void initCjsonHooks(void)
 
 // cJSON memory arena
 // *****************
-cJsonPsramArena::cJsonPsramArena(uint8_t *buffer, size_t capacity)
+cJsonObjectArena::cJsonObjectArena(uint8_t *buffer, size_t capacity)
 {
     arenaState.buffer = buffer;
     arenaState.capacity = capacity;
@@ -161,13 +165,15 @@ cJsonPsramArena::cJsonPsramArena(uint8_t *buffer, size_t capacity)
 }
 
 
-cJsonPsramArena::~cJsonPsramArena()
+cJsonObjectArena::~cJsonObjectArena()
 {
-    LogFile.writeToFile(ESP_LOG_DEBUG, TAG,
-                        "cJSON PSRAM arena used: " + std::to_string(arenaState.offset) + "/" + std::to_string(arenaState.capacity));
+    if (arenaState.capacity > 0 && arenaState.offset >= (arenaState.capacity * 97U) / 100U) {
+        LogFile.writeToFile(ESP_LOG_WARN, TAG,
+                            "cJSON arena usage high (%): " + std::to_string((arenaState.offset * 100U) / arenaState.capacity));
+    }
 
     arenaState.active = false;
-    arenaState.offset = 0;
+    s arenaState.offset = 0;
 
     if (cJsonActiveArena == &arenaState) {
         cJsonActiveArena = nullptr;

--- a/code/components/misc_helper/psram.cpp
+++ b/code/components/misc_helper/psram.cpp
@@ -9,6 +9,8 @@
 static const char *TAG = "PSRAM";
 
 struct strSTBI STBIObjectPSRAM = {};
+static __thread taskArena_t *cJsonActiveArena = nullptr; // cJSON memory management: Thread-Local Storage pointer
+
 
 void *malloc_psram_heap(std::string name, size_t size, uint32_t caps)
 {
@@ -104,32 +106,32 @@ void free_psram_heap(std::string name, void *ptr)
 
 // cJSON custom hooks
 // *****************
-
-// cJSON memory management: Thread-Local Storage pointer
-__thread taskArena_t *tActiveArena = nullptr;
-
 static void *mallocCjson(size_t size)
 {
-    if (tActiveArena != nullptr && tActiveArena->active) {
+    if (cJsonActiveArena != nullptr && cJsonActiveArena->active) {
         size_t alignedSize = (size + 3) & ~3; // Ensure 4-byte boundary alignment
-        if (tActiveArena->offset + alignedSize > tActiveArena->capacity) {
-            ESP_LOGE("cJSON", "PSRAM Arena Exhausted! Needed: %zu, Capacity: %zu", alignedSize, tActiveArena->capacity);
+        if (cJsonActiveArena->offset > cJsonActiveArena->capacity || alignedSize > cJsonActiveArena->capacity - cJsonActiveArena->offset) {
+            LogFile.writeToFile(ESP_LOG_ERROR, TAG,
+                                "cJSON PSRAM arena insuffcient | Capacity:" + std::to_string(cJsonActiveArena->capacity) +
+                                    ", Used: " + std::to_string(cJsonActiveArena->offset) + ", Required: " + std::to_string(alignedSize));
             return nullptr;
         }
-        void *ptr = &tActiveArena->buffer[tActiveArena->offset];
-        tActiveArena->offset += alignedSize;
+        void *ptr = &cJsonActiveArena->buffer[cJsonActiveArena->offset];
+        cJsonActiveArena->offset += alignedSize;
         return ptr;
     }
-    return malloc(size); // Fallback to standard heap for non-arena tasks
+
+    return heap_caps_malloc(size, MALLOC_CAP_DEFAULT); // Fallback to default heap for non-arena tasks
 }
 
 
 static void freeCjson(void *ptr)
 {
-    if (tActiveArena != nullptr && tActiveArena->active) {
+    if (cJsonActiveArena != nullptr && cJsonActiveArena->active) {
         return; // Arena deallocations are cleared in bulk when offset resets
     }
-    free(ptr); // Standard heap free for non-arena tasks
+
+    heap_caps_free(ptr); // Standard heap free for non-arena tasks
 }
 
 
@@ -139,4 +141,31 @@ void initCjsonHooks(void)
     hooks.malloc_fn = mallocCjson;
     hooks.free_fn = freeCjson;
     cJSON_InitHooks(&hooks);
+}
+
+
+// cJSON memory arena
+// *****************
+cJsonPsramArena::cJsonPsramArena(uint8_t *buffer, size_t capacity)
+{
+    arenaState.buffer = buffer;
+    arenaState.capacity = capacity;
+    arenaState.offset = 0;
+    arenaState.active = true;
+
+    cJsonActiveArena = &arenaState;
+}
+
+
+cJsonPsramArena::~cJsonPsramArena()
+{
+    LogFile.writeToFile(ESP_LOG_DEBUG, TAG,
+                        "cJSON PSRAM arena used: " + std::to_string(arenaState.offset) + "/" + std::to_string(arenaState.capacity));
+
+    arenaState.active = false;
+    arenaState.offset = 0;
+
+    if (cJsonActiveArena == &arenaState) {
+        cJsonActiveArena = nullptr;
+    }
 }

--- a/code/components/misc_helper/psram.cpp
+++ b/code/components/misc_helper/psram.cpp
@@ -104,6 +104,10 @@ void free_psram_heap(std::string name, void *ptr)
 
 // cJSON custom hooks
 // *****************
+
+// cJSON memory management: Thread-Local Storage pointer
+static __thread taskArena_t *tActiveArena = nullptr;
+
 static void *mallocCjson(size_t size)
 {
     if (tActiveArena != nullptr && tActiveArena->active) {

--- a/code/components/misc_helper/psram.cpp
+++ b/code/components/misc_helper/psram.cpp
@@ -127,6 +127,10 @@ static void *mallocCjson(size_t size)
 
 static void freeCjson(void *ptr)
 {
+    if (ptr == nullptr) {
+        return;
+    }
+
     if (cJsonActiveArena != nullptr && cJsonActiveArena->active) {
         return; // Arena deallocations are cleared in bulk when offset resets
     }

--- a/code/components/misc_helper/psram.cpp
+++ b/code/components/misc_helper/psram.cpp
@@ -9,7 +9,6 @@
 static const char *TAG = "PSRAM";
 
 struct strSTBI STBIObjectPSRAM = {};
-struct strcJSON cJSONObjectPSRAM = {};
 
 void *malloc_psram_heap(std::string name, size_t size, uint32_t caps)
 {
@@ -103,29 +102,37 @@ void free_psram_heap(std::string name, void *ptr)
 }
 
 
-void *malloc_psram_heap_cjson(size_t size)
+// cJSON custom hooks
+// *****************
+static void *mallocCjson(size_t size)
 {
-    cJSONObjectPSRAM.usedMemory += size;
-    if (cJSONObjectPSRAM.preallocatedMemory != NULL && cJSONObjectPSRAM.preallocatedMemorySize >= cJSONObjectPSRAM.usedMemory) {
-        return (uint8_t *)cJSONObjectPSRAM.preallocatedMemory + cJSONObjectPSRAM.usedMemory - size;
+    if (tActiveArena != nullptr && tActiveArena->active) {
+        size_t alignedSize = (size + 3) & ~3; // Ensure 4-byte boundary alignment
+        if (tActiveArena->offset + alignedSize > tActiveArena->capacity) {
+            ESP_LOGE("cJSON", "PSRAM Arena Exhausted! Needed: %zu, Capacity: %zu", alignedSize, tActiveArena->capacity);
+            return nullptr;
+        }
+        void *ptr = &tActiveArena->buffer[tActiveArena->offset];
+        tActiveArena->offset += alignedSize;
+        return ptr;
     }
-    else {
-#ifdef DEBUG_DETAIL_ON
-        LogFile.writeToFile(ESP_LOG_DEBUG, TAG, "cJSON: Use default region");
-#endif // DEBUG_DETAIL_ON
-        cJSONObjectPSRAM.useDefaultAllocation = true;
-        return heap_caps_malloc(size, MALLOC_CAP_DEFAULT);
-    }
+    return malloc(size); // Fallback to standard heap for non-arena tasks
 }
 
 
-void free_psram_heap_cjson(void *ptr)
+static void freeCjson(void *ptr)
 {
-    if (!cJSONObjectPSRAM.useDefaultAllocation) {
-        cJSONObjectPSRAM.usedMemory = 0;
+    if (tActiveArena != nullptr && tActiveArena->active) {
+        return; // Arena deallocations are cleared in bulk when offset resets
     }
-    else {
-        cJSONObjectPSRAM.useDefaultAllocation = false;
-        heap_caps_free(ptr);
-    }
+    free(ptr); // Standard heap free for non-arena tasks
+}
+
+
+void initCjsonHooks(void)
+{
+    cJSON_Hooks hooks;
+    hooks.malloc_fn = mallocCjson;
+    hooks.free_fn = freeCjson;
+    cJSON_InitHooks(&hooks);
 }

--- a/code/components/misc_helper/psram.cpp
+++ b/code/components/misc_helper/psram.cpp
@@ -173,7 +173,7 @@ cJsonObjectArena::~cJsonObjectArena()
     }
 
     arenaState.active = false;
-    s arenaState.offset = 0;
+    arenaState.offset = 0;
 
     if (cJsonActiveArena == &arenaState) {
         cJsonActiveArena = nullptr;

--- a/code/components/misc_helper/psram.h
+++ b/code/components/misc_helper/psram.h
@@ -67,7 +67,7 @@ typedef struct {
 } taskArena_t;
 
 // Thread-Local Storage pointer
-static __thread taskArena_t *tActiveArena = nullptr;
+extern __thread taskArena_t *tActiveArena;
 
 class cJsonPsramArena
 {

--- a/code/components/misc_helper/psram.h
+++ b/code/components/misc_helper/psram.h
@@ -67,14 +67,14 @@ typedef struct {
 } taskArena_t;
 
 
-class cJsonPsramArena
+class cJsonObjectArena
 {
   public:
-    cJsonPsramArena(uint8_t *buffer, size_t capacity);
-    ~cJsonPsramArena();
+    cJsonObjectArena(uint8_t *buffer, size_t capacity);
+    ~cJsonObjectArena();
 
-    cJsonPsramArena(const cJsonPsramArena &) = delete;
-    cJsonPsramArena &operator=(const cJsonPsramArena &) = delete;
+    cJsonObjectArena(const cJsonObjectArena &) = delete;
+    cJsonObjectArena &operator=(const cJsonObjectArena &) = delete;
 
   private:
     taskArena_t arenaState;

--- a/code/components/misc_helper/psram.h
+++ b/code/components/misc_helper/psram.h
@@ -66,23 +66,15 @@ typedef struct {
     bool active;
 } taskArena_t;
 
-// Thread-Local Storage pointer
-extern __thread taskArena_t *tActiveArena;
 
 class cJsonPsramArena
 {
   public:
-    cJsonPsramArena(uint8_t *buffer, size_t capacity)
-    {
-        arenaState.buffer = buffer;
-        arenaState.capacity = capacity;
-        arenaState.offset = 0;
-        arenaState.active = true;
+    cJsonPsramArena(uint8_t *buffer, size_t capacity);
+    ~cJsonPsramArena();
 
-        tActiveArena = &arenaState;
-    }
-
-    ~cJsonPsramArena() { tActiveArena = nullptr; }
+    cJsonPsramArena(const cJsonPsramArena &) = delete;
+    cJsonPsramArena &operator=(const cJsonPsramArena &) = delete;
 
   private:
     taskArena_t arenaState;

--- a/code/components/misc_helper/psram.h
+++ b/code/components/misc_helper/psram.h
@@ -47,15 +47,6 @@ struct strSTBI {
 extern struct strSTBI STBIObjectPSRAM;
 
 
-struct strcJSON {
-    uint8_t *preallocatedMemory = NULL;
-    int preallocatedMemorySize = 0;
-    int usedMemory = 0;
-    bool useDefaultAllocation = false;
-};
-extern struct strcJSON cJSONObjectPSRAM;
-
-
 void *malloc_psram_heap(std::string name, size_t size, uint32_t caps);
 void *malloc_psram_heap_STBI(std::string name, size_t size, uint32_t caps);
 void *remalloc_psram_heap(std::string name, void *p, size_t size, uint32_t caps);
@@ -63,7 +54,38 @@ void *calloc_psram_heap(std::string name, size_t n, size_t size, uint32_t caps);
 
 void free_psram_heap(std::string name, void *ptr);
 
-void *malloc_psram_heap_cjson(size_t size);
-void free_psram_heap_cjson(void *ptr);
+
+// cJSON - PSRAM arena
+// ****************************************
+void initCjsonHooks(void);
+
+typedef struct {
+    uint8_t *buffer;
+    size_t capacity;
+    size_t offset;
+    bool active;
+} taskArena_t;
+
+// Thread-Local Storage pointer
+static __thread taskArena_t *tActiveArena = nullptr;
+
+class cJsonPsramArena
+{
+  public:
+    cJsonPsramArena(uint8_t *buffer, size_t capacity)
+    {
+        arenaState.buffer = buffer;
+        arenaState.capacity = capacity;
+        arenaState.offset = 0;
+        arenaState.active = true;
+
+        tActiveArena = &arenaState;
+    }
+
+    ~cJsonPsramArena() { tActiveArena = nullptr; }
+
+  private:
+    taskArena_t arenaState;
+};
 
 #endif // PSRAM_H_

--- a/code/components/misc_helper/psram.h
+++ b/code/components/misc_helper/psram.h
@@ -5,36 +5,64 @@
 #include <string>
 #include <unistd.h>
 
-/* SPIRAM profile in IDLE (date: 19.08.2023)*/
-/* Showing data for heap: 0x3f802fa8
-Block 0x3f803824 data, size: 55880 bytes, Free: No      --> WIFI
-Block 0x3f811270 data, size: 12 bytes, Free: No
-Block 0x3f811280 data, size: 56 bytes, Free: No
-Block 0x3f8112bc data, size: 16 bytes, Free: Yes
-Block 0x3f8112d0 data, size: 61440 bytes, Free: No      --> CAMERA
-Block 0x3f8202d4 data, size: 921604 bytes, Free: No     --> RAWIMAGE (shared)
-Block 0x3f9012dc data, size: 128004 bytes, Free: No     --> ALG_ROI
-Block 0x3f9206e4 data, size: 2816 bytes, Free: No       --> REF0
-Block 0x3f9211e8 data, size: 3964 bytes, Free: No       --> REF1
-Block 0x3f922168 data, size: 226968 bytes, Free: No     --> MODEL 1
-Block 0x3f959804 data, size: 1920 bytes, Free: No       --> ROIs DIGIT
-Block 0x3f959f88 data, size: 10904 bytes, Free: No      ..
-Block 0x3f95ca24 data, size: 1920 bytes, Free: No       ..
-Block 0x3f95d1a8 data, size: 10904 bytes, Free: No      ..
-Block 0x3f95fc44 data, size: 1920 bytes, Free: No       ..
-Block 0x3f9603c8 data, size: 10904 bytes, Free: No      ..
-Block 0x3f962e64 data, size: 1920 bytes, Free: No       ..
-Block 0x3f9635e8 data, size: 10904 bytes, Free: No      ..
-Block 0x3f966084 data, size: 133656 bytes, Free: No     --> MODEL 2
-Block 0x3f986aa0 data, size: 3072 bytes, Free: No       --> ROIs ANALOG
-Block 0x3f9876a4 data, size: 50700 bytes, Free: No      ..
-Block 0x3f993cb4 data, size: 3072 bytes, Free: No       ..
-Block 0x3f9948b8 data, size: 50700 bytes, Free: No      ..
-Block 0x3f9a0ec8 data, size: 3072 bytes, Free: No       ..
-Block 0x3f9a1acc data, size: 50700 bytes, Free: No      ..
-Block 0x3f9ae0dc data, size: 3072 bytes, Free: No       ..
-Block 0x3f9aece0 data, size: 50700 bytes, Free: No      ..
-Block 0x3f9bb2f0 data, size: 2379020 bytes, Free: Yes
+// SPIRAM profile in IDLE (date: 31.08.2026) / Freenove ESP32-S3 N16R8
+/*
+Showing data for heap: 0x3c160000
+Block 0x3c160900 data, size: 36 bytes, Free: No
+Block 0x3c160928 data, size: 36 bytes, Free: No
+Block 0x3c160950 data, size: 36 bytes, Free: No
+Block 0x3c160978 data, size: 36 bytes, Free: No
+Block 0x3c1609a0 data, size: 32768 bytes, Free: No      --> CONFIG
+Block 0x3c1689a4 data, size: 32768 bytes, Free: No      --> CONFIG
+Block 0x3c1709a8 data, size: 59392 bytes, Free: No      --> FAT
+Block 0x3c17f1ac data, size: 48 bytes, Free: No
+Block 0x3c17f1e0 data, size: 36 bytes, Free: No
+Block 0x3c17f208 data, size: 24 bytes, Free: No
+Block 0x3c17f224 data, size: 56 bytes, Free: No
+Block 0x3c17f260 data, size: 36 bytes, Free: No
+Block 0x3c17f288 data, size: 68 bytes, Free: No
+Block 0x3c17f2d0 data, size: 84 bytes, Free: No
+Block 0x3c17f328 data, size: 84 bytes, Free: No
+Block 0x3c17f380 data, size: 84 bytes, Free: No
+Block 0x3c17f3d8 data, size: 12 bytes, Free: No
+Block 0x3c17f3e8 data, size: 32 bytes, Free: No
+Block 0x3c17f40c data, size: 12 bytes, Free: No
+Block 0x3c17f41c data, size: 100 bytes, Free: No
+Block 0x3c17f484 data, size: 33792 bytes, Free: No      --> HTTP
+Block 0x3c187888 data, size: 720 bytes, Free: No
+Block 0x3c187b5c data, size: 16 bytes, Free: Yes
+Block 0x3c187b70 data, size: 56 bytes, Free: No
+Block 0x3c187bac data, size: 16 bytes, Free: Yes
+Block 0x3c187bc0 data, size: 61440 bytes, Free: No      --> CAMERA
+Block 0x3c196bc4 data, size: 168 bytes, Free: No
+Block 0x3c196c70 data, size: 24 bytes, Free: No
+Block 0x3c196c8c data, size: 36864 bytes, Free: No      --> WIFI
+Block 0x3c19fc90 data, size: 933888 bytes, Free: No     --> RAWIMAGE (shared)
+Block 0x3c283c94 data, size: 192512 bytes, Free: No     --> ALG_ROI
+Block 0x3c2b2c98 data, size: 2880 bytes, Free: No       --> REF0
+Block 0x3c2b37dc data, size: 4864 bytes, Free: No       --> REF1
+Block 0x3c2b4ae0 data, size: 229376 bytes, Free: No     --> MODEL 1
+Block 0x3c2ecae4 data, size: 1920 bytes, Free: No       --> ROIs DIGIT
+Block 0x3c2ed268 data, size: 3840 bytes, Free: No       ..
+Block 0x3c2ee16c data, size: 1920 bytes, Free: No       ..
+Block 0x3c2ee8f0 data, size: 3840 bytes, Free: No       ..
+Block 0x3c2ef7f4 data, size: 1920 bytes, Free: No       ..
+Block 0x3c2eff78 data, size: 3840 bytes, Free: No       ..
+Block 0x3c2f0e7c data, size: 1920 bytes, Free: No       ..
+Block 0x3c2f1600 data, size: 3840 bytes, Free: No       ..
+Block 0x3c2f2504 data, size: 1920 bytes, Free: No       ..
+Block 0x3c2f2c88 data, size: 3840 bytes, Free: No       ..
+Block 0x3c2f3b8c data, size: 135168 bytes, Free: No     --> MODEL 2
+Block 0x3c314b90 data, size: 3072 bytes, Free: No       --> ROIs ANALOG
+Block 0x3c315794 data, size: 21504 bytes, Free: No      ..
+Block 0x3c31ab98 data, size: 3072 bytes, Free: No       ..
+Block 0x3c31b79c data, size: 21504 bytes, Free: No      ..
+Block 0x3c320ba0 data, size: 3072 bytes, Free: No       ..
+Block 0x3c3217a4 data, size: 21504 bytes, Free: No      ..
+Block 0x3c326ba8 data, size: 3072 bytes, Free: No       ..
+Block 0x3c3277ac data, size: 21504 bytes, Free: No      ..
+Block 0x3c32cbb0 data, size: 256 bytes, Free: No
+Block 0x3c32ccb4 data, size: 6501192 bytes, Free: Yes
 */
 
 struct strSTBI {

--- a/code/include/defines.h
+++ b/code/include/defines.h
@@ -66,11 +66,6 @@
 #define XTENSA
 
 
-// ConfigClass
-//******************************
-#define CONFIG_HANDLING_PREALLOCATED_BUFFER_SIZE 32768 // Size of preallocated buffer for larger files (cJSON Object, JSON string buffer)
-
-
 // ClassControlCamera
 //******************************
 // Camera image size which is used for further processing (Max. 640 x 480 due to RAM restrictions)
@@ -114,8 +109,13 @@
 
 #define LOGFILE_LAST_PART_BYTES 80 * 1024 // 80 kBytes  // Size of partial log file to return
 
-#define WEBSERVER_SCRATCH_BUFSIZE  4096
+#define WEBSERVER_SCRATCH_BUFSIZE   32768
 #define SERVER_OTA_SCRATCH_BUFSIZE  1024
+
+
+// ConfigClass
+//******************************
+#define CONFIG_HANDLING_PREALLOCATED_BUFFER_SIZE 32768 // Size of preallocated buffer for larger files (cJSON Object, JSON string buffer)
 
 
 // Server_file + server_help

--- a/code/include/defines.h
+++ b/code/include/defines.h
@@ -115,7 +115,8 @@
 
 // ConfigClass
 //******************************
-#define CONFIG_HANDLING_PREALLOCATED_BUFFER_SIZE 32768 // Size of preallocated buffer for larger files (cJSON Object, JSON string buffer)
+#define CONFIG_HANDLING_CJSON_OBJECT_BUFFER_SIZE 65536 // Size of preallocated buffer for larger files (cJSON Object)
+#define CONFIG_HANDLING_CJSON_STRING_BUFFER_SIZE 32768 // Size of preallocated buffer for larger files (JSON string buffer)
 
 
 // Server_file + server_help

--- a/code/include/defines.h
+++ b/code/include/defines.h
@@ -115,7 +115,7 @@
 
 // ConfigClass
 //******************************
-#define CONFIG_HANDLING_CJSON_OBJECT_BUFFER_SIZE 65536 // Size of preallocated buffer for larger files (cJSON Object)
+#define CONFIG_HANDLING_CJSON_OBJECT_BUFFER_SIZE 32768 // Size of preallocated buffer for larger files (cJSON Object)
 #define CONFIG_HANDLING_CJSON_STRING_BUFFER_SIZE 32768 // Size of preallocated buffer for larger files (JSON string buffer)
 
 


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Summary</h3>

The PR makes configuration parsing, serialization, and persistence use mutex-protected cJSON arenas backed by PSRAM.
- Separates parsing and serialization arena lifetimes so each operation receives the full arena capacity.
- Receives and returns configuration payloads through the HTTP scratch buffer while protecting shared configuration state.
- Installs process-wide cJSON hooks whose active arena is selected through task-local state.
- Adds allocation checks, bounded payload handling, and explicit persistence error reporting.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| code/components/config_handling/configClass.cpp | Centralizes configuration parsing, serialization, persistence, and HTTP handling around a mutex and separate PSRAM arena scopes. |
| code/components/config_handling/configClass.h | Adds the mutex guard and updates the configuration parsing and persistence interfaces. |
| code/components/misc_helper/psram.cpp | Implements task-local cJSON arena selection and process-wide allocation hooks. |
| code/components/misc_helper/psram.h | Defines the cJSON arena state and RAII interface. |
| code/include/defines.h | Defines matching 32 KiB object, string, and HTTP scratch-buffer capacities. |

</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client
    participant HTTP as HTTP handler
    participant Mutex as cfgMutex
    participant Arena as PSRAM cJSON arena
    participant Config as Config state
    participant SD as Config file

    Client->>HTTP: POST /config
    HTTP->>HTTP: Receive complete payload into scratch
    HTTP->>Mutex: Acquire
    HTTP->>Arena: Activate parse arena
    Arena->>Config: Parse and apply configuration
    HTTP->>Arena: Reset parse arena
    HTTP->>Arena: Activate serialization arena
    Config->>Arena: Serialize configuration
    Arena-->>HTTP: JSON response
    HTTP->>SD: Persist JSON
    HTTP->>Mutex: Release
    HTTP-->>Client: Send response from scratch
```
</details>

<sub>Reviews (23): Last reviewed commit: ["Update"](https://github.com/slider0007/ai-on-the-edge-device/commit/6d81a5caa742b3a54484fc632fed9071a37c0173) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58068304)</sub>

<!-- /greptile_comment -->

---
### Usage Stats

Before (based on ESP32CAM)
RAM:   [==        ]  15.2% (used 49824 bytes from 327680 bytes)
Flash: [========  ]  79.4% (used 1544966 bytes from 1945600 bytes)

After
RAM:   [==        ]  15.2% (used 49808 bytes from 327680 bytes)
Flash: [========  ]  79.5% (used 1546806 bytes from 1945600 bytes)