### PR TITLE
fix(gpio handler): Fix sporadic race condition using smartleds during reinit

### DIFF
--- a/code/components/gpio_ctrl/gpioControl.cpp
+++ b/code/components/gpio_ctrl/gpioControl.cpp
@@ -377,6 +377,7 @@ void GpioHandler::clearData()
             // Free smartLED instances
             if ((it->second->getMode() == GPIO_PIN_MODE_FLASHLIGHT_SMARTLED || it->second->getMode() == GPIO_PIN_MODE_STATUSLED_SMARTLED) &&
                 it->second->getSmartLed() != NULL) {
+                it->second->getSmartLed()->wait();
                 delete it->second->getSmartLed();
                 it->second->setSmartLed(NULL);
             }
@@ -391,6 +392,9 @@ void GpioHandler::clearData()
     }
 
     frequencyTable.clear();
+
+    // Yield to let IPC background tasks finishing ISR deinit
+    vTaskDelay(pdMS_TO_TICKS(100));
 
     // gpio_uninstall_isr_service(); can't uninstall, ISR service is also used by camera
 }

--- a/code/components/gpio_ctrl/gpioControl.cpp
+++ b/code/components/gpio_ctrl/gpioControl.cpp
@@ -377,7 +377,7 @@ void GpioHandler::clearData()
             // Free smartLED instances
             if ((it->second->getMode() == GPIO_PIN_MODE_FLASHLIGHT_SMARTLED || it->second->getMode() == GPIO_PIN_MODE_STATUSLED_SMARTLED) &&
                 it->second->getSmartLed() != NULL) {
-                it->second->getSmartLed()->wait();
+                it->second->getSmartLed()->wait(pdMS_TO_TICKS(50));
                 delete it->second->getSmartLed();
                 it->second->setSmartLed(NULL);
             }


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Summary</h3>

The PR adjusts GPIO teardown sequencing to reduce a sporadic SmartLED race.
- Waits up to 50 ticks for each SmartLED before deleting it.
- Adds a 100 ms yield after clearing GPIO and frequency state so background deinitialization can finish.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because no blocking failure remains within the eligible follow-up review scope.

No blocking failure remains.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| code/components/gpio_ctrl/gpioControl.cpp | Adds bounded SmartLED completion waiting and a post-cleanup delay to reduce teardown races. |

</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant GH as GpioHandler
    participant LED as SmartLED
    participant BG as IPC background tasks
    GH->>LED: wait(50 ticks)
    GH->>LED: delete
    GH->>GH: clear GPIO and frequency state
    GH-->>BG: yield for 100 ms
    BG-->>GH: finish deinitialization work
```
</details>

<sub>Reviews (2): Last reviewed commit: ["Update"](https://github.com/slider0007/ai-on-the-edge-device/commit/7bbf2513ee1a1628e9e763c61e9a58ddc6f19a74) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59062656)</sub>

<!-- /greptile_comment -->