### PR TITLE
fix(rest api - config): Reload configuration on POST request

### DIFF
--- a/code/components/config_handling/configClass.cpp
+++ b/code/components/config_handling/configClass.cpp
@@ -2932,12 +2932,9 @@ esp_err_t ConfigClass::setConfigRequest(httpd_req_t *req, bool triggerReload)
 
     // Scratch buffer must accommodate the complete payload plus '\0'
     if (req->content_len >= WEBSERVER_SCRATCH_BUFSIZE) {
-        httpd_resp_set_type(req, "application/json");
         httpd_resp_send_err(req, HTTPD_413_CONTENT_TOO_LARGE, "Payload exceeds maximum buffer size");
         return ESP_FAIL;
     }
-
-    httpd_resp_set_type(req, "application/json");
 
     // Receive the complete request into the webserver scratch buffer
     size_t remaining = req->content_len;
@@ -3021,6 +3018,11 @@ esp_err_t ConfigClass::setConfigRequest(httpd_req_t *req, bool triggerReload)
                 }
             }
         } // Free serialization arena
+
+        // Persist updated configuration
+        if (retVal == ESP_OK) {
+            retVal = writeConfigFile();
+        }
     } // Release cfgMutex
 
     // HTTP response
@@ -3029,21 +3031,18 @@ esp_err_t ConfigClass::setConfigRequest(httpd_req_t *req, bool triggerReload)
         return retVal;
     }
 
-    // Stage config reload + add headers
-    if (triggerReload) {
-        triggerReloadConfig(req);
-    }
-    retVal = httpd_resp_send(req, httpBuffer, HTTPD_RESP_USE_STRLEN);
-
-    // Persist updated configuration
-    // Note: Using httpBuffer - exclusivly used until functions returns
-    esp_err_t writeStatus = writeConfigFile(httpBuffer, strlen(httpBuffer));
-
-    // Return write stataus only if send step was successful
+    // HTTP response
     if (retVal == ESP_OK) {
-        return writeStatus;
+        // Stage config reload + add custom headers
+        if (triggerReload) {
+            triggerReloadConfig(req);
+        }
+
+        httpd_resp_set_type(req, "application/json");
+        return httpd_resp_send(req, httpBuffer, HTTPD_RESP_USE_STRLEN);
     }
 
+    httpd_resp_send_err(req, httpError, errorMsg);
     return retVal;
 }
 

--- a/code/components/config_handling/configClass.cpp
+++ b/code/components/config_handling/configClass.cpp
@@ -2658,21 +2658,20 @@ esp_err_t ConfigClass::writeConfigFile()
 {
     FILE *file = fopen(CONFIG_PERSISTENCE_FILE, "w");
     if (!file) {
-        LogFile.writeToFile(ESP_LOG_ERROR, TAG, "writeConfigFile: Failed to write JSON file");
+        LogFile.writeToFile(ESP_LOG_ERROR, TAG, "writeConfigFile: Failed to open config file");
         return ESP_FAIL;
     }
 
     const size_t bufLength = strlen(jsonBuffer);
-    size_t written = fwrite(jsonBuffer, 1, bufLength, file);
-    fclose(file);
 
-    if (written != bufLength) {
-        LogFile.writeToFile(ESP_LOG_ERROR, TAG, "writeConfigFile: Failed to write complete JSON data");
+    if (fwrite(jsonBuffer, 1, bufLength, file) != bufLength || fflush(file) != 0 || fsync(fileno(file)) != 0 || fclose(file) != 0) {
+        LogFile.writeToFile(ESP_LOG_ERROR, TAG, "writeConfigFile: Failed to write config file");
         return ESP_FAIL;
     }
 
-    // Save config file additionally as fallback config file
-    copyFile(CONFIG_PERSISTENCE_FILE, CONFIG_PERSISTENCE_FILE_FALLBACK);
+    if (copyFile(CONFIG_PERSISTENCE_FILE, CONFIG_PERSISTENCE_FILE_FALLBACK) != ESP_OK) {
+        LogFile.writeToFile(ESP_LOG_WARN, TAG, "writeConfigFile: Failed to update fallback config file");
+    }
 
     return ESP_OK;
 }

--- a/code/components/config_handling/configClass.cpp
+++ b/code/components/config_handling/configClass.cpp
@@ -3025,12 +3025,6 @@ esp_err_t ConfigClass::setConfigRequest(httpd_req_t *req, bool triggerReload)
     } // Release cfgMutex
 
     // HTTP response
-    if (retVal != ESP_OK) {
-        httpd_resp_send_err(req, httpError, errorMsg);
-        return retVal;
-    }
-
-    // HTTP response
     if (retVal == ESP_OK) {
         // Stage config reload + add custom headers
         if (triggerReload) {

--- a/code/components/config_handling/configClass.cpp
+++ b/code/components/config_handling/configClass.cpp
@@ -205,7 +205,7 @@ bool ConfigClass::parseJsonFromFile(const char *jsonStr, bool unityTest)
     } // Free serialization arena
 
     // Persist updated configuration
-    if (!unityTest && writeConfigFile(jsonBuffer, strlen(jsonBuffer)) != ESP_OK) {
+    if (!unityTest && writeConfigFile() != ESP_OK) {
         LogFile.writeToFile(ESP_LOG_ERROR, TAG, "parseJsonFromFile: Failed to write configuration file");
         return false;
     }
@@ -2647,17 +2647,16 @@ bool ConfigClass::persistConfig()
         return false;
     }
 
-    return (writeConfigFile(jsonBuffer, strlen(jsonBuffer)) == ESP_OK);
+    return (writeConfigFile() == ESP_OK);
 }
 
 
 //**************************************************************************************************
 // Write configuration to file (JSON string)
 //**************************************************************************************************
-esp_err_t ConfigClass::writeConfigFile(const char *buf, const size_t bufLen)
+esp_err_t ConfigClass::writeConfigFile()
 {
     FILE *file = fopen(CONFIG_PERSISTENCE_FILE, "w");
-
     if (!file) {
         LogFile.writeToFile(ESP_LOG_ERROR, TAG, "writeConfigFile: Failed to write JSON file");
         return ESP_FAIL;

--- a/code/components/config_handling/configClass.cpp
+++ b/code/components/config_handling/configClass.cpp
@@ -205,7 +205,7 @@ bool ConfigClass::parseJsonFromFile(const char *jsonStr, bool unityTest)
     } // Free serialization arena
 
     // Persist updated configuration
-    if (!unityTest && writeConfigFile() != ESP_OK) {
+    if (!unityTest && writeConfigFile(jsonBuffer, strlen(jsonBuffer)) != ESP_OK) {
         LogFile.writeToFile(ESP_LOG_ERROR, TAG, "parseJsonFromFile: Failed to write configuration file");
         return false;
     }
@@ -2647,14 +2647,14 @@ bool ConfigClass::persistConfig()
         return false;
     }
 
-    return (writeConfigFile() == ESP_OK);
+    return (writeConfigFile(jsonBuffer, strlen(jsonBuffer)) == ESP_OK);
 }
 
 
 //**************************************************************************************************
 // Write configuration to file (JSON string)
 //**************************************************************************************************
-esp_err_t ConfigClass::writeConfigFile()
+esp_err_t ConfigClass::writeConfigFile(const char *buf, const size_t bufLen)
 {
     FILE *file = fopen(CONFIG_PERSISTENCE_FILE, "w");
 
@@ -2912,7 +2912,7 @@ esp_err_t ConfigClass::getConfigRequest(httpd_req_t *req)
 //**************************************************************************************************
 // Update configuration via REST API (JSON notation)
 //**************************************************************************************************
-esp_err_t ConfigClass::setConfigRequest(httpd_req_t *req)
+esp_err_t ConfigClass::setConfigRequest(httpd_req_t *req, bool triggerReload)
 {
     if (!cJsonObjectBuffer || !jsonBuffer || !cfgMutex || !req) {
         return ESP_FAIL;
@@ -2949,7 +2949,6 @@ esp_err_t ConfigClass::setConfigRequest(httpd_req_t *req)
 
         if (received <= 0) {
             if (received == HTTPD_SOCK_ERR_TIMEOUT && ++retries < 5) {
-                vTaskDelay(pdMS_TO_TICKS(10));
                 continue;
             }
 
@@ -3022,19 +3021,29 @@ esp_err_t ConfigClass::setConfigRequest(httpd_req_t *req)
                 }
             }
         } // Free serialization arena
-
-        // Persist updated configuration
-        if (retVal == ESP_OK) {
-            retVal = writeConfigFile();
-        }
     } // Release cfgMutex
 
     // HTTP response
-    if (retVal == ESP_OK) {
-        return httpd_resp_send(req, httpBuffer, HTTPD_RESP_USE_STRLEN);
+    if (retVal != ESP_OK) {
+        httpd_resp_send_err(req, httpError, errorMsg);
+        return retVal;
     }
 
-    httpd_resp_send_err(req, httpError, errorMsg);
+    // Stage config reload + add headers
+    if (triggerReload) {
+        triggerReloadConfig(req);
+    }
+    retVal = httpd_resp_send(req, httpBuffer, HTTPD_RESP_USE_STRLEN);
+
+    // Persist updated configuration
+    // Note: Using httpBuffer - exclusivly used until functions returns
+    esp_err_t writeStatus = writeConfigFile(httpBuffer, strlen(httpBuffer));
+
+    // Return write stataus only if send step was successful
+    if (retVal == ESP_OK) {
+        return writeStatus;
+    }
+
     return retVal;
 }
 
@@ -3066,7 +3075,24 @@ esp_err_t handlerGetConfigRequest(httpd_req_t *req)
 
 esp_err_t handlerSetConfigRequest(httpd_req_t *req)
 {
-    return ConfigClass::getInstance()->setConfigRequest(req);
+    // Check for query parameter
+    bool triggerReload = false;
+    size_t queryLen = httpd_req_get_url_query_len(req);
+
+    if (queryLen > 0) {
+        char queryBuf[queryLen + 1];
+        if (httpd_req_get_url_query_str(req, queryBuf, sizeof(queryBuf)) == ESP_OK) {
+            char valBuf[16] = {0};
+            if (httpd_query_key_value(queryBuf, "reload", valBuf, sizeof(valBuf)) == ESP_OK) {
+                if (strcasecmp(valBuf, "true") == 0 || strcmp(valBuf, "1") == 0) {
+                    triggerReload = true;
+                }
+            }
+        }
+    }
+
+    // Process setConfigRequest
+    return ConfigClass::getInstance()->setConfigRequest(req, triggerReload);
 }
 
 
@@ -3084,7 +3110,13 @@ void registerConfigFileUri(httpd_handle_t server)
 
     camuri.uri = "/config";
     camuri.handler = HTTP_AUTH_BASIC(handlerSetConfigRequest);
-    camuri.method = HTTP_POST,
+    camuri.method = HTTP_POST;
     camuri.user_ctx = httpServerData; // Pass server data as context
+    httpd_register_uri_handler(server, &camuri);
+
+    camuri.uri = "/config";
+    camuri.handler = HTTP_AUTH_BASIC(NULL);
+    camuri.method = HTTP_OPTIONS;
+    camuri.user_ctx = NULL;
     httpd_register_uri_handler(server, &camuri);
 }

--- a/code/components/config_handling/configClass.cpp
+++ b/code/components/config_handling/configClass.cpp
@@ -2664,7 +2664,17 @@ esp_err_t ConfigClass::writeConfigFile()
 
     const size_t bufLength = strlen(jsonBuffer);
 
-    if (fwrite(jsonBuffer, 1, bufLength, file) != bufLength || fflush(file) != 0 || fsync(fileno(file)) != 0 || fclose(file) != 0) {
+    bool writeFailed = fwrite(jsonBuffer, 1, bufLength, file) != bufLength;
+    if (!writeFailed) {
+        writeFailed = fflush(file) != 0;
+    }
+    if (!writeFailed) {
+        writeFailed = fsync(fileno(file)) != 0;
+    }
+    if (fclose(file) != 0) {
+        writeFailed = true;
+    }
+    if (writeFailed) {
         LogFile.writeToFile(ESP_LOG_ERROR, TAG, "writeConfigFile: Failed to write config file");
         return ESP_FAIL;
     }

--- a/code/components/config_handling/configClass.h
+++ b/code/components/config_handling/configClass.h
@@ -56,10 +56,14 @@ class ConfigClass
     char *httpBuffer = NULL;
 
     bool parseJsonFromFile(const char *jsonStr, bool unityTest = false);
+
+    // Parse JSON to internal struct
     esp_err_t parseConfig(bool init = false, bool unityTest = false);
+
+    // Serialize internal struct to JSON string
     esp_err_t serializeConfig(bool unityTest = false);
-    bool serializeConfigToPersist(void);
-    esp_err_t writeConfigFile(void);
+
+    esp_err_t writeConfigFile(const char *buf, const size_t bufLen);
 
     bool loadDataFromNVS(std::string key, std::string &value);
     bool saveDataToNVS(std::string key, std::string value);
@@ -82,7 +86,7 @@ class ConfigClass
     const CfgData *get(void) const { return &cfgData; };
 
     esp_err_t getConfigRequest(httpd_req_t *req);
-    esp_err_t setConfigRequest(httpd_req_t *req);
+    esp_err_t setConfigRequest(httpd_req_t *req, bool triggerReload = false);
 
     // Only for migration and internal parameter modification purpose
     void initCfgTmp(void)
@@ -98,7 +102,12 @@ class ConfigClass
     char *getJsonBuffer(void) { return jsonBuffer; };
 };
 
+void registerConfigFileUri(httpd_handle_t server);
 
+
+//-------------------------------------------------------------------------------------
+// Mutex Guard
+//-------------------------------------------------------------------------------------
 class CfgMutexGuard
 {
     SemaphoreHandle_t mMutex;
@@ -121,8 +130,5 @@ class CfgMutexGuard
         }
     }
 };
-
-
-void registerConfigFileUri(httpd_handle_t server);
 
 #endif // CONFIGCLASS_H

--- a/code/components/config_handling/configClass.h
+++ b/code/components/config_handling/configClass.h
@@ -63,7 +63,7 @@ class ConfigClass
     // Serialize internal struct to JSON string
     esp_err_t serializeConfig(bool unityTest = false);
 
-    esp_err_t writeConfigFile(const char *buf, const size_t bufLen);
+    esp_err_t writeConfigFile();
 
     bool loadDataFromNVS(std::string key, std::string &value);
     bool saveDataToNVS(std::string key, std::string value);

--- a/code/components/mainprocess_ctrl/MainFlowControl.cpp
+++ b/code/components/mainprocess_ctrl/MainFlowControl.cpp
@@ -117,38 +117,58 @@ bool doInit(void)
 
 esp_err_t triggerReloadConfig(httpd_req_t *req)
 {
-    httpd_resp_set_type(req, "text/plain");
+    static char codeBuf[16] = {0};
+    static char messageBuf[128] = {0};
+
+    const std::string timestamp = getCurrentTimeString("%H:%M:%S");
 
     if (taskAutoFlowState == FLOW_TASK_STATE_INIT || taskAutoFlowState == FLOW_TASK_STATE_SETUPMODE ||
         taskAutoFlowState == FLOW_TASK_STATE_IDLE_NO_AUTOSTART) {
-        const std::string zw = "001: Reload config and redo flow initialization (" + getCurrentTimeString("%H:%M:%S") + ")";
-        httpd_resp_send(req, zw.c_str(), zw.length());
+
+        snprintf(codeBuf, sizeof(codeBuf), "001");
+        snprintf(messageBuf, sizeof(messageBuf), "001: Reload config and redo flow initialization (%s)", timestamp.c_str());
         reloadConfig = true;
     }
     else if (taskAutoFlowState == FLOW_TASK_STATE_INIT_DELAYED) {
-        const std::string zw = "002: Abort waiting delay and continue with process initialization (" + getCurrentTimeString("%H:%M:%S") +
-                               ")";
-        httpd_resp_send(req, zw.c_str(), zw.length());
-        xTaskAbortDelay(xHandletask_autodoFlow); // Delay will be aborted if task is in blocked (waiting) state.
+        snprintf(codeBuf, sizeof(codeBuf), "002");
+        snprintf(messageBuf, sizeof(messageBuf), "002: Abort waiting delay and continue with process initialization (%s)",
+                 timestamp.c_str());
+        xTaskAbortDelay(xHandletask_autodoFlow);
     }
     else if (taskAutoFlowState == FLOW_TASK_STATE_IDLE_AUTOSTART) {
-        const std::string zw = "003: Abort waiting delay, reload config and reinitialize process(" + getCurrentTimeString("%H:%M:%S") + ")";
-        httpd_resp_send(req, zw.c_str(), zw.length());
+        snprintf(codeBuf, sizeof(codeBuf), "003");
+        snprintf(messageBuf, sizeof(messageBuf), "003: Abort waiting delay, reload config and reinitialize process (%s)",
+                 timestamp.c_str());
         reloadConfig = true;
-        xTaskAbortDelay(xHandletask_autodoFlow); // Delay will be aborted if task is in blocked (waiting) state.
+        xTaskAbortDelay(xHandletask_autodoFlow);
     }
     else if (taskAutoFlowState == FLOW_TASK_STATE_IMG_PROCESSING || taskAutoFlowState == FLOW_TASK_STATE_PUBLISH_DATA ||
              taskAutoFlowState == FLOW_TASK_STATE_ADDITIONAL_TASKS) {
+
         LogFile.writeToFile(ESP_LOG_DEBUG, TAG, "Reload config and schedule process reinitialization");
-        const std::string zw = "004: Reload config and reinitialization got scheduled (" + getCurrentTimeString("%H:%M:%S") + ")";
-        httpd_resp_send(req, zw.c_str(), zw.length());
+        snprintf(codeBuf, sizeof(codeBuf), "004");
+        snprintf(messageBuf, sizeof(messageBuf), "004: Reload config and reinitialization got scheduled (%s)", timestamp.c_str());
         reloadConfig = true;
     }
     else {
         LogFile.writeToFile(ESP_LOG_WARN, TAG, "Reload configuration not possible. No main task. Request rejected");
-        const std::string zw = "E90: Reload config not possible. No main task. Request rejected (" + getCurrentTimeString("%H:%M:%S") + ")";
-        httpd_resp_send(req, zw.c_str(), zw.length());
+        snprintf(codeBuf, sizeof(codeBuf), "E90");
+        snprintf(messageBuf, sizeof(messageBuf), "E90: Reload config not possible. No main task. Request rejected (%s)", timestamp.c_str());
     }
+
+    // --- Send Response
+    if (req->method == HTTP_GET) {
+        // GET Request: Plain text response body
+        httpd_resp_set_type(req, "text/plain");
+        return httpd_resp_send(req, messageBuf, strlen(messageBuf));
+    }
+    else if (req->method == HTTP_POST) {
+        // httpd_resp_set_type(req, "application/json");
+        httpd_resp_set_hdr(req, "Access-Control-Expose-Headers", "X-Reload-Code, X-Reload-Message");
+        httpd_resp_set_hdr(req, "X-Reload-Code", codeBuf);
+        httpd_resp_set_hdr(req, "X-Reload-Message", messageBuf);
+    }
+
     return ESP_OK;
 }
 

--- a/code/components/mainprocess_ctrl/MainFlowControl.cpp
+++ b/code/components/mainprocess_ctrl/MainFlowControl.cpp
@@ -124,7 +124,6 @@ esp_err_t triggerReloadConfig(httpd_req_t *req)
 
     if (taskAutoFlowState == FLOW_TASK_STATE_INIT || taskAutoFlowState == FLOW_TASK_STATE_SETUPMODE ||
         taskAutoFlowState == FLOW_TASK_STATE_IDLE_NO_AUTOSTART) {
-
         snprintf(codeBuf, sizeof(codeBuf), "001");
         snprintf(messageBuf, sizeof(messageBuf), "001: Reload config and redo flow initialization (%s)", timestamp.c_str());
         reloadConfig = true;
@@ -144,7 +143,6 @@ esp_err_t triggerReloadConfig(httpd_req_t *req)
     }
     else if (taskAutoFlowState == FLOW_TASK_STATE_IMG_PROCESSING || taskAutoFlowState == FLOW_TASK_STATE_PUBLISH_DATA ||
              taskAutoFlowState == FLOW_TASK_STATE_ADDITIONAL_TASKS) {
-
         LogFile.writeToFile(ESP_LOG_DEBUG, TAG, "Reload config and schedule process reinitialization");
         snprintf(codeBuf, sizeof(codeBuf), "004");
         snprintf(messageBuf, sizeof(messageBuf), "004: Reload config and reinitialization got scheduled (%s)", timestamp.c_str());
@@ -158,12 +156,10 @@ esp_err_t triggerReloadConfig(httpd_req_t *req)
 
     // --- Send Response
     if (req->method == HTTP_GET) {
-        // GET Request: Plain text response body
         httpd_resp_set_type(req, "text/plain");
         return httpd_resp_send(req, messageBuf, strlen(messageBuf));
     }
     else if (req->method == HTTP_POST) {
-        // httpd_resp_set_type(req, "application/json");
         httpd_resp_set_hdr(req, "Access-Control-Expose-Headers", "X-Reload-Code, X-Reload-Message");
         httpd_resp_set_hdr(req, "X-Reload-Code", codeBuf);
         httpd_resp_set_hdr(req, "X-Reload-Message", messageBuf);

--- a/code/components/webserver_softap/http_auth.cpp
+++ b/code/components/webserver_softap/http_auth.cpp
@@ -36,87 +36,73 @@ static char *getAuthBase64Encoded(const std::string username, const std::string 
 }
 
 
+static esp_err_t sendAuthRequired(httpd_req_t *req, const char *message)
+{
+    httpd_resp_set_hdr(req, "WWW-Authenticate", "Basic realm=\"AI-on-the-Edge\"");
+    return httpd_resp_send_err(req, HTTPD_401_UNAUTHORIZED, message);
+}
+
+
 esp_err_t handleHttpAuthBasic(httpd_req_t *req, esp_err_t httpHandler(httpd_req_t *))
 {
-    // Allow permissive cross-origin requests by design
-    char originBuf[128] = {0};
+    const auto *config = ConfigClass::getInstance()->get();
+    const auto &auth = config->sectionWebUi.httpAuth;
+    const bool authActive = auth.authMode != HTTP_AUTH_DISABLED && getSystemStatus() == 0;
 
-    size_t bufLen = httpd_req_get_hdr_value_len(req, "Origin");
+    // CORS handling (permissive cross-origin requests by design)
+    char originBuf[128] = {};
+    const size_t originLen = httpd_req_get_hdr_value_len(req, "Origin");
 
-    if (bufLen > 0 && bufLen < sizeof(originBuf)) {
-        if (httpd_req_get_hdr_value_str(req, "Origin", originBuf, sizeof(originBuf)) == ESP_OK) {
-            httpd_resp_set_hdr(req, "Access-Control-Allow-Origin", originBuf);
-        }
-        else {
-            httpd_resp_set_hdr(req, "Access-Control-Allow-Origin", "*");
-        }
+    if (originLen > 0 && originLen < sizeof(originBuf) &&
+        httpd_req_get_hdr_value_str(req, "Origin", originBuf, sizeof(originBuf)) == ESP_OK) {
+        httpd_resp_set_hdr(req, "Access-Control-Allow-Origin", originBuf);
+        httpd_resp_set_hdr(req, "Vary", "Origin");
+        httpd_resp_set_hdr(req, "Access-Control-Allow-Credentials", "true");
+        httpd_resp_set_hdr(req, "Access-Control-Allow-Methods", "GET, POST, OPTIONS");
+        httpd_resp_set_hdr(req, "Access-Control-Allow-Headers", authActive ? "Content-Type, Authorization" : "Content-Type");
     }
-    else {
-        httpd_resp_set_hdr(req, "Access-Control-Allow-Origin", "*");
-    }
 
-    // Permissive CORS parameters
-    httpd_resp_set_hdr(req, "Access-Control-Allow-Credentials", "true");
-    httpd_resp_set_hdr(req, "Access-Control-Allow-Methods", "GET, POST, OPTIONS");
-    httpd_resp_set_hdr(req, "Access-Control-Allow-Headers", "Content-Type, Authorization");
-
-    // Bypass Auth for CORS Preflight (OPTIONS Requests)
+    // CORS preflight
     if (req->method == HTTP_OPTIONS) {
-        httpd_resp_send(req, NULL, 0); // Respond 200 OK to CORS preflight
-        return ESP_OK;
+        return httpd_resp_send(req, NULL, 0);
     }
 
     // Skip authorization check if
     // 1. HTTP authorization is disabled
     // 2. At critical system state (reduced web interface)
-    if (ConfigClass::getInstance()->get()->sectionWebUi.httpAuth.authMode == HTTP_AUTH_DISABLED || getSystemStatus() > 0) {
+    if (!authActive) {
         return httpHandler(req);
     }
 
-    // Perform authorization check
-    esp_err_t retVal = ESP_FAIL;
-    bufLen = httpd_req_get_hdr_value_len(req, "Authorization") + 1;
-    if (bufLen > 1) {
-        char *buf = (char *)calloc(1, bufLen);
-        if (buf == NULL) {
-            LogFile.writeToFile(ESP_LOG_ERROR, TAG, "Failed to allocate memory (buf)");
-            return ESP_ERR_NO_MEM;
-        }
+    // Authorization header
+    constexpr size_t MAX_AUTH_HEADER_LEN = 128;
+    char authHeader[MAX_AUTH_HEADER_LEN + 1] = {};
+    const size_t authLen = httpd_req_get_hdr_value_len(req, "Authorization");
 
-        if (httpd_req_get_hdr_value_str(req, "Authorization", buf, bufLen) == ESP_OK) {
-            char *userAuthEncoded = getAuthBase64Encoded(ConfigClass::getInstance()->get()->sectionWebUi.httpAuth.username,
-                                                         ConfigClass::getInstance()->get()->sectionWebUi.httpAuth.password);
-
-            if (strncmp((const char *)userAuthEncoded, (const char *)buf, bufLen) == 0) {
-                retVal = httpHandler(req);
-            }
-            else {
-                LogFile.writeToFile(ESP_LOG_WARN, TAG, "Access denied. Wrong username or password");
-                httpd_resp_set_status(req, "401 Unauthorized");
-                httpd_resp_set_type(req, "text/html");
-                httpd_resp_set_hdr(req, "WWW-Authenticate", "Basic realm=\"AI-on-the-Edge\"");
-                httpd_resp_send_err(req, HTTPD_401_UNAUTHORIZED, "Access denied. Wrong username or password");
-            }
-
-            free(userAuthEncoded);
-        }
-        else {
-            LogFile.writeToFile(ESP_LOG_WARN, TAG, "Access denied. No or invalid authorization data");
-            httpd_resp_set_status(req, "401 Unauthorized");
-            httpd_resp_set_type(req, "text/html");
-            httpd_resp_set_hdr(req, "WWW-Authenticate", "Basic realm=\"AI-on-the-Edge\"");
-            httpd_resp_send_err(req, HTTPD_401_UNAUTHORIZED, "Access denied. No or invalid authorization data");
-        }
-
-        free(buf);
-    }
-    else {
-        LogFile.writeToFile(ESP_LOG_DEBUG, TAG, "Access denied. No authorization header");
-        httpd_resp_set_status(req, "401 Unauthorized");
-        httpd_resp_set_type(req, "application/json");
-        httpd_resp_set_hdr(req, "WWW-Authenticate", "Basic realm=\"AI-on-the-Edge\"");
-        httpd_resp_send(req, NULL, 0);
+    if (authLen == 0 || authLen > MAX_AUTH_HEADER_LEN) {
+        LogFile.writeToFile(ESP_LOG_DEBUG, TAG, "Access denied. No or invalid authorization data");
+        return sendAuthRequired(req, "Access denied");
     }
 
-    return retVal;
+    if (httpd_req_get_hdr_value_str(req, "Authorization", authHeader, sizeof(authHeader)) != ESP_OK) {
+        return sendAuthRequired(req, "Access denied");
+    }
+
+    char *expectedAuth = getAuthBase64Encoded(auth.username, auth.password);
+
+    if (expectedAuth == nullptr) {
+        return ESP_ERR_NO_MEM;
+    }
+
+    const size_t expectedLen = strlen(expectedAuth);
+    const bool authorized = authLen == expectedLen && memcmp(expectedAuth, authHeader, expectedLen) == 0;
+
+    free(expectedAuth);
+
+    if (!authorized) {
+        LogFile.writeToFile(ESP_LOG_WARN, TAG, "Access denied. Wrong username or password");
+        return sendAuthRequired(req, "Access denied");
+    }
+
+    return httpHandler(req);
 }

--- a/code/components/webserver_softap/http_auth.cpp
+++ b/code/components/webserver_softap/http_auth.cpp
@@ -39,21 +39,33 @@ static char *getAuthBase64Encoded(const std::string username, const std::string 
 esp_err_t handleHttpAuthBasic(httpd_req_t *req, esp_err_t httpHandler(httpd_req_t *))
 {
     // Cross origin handling (e.g. allow access from localhost (test environment))
-    size_t bufLen = httpd_req_get_hdr_value_len(req, "Origin") + 1;
-    if (bufLen > 1) {
-        char *buf = (char *)calloc(1, bufLen);
-        if (buf == NULL) {
-            LogFile.writeToFile(ESP_LOG_ERROR, TAG, "Failed to allocate memory (buf1)");
-            return ESP_ERR_NO_MEM;
-        }
+    char originBuf[128] = {0};
+    const char *originKey = "Origin";
 
-        if (httpd_req_get_hdr_value_str(req, "Origin", buf, bufLen) == ESP_OK) {
-            static const std::string origin(buf, bufLen);
-            httpd_resp_set_hdr(req, "Access-Control-Allow-Origin", origin.c_str()); //@TODO FEATURE: Origin whitelist?
-            httpd_resp_set_hdr(req, "Access-Control-Allow-Credentials", "true");
-        }
+    size_t bufLen = httpd_req_get_hdr_value_len(req, "Origin");
+    if (bufLen == 0) {
+        bufLen = httpd_req_get_hdr_value_len(req, "origin");
+        originKey = "origin";
+    }
 
-        free(buf);
+    if (bufLen > 0 && bufLen < sizeof(originBuf)) {
+        if (httpd_req_get_hdr_value_str(req, originKey, originBuf, sizeof(originBuf)) == ESP_OK) {
+            httpd_resp_set_hdr(req, "Access-Control-Allow-Origin", originBuf);
+        }
+    }
+    else {
+        httpd_resp_set_hdr(req, "Access-Control-Allow-Origin", "*");
+    }
+
+    // Always set remaining CORS rules
+    httpd_resp_set_hdr(req, "Access-Control-Allow-Credentials", "true");
+    httpd_resp_set_hdr(req, "Access-Control-Allow-Methods", "GET, POST, OPTIONS");
+    httpd_resp_set_hdr(req, "Access-Control-Allow-Headers", "Content-Type, Authorization");
+
+    // Bypass Auth for CORS Preflight (OPTIONS Requests)
+    if (req->method == HTTP_OPTIONS) {
+        httpd_resp_send(req, NULL, 0); // Respond 200 OK to CORS preflight
+        return ESP_OK;
     }
 
     // Skip authorization check if

--- a/code/components/webserver_softap/http_auth.cpp
+++ b/code/components/webserver_softap/http_auth.cpp
@@ -38,26 +38,24 @@ static char *getAuthBase64Encoded(const std::string username, const std::string 
 
 esp_err_t handleHttpAuthBasic(httpd_req_t *req, esp_err_t httpHandler(httpd_req_t *))
 {
-    // Cross origin handling (e.g. allow access from localhost (test environment))
+    // Allow permissive cross-origin requests by design
     char originBuf[128] = {0};
-    const char *originKey = "Origin";
 
     size_t bufLen = httpd_req_get_hdr_value_len(req, "Origin");
-    if (bufLen == 0) {
-        bufLen = httpd_req_get_hdr_value_len(req, "origin");
-        originKey = "origin";
-    }
 
     if (bufLen > 0 && bufLen < sizeof(originBuf)) {
-        if (httpd_req_get_hdr_value_str(req, originKey, originBuf, sizeof(originBuf)) == ESP_OK) {
+        if (httpd_req_get_hdr_value_str(req, "Origin", originBuf, sizeof(originBuf)) == ESP_OK) {
             httpd_resp_set_hdr(req, "Access-Control-Allow-Origin", originBuf);
+        }
+        else {
+            httpd_resp_set_hdr(req, "Access-Control-Allow-Origin", "*");
         }
     }
     else {
         httpd_resp_set_hdr(req, "Access-Control-Allow-Origin", "*");
     }
 
-    // Always set remaining CORS rules
+    // Permissive CORS parameters
     httpd_resp_set_hdr(req, "Access-Control-Allow-Credentials", "true");
     httpd_resp_set_hdr(req, "Access-Control-Allow-Methods", "GET, POST, OPTIONS");
     httpd_resp_set_hdr(req, "Access-Control-Allow-Headers", "Content-Type, Authorization");

--- a/docs/API/REST/config.md
+++ b/docs/API/REST/config.md
@@ -4,30 +4,28 @@
 
 `http://IP-ADDRESS/config`
 
-
-Get and set process related configuration parameter. The data is provided / needs to be 
-provided in JSON notation.<br> Parameter description for every single parameter is 
-located at github repository (`docs/Configuration/Parameter`) or can be displayed on 
-WebUI configuration page (question mark symbol next to each parameter). 
+Get and set process-related configuration parameters. The data is provided / needs to be provided in JSON notation.<br>
+Parameter descriptions for every single parameter are located at the GitHub repository (`docs/Configuration/Parameter`) 
+or can be displayed on the WebUI configuration page (question mark symbol next to each parameter).
 
 - JSON: `/config`
 - HTML: `/config?task=reload`
 
-1. Get API name and version:
+1. **Get API name and version:**
     - Payload:
       - `/config?task=api_name`
     - Response:
       - Content type: `HTML`
       - Content: HTML query response, e.g. `config:v1`
 
-2. HTML query request to reload configuration and reinit process:
+2. **HTML query request to reload configuration and reinitialize process:**
     - Payload:
       - `/config?task=reload`
     - Response:
       - Content type: `HTML`
       - Content: HTML query response
 
-3. Get config in JSON notation (GET handler)
+3. **Get config in JSON notation (GET handler)**
     - Payload:
       - No payload needed
     - Response:
@@ -35,22 +33,33 @@ WebUI configuration page (question mark symbol next to each parameter).
       - Content: JSON response
     - Example: see below
 
-4. Set config in JSON notation (POST handler)
+4. **Set config in JSON notation (POST handler)**
     - Payload:
       - Configuration in JSON notation
-      - Setting only a single, some parameter or all parameter is supported
+      - Setting only a single, some, or all parameters is supported
+      - Optional query parameter `reload=true` can be used to reload the configuration and reinitialize the 
+      process after the configuration has been successfully saved
+      - `reload=1` can be used as an alternative to `reload=true`
     - Response:
       - POST handler status response
-    - Example: see below
+      - When `reload=true` or `reload=1` is used, reload status is returned in the `X-Reload-Code` and 
+      `X-Reload-Message` response headers
+    - Examples:
+      - `/config`
+      - `/config?reload=true`
+      - `/config?reload=1`
+
+    Example: see below
+
 
 ```
 {
 	"config":	{
-		"version":	3,
+		"version":	x,
 		"lastmodified":	"2024-09-18T00:09:06+0200"
 	},
 	"operationmode":	{
-		"opmode":	-1,
+		"opmode":	1,
 		"automaticprocessinterval":	"1.0",
 		"usedemoimages":	false
 	},
@@ -60,364 +69,9 @@ WebUI configuration page (question mark symbol next to each parameter).
 			"flashintensity":	20
 		},
 		"camera":	{
-			"camerafrequency":	20,
-			"imagequality":	12,
-			"imagesize":	"VGA",
-			"brightness":	0,
-			"contrast":	0,
-			"saturation":	0,
-			"sharpness":	0,
-			"exposurecontrolmode":	1,
-			"autoexposurelevel":	0,
-			"manualexposurevalue":	300,
-			"gaincontrolmode":	1,
-			"manualgainvalue":	0,
-			"specialeffect":	0,
-			"mirrorimage":	false,
-			"flipimage":	false,
-			"zoommode":	0,
-			"zoomoffsetx":	0,
-			"zoomoffsety":	0
-		},
-		"debug":	{
-			"saverawimages":	false,
-			"rawimageslocation":	"/log/source",
-			"rawimagesretention":	3
+			...
 		}
 	},
-	"imagealignment":	{
-		"alignmentalgo":	0,
-		"searchfield":	{
-			"x":	20,
-			"y":	20
-		},
-		"imagerotation":	"0.0",
-		"flipimagesize":	false,
-		"marker":	[{
-				"x":	132,
-				"y":	111
-			}, {
-				"x":	501,
-				"y":	131
-			}],
-		"debug":	{
-			"savedebuginfo":	false
-		}
-	},
-	"numbersequences":	{
-		"sequence":	[{
-				"sequenceid":	0,
-				"sequencename":	"main"
-			}]
-	},
-	"digit":	{
-		"enabled":	true,
-		"model":	"dig-class100_0168_s2_q.tflite",
-		"cnngoodthreshold":	"0.00",
-		"sequence":	[{
-				"sequenceid":	0,
-				"sequencename":	"main",
-				"roi":	[{
-						"x":	195,
-						"y":	63,
-						"dx":	55,
-						"dy":	75
-					}, {
-						"x":	255,
-						"y":	63,
-						"dx":	55,
-						"dy":	75
-					}, {
-						"x":	315,
-						"y":	63,
-						"dx":	55,
-						"dy":	75
-					}, {
-						"x":	375,
-						"y":	63,
-						"dx":	55,
-						"dy":	75
-					}, {
-						"x":	435,
-						"y":	63,
-						"dx":	55,
-						"dy":	75
-					}]
-			}],
-		"debug":	{
-			"saveroiimages":	false,
-			"roiimageslocation":	"/log/digit",
-			"roiimagesretention":	3
-		}
-	},
-	"analog":	{
-		"enabled":	true,
-		"model":	"ana-class100_0171_s1_q.tflite",
-		"sequence":	[{
-				"sequenceid":	0,
-				"sequencename":	"main",
-				"roi":	[{
-						"x":	450,
-						"y":	195,
-						"dx":	132,
-						"dy":	132,
-						"ccw":	false
-					}, {
-						"x":	358,
-						"y":	305,
-						"dx":	132,
-						"dy":	132,
-						"ccw":	false
-					}, {
-						"x":	215,
-						"y":	332,
-						"dx":	132,
-						"dy":	132,
-						"ccw":	false
-					}, {
-						"x":	84,
-						"y":	250,
-						"dx":	132,
-						"dy":	132,
-						"ccw":	false
-					}]
-			}],
-		"debug":	{
-			"saveroiimages":	false,
-			"roiimageslocation":	"/log/analog",
-			"roiimagesretention":	3
-		}
-	},
-	"postprocessing":	{
-		"sequence":	[{
-				"sequenceid":	0,
-				"sequencename":	"main",
-				"decimalshift":	0,
-				"analogdigitsyncvalue":	"9.2",
-				"extendedresolution":	true,
-				"ignoreleadingnan":	false,
-				"checkdigitincreaseconsistency":	false,
-				"maxratechecktype":	1,
-				"maxrate":	"0.150",
-				"allownegativerate":	false,
-				"usefallbackvalue":	true,
-				"fallbackvalueagestartup":	720
-			}],
-		"debug":	{
-			"savedebuginfo":	false
-		}
-	},
-	"mqtt":	{
-		"enabled":	false,
-		"uri":	"",
-		"maintopic":	"watermeter",
-		"clientid":	"watermeter",
-		"authmode":	1,
-		"username":	"",
-		"password":	"",
-		"tls":	{
-			"cacert":	"",
-			"clientcert":	"",
-			"clientkey":	""
-		},
-		"processdatanotation":	0,
-		"retainprocessdata":	false,
-		"homeassistant":	{
-			"discoveryenabled":	true,
-			"discoveryprefix":	"homeassistant",
-			"statustopic":	"homeassistant/status",
-			"metertype":	1,
-			"retaindiscovery":	false
-		}
-	},
-	"influxdbv1":	{
-		"enabled":	false,
-		"uri":	"",
-		"database":	"watermeter",
-		"authmode":	0,
-		"username":	"",
-		"password":	"",
-		"tls":	{
-			"cacert":	"",
-			"clientcert":	"",
-			"clientkey":	""
-		},
-		"sequence":	[{
-				"sequenceid":	0,
-				"sequencename":	"main",
-				"measurementname":	"",
-				"fieldname":	""
-			}]
-	},
-	"influxdbv2":	{
-		"enabled":	false,
-		"uri":	"",
-		"bucket":	"watermeter",
-		"organization":	"",
-		"authmode":	1,
-		"token":	"",
-		"tls":	{
-			"cacert":	"",
-			"clientcert":	"",
-			"clientkey":	""
-		},
-		"sequence":	[{
-				"sequenceid":	0,
-				"sequencename":	"main",
-				"measurementname":	"",
-				"fieldname":	""
-			}]
-	},
-	"gpio":	{
-		"customizationenabled":	true,
-		"gpiopin":	[{
-				"gpionumber":	1,
-				"gpiousage":	"restricted: uart0-tx",
-				"pinenabled":	false,
-				"pinname":	"",
-				"pinmode":	"input",
-				"capturemode":	"cyclic-polling",
-				"inputdebouncetime":	200,
-				"pwmfrequency":	5000,
-				"exposetomqtt":	false,
-				"exposetorest":	false,
-				"smartled":	{
-					"type":	0,
-					"quantity":	1,
-					"colorredchannel":	255,
-					"colorgreenchannel":	255,
-					"colorbluechannel":	255
-				},
-				"intensitycorrectionfactor":	100
-			}, {
-				"gpionumber":	3,
-				"gpiousage":	"restricted: uart0-rx",
-				"pinenabled":	false,
-				"pinname":	"",
-				"pinmode":	"input",
-				"capturemode":	"cyclic-polling",
-				"inputdebouncetime":	200,
-				"pwmfrequency":	5000,
-				"exposetomqtt":	false,
-				"exposetorest":	false,
-				"smartled":	{
-					"type":	0,
-					"quantity":	1,
-					"colorredchannel":	255,
-					"colorgreenchannel":	255,
-					"colorbluechannel":	255
-				},
-				"intensitycorrectionfactor":	100
-			}, {
-				"gpionumber":	4,
-				"gpiousage":	"flashlight-pwm",
-				"pinenabled":	false,
-				"pinname":	"",
-				"pinmode":	"flashlight-default",
-				"capturemode":	"cyclic-polling",
-				"inputdebouncetime":	200,
-				"pwmfrequency":	5000,
-				"exposetomqtt":	true,
-				"exposetorest":	true,
-				"smartled":	{
-					"type":	0,
-					"quantity":	1,
-					"colorredchannel":	255,
-					"colorgreenchannel":	255,
-					"colorbluechannel":	255
-				},
-				"intensitycorrectionfactor":	100
-			}, {
-				"gpionumber":	12,
-				"gpiousage":	"spare",
-				"pinenabled":	false,
-				"pinname":	"",
-				"pinmode":	"flashlight-smartled",
-				"capturemode":	"cyclic-polling",
-				"inputdebouncetime":	200,
-				"pwmfrequency":	5000,
-				"exposetomqtt":	true,
-				"exposetorest":	true,
-				"smartled":	{
-					"type":	0,
-					"quantity":	1,
-					"colorredchannel":	255,
-					"colorgreenchannel":	255,
-					"colorbluechannel":	255
-				},
-				"intensitycorrectionfactor":	100
-			}, {
-				"gpionumber":	13,
-				"gpiousage":	"spare",
-				"pinenabled":	true,
-				"pinname":	"",
-				"pinmode":	"flashlight-digital",
-				"capturemode":	"cyclic-polling",
-				"inputdebouncetime":	200,
-				"pwmfrequency":	5000,
-				"exposetomqtt":	true,
-				"exposetorest":	true,
-				"smartled":	{
-					"type":	0,
-					"quantity":	1,
-					"colorredchannel":	255,
-					"colorgreenchannel":	255,
-					"colorbluechannel":	255
-				},
-				"intensitycorrectionfactor":	100
-			}]
-	},
-	"log":	{
-		"debug":	{
-			"loglevel":	2,
-			"logfilesretention":	5,
-			"debugfilesretention":	5
-		},
-		"data":	{
-			"enabled":	true,
-			"datafilesretention":	30
-		}
-	},
-	"network":	{
-		"wlan":	{
-			"ssid":	"",
-			"password":	"",
-			"hostname":	"watermeter",
-			"ipv4":	{
-				"networkconfig":	0,
-				"ipaddress":	"",
-				"subnetmask":	"",
-				"gatewayaddress":	"",
-				"dnsserver":	""
-			},
-			"wlanroaming":	{
-				"enabled":	false,
-				"rssithreshold":	-75
-			}
-		},
-		"time":	{
-			"timezone":	"CET-1CEST,M3.5.0,M10.5.0/3",
-			"ntp":	{
-				"timesyncenabled":	true,
-				"timeserver":	"",
-				"processstartinterlock":	true
-			}
-		}
-	},
-	"system":	{
-		"cpufrequency":	160
-	},
-	"webui":	{
-		"autorefresh":	{
-			"overviewpage":	{
-				"enabled":	true,
-				"refreshtime":	5
-			},
-			"datagraphpage":	{
-				"enabled":	false,
-				"refreshtime":	60
-			}
-		}
-	}
+	...
 }
 ```

--- a/sd-card/html/edit_alignment.html
+++ b/sd-card/html/edit_alignment.html
@@ -653,12 +653,7 @@
             fileCopyOnServer("/img_tmp/marker1.jpg", "/config/marker1.jpg", getDomainname(), false);
             fileCopyOnServer("/img_tmp/marker2.jpg", "/config/marker2.jpg", getDomainname(), false);
 
-            firework.launch('Save and apply configuration...', 'success', 2000, true);
-			saveConfig(JSON.stringify(jsonConfigModifiedDelta)).then(() => {
-				setTimeout(function() {
-					reloadConfig();
-				}, 500);
-			});
+            saveConfig(JSON.stringify(jsonConfigModifiedDelta), true);
         }
     }
 

--- a/sd-card/html/edit_config_param.html
+++ b/sd-card/html/edit_config_param.html
@@ -3633,20 +3633,12 @@
 	function saveConfigData(reboot = false)
 	{
 		if (confirm("Are you sure you want to save and apply the new configuration?")) {
-			firework.launch('Save and apply configuration...', 'success', 2000, true);
-
-			saveConfig(JSON.stringify(jsonConfigModifiedDelta)).then(() => {
-				setTimeout(function() {
-					if (!reboot) {
-						reloadConfig();
-						setTimeout(function() {
-							init();
-						}, 500);
-					}
-					else {
+			saveConfig(JSON.stringify(jsonConfigModifiedDelta), !reboot).then(() => {
+				if (reboot) {
+					setTimeout(function() {
 						window.location.replace("sys_reboot_page.html?v=$COMMIT_HASH#reboot");
-					}
-				}, 500);
+					}, 500);
+				}
 			});
 		}
 	}

--- a/sd-card/html/edit_reference.html
+++ b/sd-card/html/edit_reference.html
@@ -514,7 +514,7 @@
         let flashtime = document.getElementById("takeimage_flashlight_flashtime_value").value;
         if (flashtime == "") flashtime = "2000";
 
-        firework.launch('Taking image...', 'success', flashtime, true);
+        firework.launch('Taking image...', 'success', parseInt(flashtime, 10), true);
 
         let flashintensity = document.getElementById("takeimage_flashlight_flashintensity_value").value;
         if (flashintensity == "") flashintensity = "50";
@@ -751,12 +751,7 @@
             drawRotated(false);
             SaveCanvasToImage(canvas, "/config/reference.jpg", true, getDomainname());
 
-            firework.launch('Save and apply configuration...', 'success', 2000, true);
-			saveConfig(JSON.stringify(jsonConfigModifiedDelta)).then(() => {
-				setTimeout(function() {
-					reloadConfig();
-				}, 500);
-			});
+            saveConfig(JSON.stringify(jsonConfigModifiedDelta), true);
         }
     }
 

--- a/sd-card/html/edit_sequence.html
+++ b/sd-card/html/edit_sequence.html
@@ -1526,16 +1526,14 @@
     function SaveToConfig()
     {
         if (confirm("Are you sure you want to save and apply the new configuration?")) {
-            saveConfig(JSON.stringify(jsonConfigModifiedDelta));
-            RefreshROI();
-
             document.getElementById("saveconfig").disabled = true;
-
-            firework.launch('Save and apply configuration...', 'success', 2000, true);
-            setTimeout(function() {
-                reloadConfig();
-                loadConfigData();
-            }, 1000);
+            
+			saveConfig(JSON.stringify(jsonConfigModifiedDelta), true).then(() => {
+                setTimeout(function() {
+                    loadConfigData();
+                    RefreshROI();
+                }, 500);
+			});
         }
     }
 

--- a/sd-card/html/global_data.js
+++ b/sd-card/html/global_data.js
@@ -207,29 +207,34 @@ async function getCertFileList()
 }
 
 
-function reloadConfig()
-{
+// Helper function to handle status codes & display firework messages
+function processReloadFeedback(code) {
+    if (!code) return;
+
+    if (code === "001" || code === "002" || code === "003") {
+        firework.launch('Configuration saved and applied successfully', 'success', 3000);
+    }
+    else if (code === "004") {
+        firework.launch('Configuration saved. Will apply after current cycle', 'success', 3000);
+    }
+    else if (code === "099" || code === "E90") {
+        firework.launch('Configuration saved, but failed to apply: Process uninitialized', 'danger', 10000);
+    }
+}
+
+
+function reloadConfig() {
     let url = getDomainname() + '/config?task=reload';
 
     let xhttp = new XMLHttpRequest();
     xhttp.onreadystatechange = function() {
         if (this.readyState == 4) {
             if (this.status >= 200 && this.status < 300) {
-                if (xhttp.responseText.substring(0,3) == "001" || xhttp.responseText.substring(0,3) == "002" ||
-                        xhttp.responseText.substring(0,3) == "003")
-                {
-                        firework.launch('Configuration updated and applied', 'success', 2000);
-                }
-                else if (xhttp.responseText.substring(0,3) == "004") {
-                        firework.launch('Configuration updated and get applied after actual cycle is completed', 'success', 3000);
-                }
-                else if (xhttp.responseText.substring(0,3) == "099") {
-                        firework.launch('Configuration updated, but cannot get applied (flow not initialized)', 'danger', 30000);
-                }
+                // For GET requests, extract the 3-character code from the text response
+                processReloadFeedback(this.responseText.substring(0, 3));
             }
             else {
-                firework.launch("Configuration update failed (Response status: " + this.status +
-                                "). Repeat action or check logs.", 'danger', 30000);
+                firework.launch("Configuration update failed (Response status: " + this.status + "). Repeat action or check logs.", 'danger', 30000);
                 console.error("Configuration update failed. Response status: " + this.status);
             }
         }
@@ -242,32 +247,47 @@ function reloadConfig()
 }
 
 
+async function saveConfig(data, reload = false) {
+    const fireworkSaveConfig = firework.launch('Save and apply configuration...', 'success', 10000, true);
 
-async function saveConfig(data)
-{
     return new Promise(function (resolve, reject) {
         let url = getDomainname() + "/config";
+        if (reload) url += "?reload=true";
 
         let xhttp = new XMLHttpRequest();
         xhttp.onreadystatechange = function() {
             if (xhttp.readyState == 4) {
                 if (xhttp.status >= 200 && xhttp.status < 300) {
-                        sessionStorage.setItem("jsonConfigData", xhttp.responseText); // Store the object into storage
-                        return resolve();
+                    sessionStorage.setItem("jsonConfigData", xhttp.responseText); // Store JSON into session storage
+                    firework.remove(fireworkSaveConfig);
+
+                    // If reload was requested, process response headers
+                    if (reload) {
+                        const reloadCode = xhttp.getResponseHeader("X-Reload-Code");
+                        if (reloadCode) {
+                            processReloadFeedback(reloadCode);
+                        }
+                    }
+                    else {
+                        firework.launch('Configuration saved successfully', 'success', 3000);
+                    }
+
+                    return resolve();
                 }
                 else if (xhttp.status == 0) {
-                        firework.launch('Save config failed failed. Server closed the connection abruptly!', 'danger', 30000);
+                    firework.launch('Save config failed. Server closed the connection abruptly!', 'danger', 30000);
+                    return reject("Save config failed");
                 }
                 else {
-                        firework.launch("Save config failed (Response status: " + this.status +
-                                            "). Repeat action or check logs.", 'danger', 30000);
-                        console.error("Save config failed. Response status: " + this.status);
-                        return reject("Save config failed");
+                    firework.launch("Save config failed (Response status: " + xhttp.status + "). Repeat action or check logs.", 'danger', 30000);
+                    console.error("Save config failed. Response status: " + xhttp.status);
+                    return reject("Save config failed");
                 }
             }
         };
 
         xhttp.open("POST", url, true);
+        xhttp.setRequestHeader("Content-Type", "application/json");
         xhttp.withCredentials = true;
         xhttp.send(data);
     });

--- a/sd-card/html/setup_explain_5.html
+++ b/sd-card/html/setup_explain_5.html
@@ -190,12 +190,8 @@
             jsonConfig.webui.httpauth.username = $("#webui_httpauth_username_value").val();
             jsonConfig.webui.httpauth.password = $("#webui_httpauth_password_value").val();
 
-            saveConfig(JSON.stringify(jsonConfig)).then(() => {
-                setTimeout(function() {
-                    reloadConfig();
-                }, 500);
-            });
-
+            saveConfig(JSON.stringify(jsonConfig), true);
+			
 			sessionStorage.removeItem("setupStep");
 
             firework.launch('Regular web interface gets loaded in a few seconds...', 'success', 10000);

--- a/sd-card/html/setup_explain_5_abort.html
+++ b/sd-card/html/setup_explain_5_abort.html
@@ -53,12 +53,8 @@
         jsonConfig = getConfigFromStorage(); // Get config
         jsonConfig.operationmode.opmode = 1;
 
-        saveConfig(JSON.stringify(jsonConfig)).then(() => {
-            setTimeout(function() {
-                reloadConfig();
-            }, 500);
-        });
-
+        saveConfig(JSON.stringify(jsonConfig), true);
+        
         sessionStorage.removeItem("setupStep");
 
         firework.launch('Regular web interface gets loaded in a few seconds...', 'success', 10000);


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Summary</h3>

The PR adds optional configuration reloads to successful `POST /config` requests and strengthens configuration persistence and HTTP handling.
- Supports `reload=true` and `reload=1`, returning reload status through response headers.
- Ensures primary configuration writes are flushed, synchronized, closed, and validated before reload or success.
- Updates Basic-auth/CORS handling, configuration documentation, and Web UI save/reload flows.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because no blocking failure remains.

No blocking failure remains.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| code/components/config_handling/configClass.cpp | Adds reload-query handling and gates reload and HTTP success on a fully checked, durably synchronized primary configuration write. |
| code/components/mainprocess_ctrl/MainFlowControl.cpp | Refactors reload status generation so GET requests receive text while POST requests receive reload metadata in headers. |
| code/components/webserver_softap/http_auth.cpp | Refactors Basic authentication and preflight handling; its permissive credentialed CORS behavior was explicitly accepted in the prior thread. |
| docs/API/REST/config.md | Documents optional POST-triggered reloads and the associated response headers. |
| sd-card/html/global_data.js | Updates shared Web UI configuration request behavior to use the revised save-and-reload API flow. |

</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client
    participant API as POST /config
    participant Config as ConfigClass
    participant FS as Config file
    participant Flow as Main flow
    Client->>API: "JSON with optional reload=true"
    API->>Config: Parse and serialize under cfgMutex
    Config->>FS: Write, flush, fsync, and close
    alt Persistence succeeds
        opt Reload requested
            API->>Flow: Stage configuration reload
            Flow-->>API: Reload status headers
        end
        API-->>Client: 200 with serialized configuration
    else Persistence fails
        API-->>Client: Error response without reload
    end
```
</details>

<sub>Reviews (7): Last reviewed commit: ["Update"](https://github.com/slider0007/ai-on-the-edge-device/commit/727ca7342649c72557525c75e17b1309525f252e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59670696)</sub>

<!-- /greptile_comment -->

---
### Usage Stats

Before (based on ESP32CAM)
RAM:   [==        ]  15.2% (used 49808 bytes from 327680 bytes)
Flash: [========  ]  79.5% (used 1546830 bytes from 1945600 bytes)

After
RAM:   [==        ]  15.2% (used 49920 bytes from 327680 bytes)
Flash: [========  ]  79.5% (used 1547110 bytes from 1945600 bytes)